### PR TITLE
Rename None to Hidden, to avoid collision with X11 and reset data path

### DIFF
--- a/include/openspace/properties/property.h
+++ b/include/openspace/properties/property.h
@@ -64,13 +64,13 @@ class Property {
 public:
     /**
      * The visibility classes for Property%s. The classes are strictly ordered as
-     * All > Developer > User > None
+     * All > Developer > User > Hidden
      */
     enum class Visibility {
         All = 3,  ///< Visible for all types, no matter what
         Developer = 2, ///< Visible in Developer mode
         User = 1, ///< Visible in User mode
-        None = 0 ///< Never visible
+        Hidden = 0 ///< Never visible
     };
 
     /**

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -36,7 +36,7 @@ return {
         SGCT = "${BASE_PATH}/config/sgct",
         SCRIPTS = "${BASE_PATH}/scripts",
         SHADERS = "${BASE_PATH}/shaders",
-        OPENSPACE_DATA = "${BASE_PATH}/data-minimal",
+        OPENSPACE_DATA = "${BASE_PATH}/data",
         SCENE = "${OPENSPACE_DATA}/scene",
         TASKS = "${OPENSPACE_DATA}/tasks",
         SPICE = "${OPENSPACE_DATA}/spice",

--- a/src/properties/property.cpp
+++ b/src/properties/property.cpp
@@ -193,7 +193,7 @@ std::string Property::generateMetaDataDescription() const {
         { Visibility::All, "All" },
         { Visibility::Developer, "Developer" },
         { Visibility::User, "User" },
-        { Visibility::None, "None" }
+        { Visibility::Hidden, "Hidden" }
     };
     Visibility visibility = _metaData.value<Visibility>(MetaDataKeyVisibility);
     bool isReadOnly = _metaData.value<bool>(MetaDataKeyReadOnly);


### PR DESCRIPTION
`Visibility::None` caused a compile error on Linux, since x11 defines the macro None. (https://github.com/aseprite/aseprite/issues/482). Changed None to Hidden.

This seems to have been accidentally pushed ?
`OPENSPACE_DATA = "${BASE_PATH}/data-minimal",`
changed back to `${BASE_PATH}/data`