### PR TITLE
* When Launcher first starts only the default scene is selected.

### DIFF
--- a/apps/Launcher/syncwidget.cpp
+++ b/apps/Launcher/syncwidget.cpp
@@ -225,8 +225,11 @@ void SyncWidget::setSceneFiles(QMap<QString, QString> sceneFiles) {
         const QString& sceneName = keys[i];
 
         QCheckBox* checkbox = new QCheckBox(sceneName);
-        checkbox->setChecked(true);
-
+        checkbox->setChecked(false);
+        QString defaultName = "default";
+        if(QString::compare(defaultName, sceneName, Qt::CaseInsensitive)==0){
+            checkbox->setChecked(true);
+        }
         _sceneLayout->addWidget(checkbox, i / nColumns, i % nColumns);
     }
 }

--- a/apps/Launcher/syncwidget.cpp
+++ b/apps/Launcher/syncwidget.cpp
@@ -225,9 +225,8 @@ void SyncWidget::setSceneFiles(QMap<QString, QString> sceneFiles) {
         const QString& sceneName = keys[i];
 
         QCheckBox* checkbox = new QCheckBox(sceneName);
-        checkbox->setChecked(false);
         QString defaultName = "default";
-        if(QString::compare(defaultName, sceneName, Qt::CaseInsensitive)==0){
+        if (sceneName == defaultName){
             checkbox->setChecked(true);
         }
         _sceneLayout->addWidget(checkbox, i / nColumns, i % nColumns);


### PR DESCRIPTION
This now works, and builds on Jenkins on all platforms.