### PR TITLE
add missing include directive for stdio.h

### DIFF
--- a/src/interaction/deviceidentifier.cpp
+++ b/src/interaction/deviceidentifier.cpp
@@ -25,6 +25,7 @@
 // open space includes
 #include <openspace/interaction/deviceidentifier.h>
 
+#include <stdio.h>
 #include <assert.h>
 
 namespace openspace {


### PR DESCRIPTION
stdio.h is needed because printf(3) is used in the file.
This change is necessary for compilation on FreeBSD.