### PR TITLE
Modification to Launcher checkboxes - clearly defined status-indicators.

### DIFF
--- a/apps/Launcher/main.cpp
+++ b/apps/Launcher/main.cpp
@@ -82,14 +82,14 @@ QCheckBox::indicator {
 }
 QCheckBox::indicator::unchecked {
     border: 1px solid #5A5A5A;
-    background: transparent;
+    background: #a10000;
 }
 QCheckBox::indicator:unchecked:hover {
     border: 1px solid #DDDDDD;
 }
 QCheckBox::indicator::checked {
-    border: 1px solid #AAAAAA;
-    background: #666666;
+    border: 1px solid #5A5A5A;
+    background: #8dc73f;
 }
 QCheckBox::indicator:checked:hover {
     border: 1px solid #DDDDDD;


### PR DESCRIPTION
This is a simple alteration to how Launcher checkboxes display status; green indicates a check, whereas red does not.

This is an attempt to deal with [Issue #155.](https://github.com/OpenSpace/OpenSpace/issues/155)