### PR TITLE
Feature/planetradius

### DIFF
--- a/data/scene/atmosphereearth/atmosphereearth.mod
+++ b/data/scene/atmosphereearth/atmosphereearth.mod
@@ -30,15 +30,15 @@ return {
                 Source1 = {
                     Name = "Sun",
                     -- All radius in meters
-                    Radius = {696.3, 6}
+                    Radius = 696.3E6
                 },
-                --Source2 = { Name = "Monolith", Radius = {0.01, 6} },
+                --Source2 = { Name = "Monolith", Radius = 0.01E6 },
                 Caster1 = { 
                     Name = "Moon",
                     -- All radius in meters
-                    Radius = {1.737, 6}
+                    Radius = 1.737E6
                 },
-                --Caster2 = { Name = "Independency Day Ship", Radius = {0.0, 0.0} }
+                --Caster2 = { Name = "Independency Day Ship", Radius = 0 }
             },
             Textures = {
                 Type = "simple",
@@ -127,7 +127,7 @@ return {
         Parent = "Earth",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {3.0, 11.0},
+            Size = 3.0E11.0,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/marker.png",
@@ -145,7 +145,7 @@ return {
     --     Renderable = {
     --         Type = "RenderablePlane",
     --         Billboard = true,
-    --         Size = { 6.371, 6 },
+    --         Size = 6.371E6,
     --         Texture = "textures/graph.jpg",
     --         Atmosphere = {
     --             Type = "Nishita", -- for example, values missing etc etc

--- a/data/scene/earth/earth.mod
+++ b/data/scene/earth/earth.mod
@@ -34,7 +34,7 @@ return {
             Body = "EARTH",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 6.371, 6 },
+                Radius = 6.371E6,
                 Segments = 100
             },
             Textures = {
@@ -88,7 +88,7 @@ return {
         Parent = "Earth",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {3.0, 11.0},
+            Size = 3.0E11,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/marker.png",

--- a/data/scene/jupiter/callisto/callisto.mod
+++ b/data/scene/jupiter/callisto/callisto.mod
@@ -9,7 +9,7 @@ return {
             Body = "CALLISTO",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 2.631, 6},
+                Radius = 2.631E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/jupiter/europa/europa.mod
+++ b/data/scene/jupiter/europa/europa.mod
@@ -9,7 +9,7 @@ return {
             Body = "EUROPA",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.561, 6},
+                Radius = 1.561E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/jupiter/ganymede/ganymede.mod
+++ b/data/scene/jupiter/ganymede/ganymede.mod
@@ -9,7 +9,7 @@ return {
             Body = "JUPITER BARYCENTER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 2.631, 6},
+                Radius = 2.631E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/jupiter/io/io.mod
+++ b/data/scene/jupiter/io/io.mod
@@ -9,7 +9,7 @@ return {
             Body = "IO",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.8213, 6 },
+                Radius = 1.8213E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/jupiter/jupiter/jupiter.mod
+++ b/data/scene/jupiter/jupiter/jupiter.mod
@@ -22,7 +22,7 @@ return {
             Body = "JUPITER BARYCENTER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.71492, 8 },
+                Radius = 0.71492E8,
                 Segments = 200
             },
             Textures = {

--- a/data/scene/mars/mars.mod
+++ b/data/scene/mars/mars.mod
@@ -22,7 +22,7 @@ return {
             Body = "MARS BARYCENTER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 6.390, 6 },
+                Radius = 6.390E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/mercury/mercury.mod
+++ b/data/scene/mercury/mercury.mod
@@ -1,5 +1,3 @@
-MercuryRadius = 2.4397E6;
-
 return {
     -- Mercury barycenter module
     {
@@ -24,7 +22,7 @@ return {
             Body = "MERCURY",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = {MercuryRadius, 1.0},
+                Radius = 2.4397E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/missions/dawn/ceres/ceres.mod
+++ b/data/scene/missions/dawn/ceres/ceres.mod
@@ -10,7 +10,7 @@ return {
             Body = "CERES",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 6.390, 5 },
+                Radius = 6.390E5,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/missions/newhorizons/jupiter/callisto/callisto.mod
+++ b/data/scene/missions/newhorizons/jupiter/callisto/callisto.mod
@@ -9,7 +9,7 @@ return {
             Body = "CALLISTO",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.8213, 6 },
+                Radius = 1.8213E6,
                 Segments = 100
             },
             Textures = {
@@ -58,7 +58,7 @@ return {
         Parent = "Callisto",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 7.4},
+            Size = 1.0E7.4,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Callisto-Text.png",

--- a/data/scene/missions/newhorizons/jupiter/europa/europa.mod
+++ b/data/scene/missions/newhorizons/jupiter/europa/europa.mod
@@ -9,7 +9,7 @@ return {
             Body = "EUROPA",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.8213, 6 },
+                Radius = 1.8213E6,
                 Segments = 100
             },
             Textures = {
@@ -58,7 +58,7 @@ return {
         Parent = "Europa",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 7.4},
+            Size = 1.0E7.4,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Europa-Text.png",

--- a/data/scene/missions/newhorizons/jupiter/ganymede/ganymede.mod
+++ b/data/scene/missions/newhorizons/jupiter/ganymede/ganymede.mod
@@ -9,7 +9,7 @@ return {
             Body = "GANYMEDE",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.8213, 6 },
+                Radius = 1.8213E6,
                 Segments = 100
             },
             Textures = {
@@ -58,7 +58,7 @@ return {
         Parent = "Ganymede",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 7.4},
+            Size = 1.0E7.4,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Ganymede-Text.png",

--- a/data/scene/missions/newhorizons/jupiter/io/io.mod
+++ b/data/scene/missions/newhorizons/jupiter/io/io.mod
@@ -9,7 +9,7 @@ return {
             Body = "IO",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.8213, 6 },
+                Radius = 1.8213E6,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/missions/newhorizons/jupiter/jupiter/jupiter.mod
+++ b/data/scene/missions/newhorizons/jupiter/jupiter/jupiter.mod
@@ -22,7 +22,7 @@ return {
             Body = "JUPITER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.71492, 8 },
+                Radius = 0.71492E8,
                 Segments = 200,
             },
             Textures = {
@@ -101,7 +101,7 @@ return {
         Parent = "JupiterProjection",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 7.5},
+            Size = 1.0E7.5,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Jupiter-text.png",

--- a/data/scene/missions/newhorizons/pluto/charon/charon.mod
+++ b/data/scene/missions/newhorizons/pluto/charon/charon.mod
@@ -24,7 +24,7 @@ return {
             Type = "RenderablePlanetProjection",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 6.035 , 5 },
+                Radius = 6.035E5,
                 Segments = 100
             },
             Textures = {
@@ -72,7 +72,7 @@ return {
         Parent = "Charon",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 6.3},
+            Size = 1.0E6.3,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Charon-Text.png",

--- a/data/scene/missions/newhorizons/pluto/hydra/hydra.mod
+++ b/data/scene/missions/newhorizons/pluto/hydra/hydra.mod
@@ -46,7 +46,7 @@ return {
         Parent = "Hydra",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 6.3},
+            Size = 1.0E6.3,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Hydra-Text.png"

--- a/data/scene/missions/newhorizons/pluto/kerberos/kerberos.mod
+++ b/data/scene/missions/newhorizons/pluto/kerberos/kerberos.mod
@@ -46,7 +46,7 @@ return {
         Parent = "Kerberos",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 6.3},
+            Size = 1.0E6.3,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Kerberos-Text.png"

--- a/data/scene/missions/newhorizons/pluto/nix/nix.mod
+++ b/data/scene/missions/newhorizons/pluto/nix/nix.mod
@@ -19,7 +19,7 @@ return {
             Body = "NIX",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.45 , 5 },
+                Radius = 0.45E5,
                 Segments = 100
             },
             Textures = {
@@ -46,7 +46,7 @@ return {
         Parent = "Nix",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 6.3},
+            Size = 1.0E6.3,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Nix-Text.png"

--- a/data/scene/missions/newhorizons/pluto/pluto/pluto.mod
+++ b/data/scene/missions/newhorizons/pluto/pluto/pluto.mod
@@ -38,7 +38,7 @@ return {
             Type = "RenderablePlanetProjection",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.173 , 6 },
+                Radius = 1.173E6,
                 Segments = 100
             },
             Textures = {
@@ -173,7 +173,7 @@ return {
        Renderable = {
            Type = "RenderablePlane",
            Billboard = true,
-           Size = { 5, 4 },
+           Size = 5E4,
            Texture = "textures/barycenter.png",
            Atmosphere = {
                Type = "Nishita", -- for example, values missing etc etc
@@ -187,7 +187,7 @@ return {
         Parent = "Pluto",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 6.3},
+            Size = 1.0E6.3,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Pluto-Text.png",

--- a/data/scene/missions/newhorizons/pluto/styx/styx.mod
+++ b/data/scene/missions/newhorizons/pluto/styx/styx.mod
@@ -19,7 +19,7 @@ return {
             Body = "STYX",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.75 , 4 },
+                Radius = 0.75E4,
                 Segments = 100
             },
             Textures = {
@@ -46,7 +46,7 @@ return {
         Parent = "Styx",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.0, 6.3},
+            Size = 1.0E6.3,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/Styx-Text.png",

--- a/data/scene/moon/moon.mod
+++ b/data/scene/moon/moon.mod
@@ -9,17 +9,17 @@ return {
             Body = "MOON",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.737, 6},
+                Radius = 1.737E6,
                 Segments = 100
             },
             Shadow_Group = {
                 Source1 = {
                     Name = "Sun",
-                    Radius = {696.3, 6}
+                    Radius = 696.3E6
                 },
                 Caster1 = { 
                     Name = "Earth",
-                    Radius = {6.371, 6}
+                    Radius = 6.371E6
                 },
             },
             Textures = {

--- a/data/scene/neptune/neptune.mod
+++ b/data/scene/neptune/neptune.mod
@@ -23,7 +23,7 @@ return {
             Body = "NEPTUNE BARYCENTER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 2.4622 , 7 },
+                Radius = 2.4622E7,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/pluto/pluto.mod
+++ b/data/scene/pluto/pluto.mod
@@ -25,7 +25,7 @@ return {
             Body = "PLUTO",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 1.173 , 6 },
+                Radius = 1.173E6,
                 Segments = 100
             },
             Textures = {
@@ -61,7 +61,7 @@ return {
             Body = "CHARON",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 6.035 , 5 },
+                Radius = 6.035E5,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/saturn/dione/dione.mod
+++ b/data/scene/saturn/dione/dione.mod
@@ -8,7 +8,7 @@ return {
             Body = "DIONE",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.563, 3 },
+                Radius = 0.563E3,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/saturn/enceladus/enceladus.mod
+++ b/data/scene/saturn/enceladus/enceladus.mod
@@ -8,7 +8,7 @@ return {
             Body = "ENCELADUS",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.257, 3 },
+                Radius = 0.257E3,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/saturn/iapetus/iapetus.mod
+++ b/data/scene/saturn/iapetus/iapetus.mod
@@ -8,7 +8,7 @@ return {
             Body = "IAPETUS",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.746, 3 },
+                Radius = 0.746E3,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/saturn/mimas/mimas.mod
+++ b/data/scene/saturn/mimas/mimas.mod
@@ -8,7 +8,7 @@ return {
             Body = "MIMAS",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.28, 3 },
+                Radius = 0.28E3,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/saturn/rhea/rhea.mod
+++ b/data/scene/saturn/rhea/rhea.mod
@@ -8,7 +8,7 @@ return {
             Body = "RHEA",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.765, 3 },
+                Radius = 0.765E3,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/saturn/saturn/saturn.mod
+++ b/data/scene/saturn/saturn/saturn.mod
@@ -1,6 +1,3 @@
-SaturnRadius = 5.8232E7;
-
-
 return {
     -- Saturn barycenter module
     {
@@ -26,7 +23,7 @@ return {
             Body = "SATURN BARYCENTER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = {SaturnRadius, 0},
+                Radius = 5.8232E7,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/saturn/tethys/tethys.mod
+++ b/data/scene/saturn/tethys/tethys.mod
@@ -8,7 +8,7 @@ return {
             Body = "TETHYS",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.538, 3 },
+                Radius = 0.538E3,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/saturn/titan/titan.mod
+++ b/data/scene/saturn/titan/titan.mod
@@ -8,7 +8,7 @@ return {
             Body = "TITAN",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 0.2575, 4 },
+                Radius = 0.2575E4,
                 Segments = 50
             },
             Textures = {

--- a/data/scene/sun/sun.mod
+++ b/data/scene/sun/sun.mod
@@ -20,7 +20,8 @@ return {
             Body = "SUN", 
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 2.783200, 9 },
+                --Radius = 2.783200E9,
+                Radius = 6.957E8,
                 Segments = 100
             },
             Textures = {
@@ -49,7 +50,7 @@ return {
         Parent = "SolarSystemBarycenter",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {1.3, 10.5},
+            Size = 1.3*10^10.5,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/sun-glare.png",
@@ -70,7 +71,7 @@ return {
         Parent = "Sun",
         Renderable = {
             Type = "RenderablePlane",
-            Size = {3.0, 11.0},
+            Size = 3.0E11,
             Origin = "Center",
             Billboard = true,
             Texture = "textures/marker.png",

--- a/data/scene/uranus/uranus.mod
+++ b/data/scene/uranus/uranus.mod
@@ -23,7 +23,7 @@ return {
             Body = "URANUS BARYCENTER",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 2.5362 , 7 },
+                Radius = 2.5362E7,
                 Segments = 100
             },
             Textures = {

--- a/data/scene/venus/venus.mod
+++ b/data/scene/venus/venus.mod
@@ -23,7 +23,7 @@ return {
             Body = "VENUS",
             Geometry = {
                 Type = "SimpleSphere",
-                Radius = { 3.760, 6 },
+                Radius = 3.760E6,
                 Segments = 100
             },
             Textures = {

--- a/include/openspace/rendering/renderable.h
+++ b/include/openspace/rendering/renderable.h
@@ -28,7 +28,6 @@
 #include <openspace/properties/propertyowner.h>
 
 #include <openspace/properties/scalar/boolproperty.h>
-#include <openspace/util/powerscaledscalar.h>
 #include <openspace/util/updatestructures.h>
 
 #include <ghoul/opengl/programobject.h>
@@ -72,8 +71,8 @@ public:
     virtual bool isReady() const = 0;
     bool isEnabled() const;
 
-    void setBoundingSphere(PowerScaledScalar boundingSphere);
-    PowerScaledScalar getBoundingSphere();
+    void setBoundingSphere(float boundingSphere);
+    float boundingSphere() const;
 
     virtual void render(const RenderData& data);
     virtual void render(const RenderData& data, RendererTasks& rendererTask);
@@ -99,7 +98,7 @@ protected:
     
 private:
     RenderBin _renderBin;
-    PowerScaledScalar boundingSphere_;
+    float _boundingSphere;
     std::string _startTime;
     std::string _endTime;
     bool _hasTimeInterval;

--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -95,11 +95,6 @@ public:
     void update(const UpdateData& data);
 
     /**
-     * Evaluate if the SceneGraphNodes are visible to the provided camera.
-     */
-    void evaluate(Camera* camera);
-
-    /**
      * Render visible SceneGraphNodes using the provided camera.
      */
     void render(const RenderData& data, RendererTasks& tasks);

--- a/include/openspace/scene/scenegraphnode.h
+++ b/include/openspace/scene/scenegraphnode.h
@@ -73,7 +73,6 @@ public:
     void traversePreOrder(std::function<void(SceneGraphNode*)> fn);
     void traversePostOrder(std::function<void(SceneGraphNode*)> fn);
     void update(const UpdateData& data);
-    void evaluate(const Camera* camera, const psc& parentPosition = psc());
     void render(const RenderData& data, RendererTasks& tasks);
     void updateCamera(Camera* camera) const;
 
@@ -103,8 +102,7 @@ public:
     SceneGraphNode* parent() const;
     std::vector<SceneGraphNode*> children() const;
 
-    PowerScaledScalar calculateBoundingSphere();
-    PowerScaledScalar boundingSphere() const;
+    float boundingSphere() const;
 
     SceneGraphNode* childNode(const std::string& name);
 
@@ -130,10 +128,6 @@ private:
     PerformanceRecord _performanceRecord;
 
     std::unique_ptr<Renderable> _renderable;
-    bool _renderableVisible;
-
-    bool _boundingSphereVisible;
-    PowerScaledScalar _boundingSphere;
 
     // Transformation defined by ephemeris, rotation and scale
     struct {

--- a/include/openspace/util/powerscaledsphere.h
+++ b/include/openspace/util/powerscaledsphere.h
@@ -38,8 +38,8 @@ public:
     // initializers
     PowerScaledSphere(const PowerScaledScalar& radius, 
         int segments = 8);
-    PowerScaledSphere(properties::Vec4Property &radius,
-        int segments, std::string planetName);
+
+    PowerScaledSphere(glm::vec3 radius, int segments);
 
     ~PowerScaledSphere();
     PowerScaledSphere(const PowerScaledSphere& cpy);

--- a/modules/base/rendering/modelgeometry.cpp
+++ b/modules/base/rendering/modelgeometry.cpp
@@ -144,7 +144,7 @@ bool ModelGeometry::initialize(Renderable* parent) {
             glm::pow(v.location[1], 2.f) +
             glm::pow(v.location[2], 2.f), maximumDistanceSquared);
     }
-    _parent->setBoundingSphere(PowerScaledScalar(glm::sqrt(maximumDistanceSquared), 0.0));
+    _parent->setBoundingSphere(glm::sqrt(maximumDistanceSquared));
 
     if (_vertices.empty())
         return false;

--- a/modules/base/rendering/renderableplane.cpp
+++ b/modules/base/rendering/renderableplane.cpp
@@ -55,7 +55,7 @@ RenderablePlane::RenderablePlane(const ghoul::Dictionary& dictionary)
     , _texturePath("texture", "Texture")
     , _billboard("billboard", "Billboard", false)
     , _projectionListener("projectionListener", "DisplayProjections", false)
-    , _size("size", "Size", glm::vec2(1,1), glm::vec2(0.f), glm::vec2(1.f, 25.f))
+    , _size("size", "Size", 10, 0, std::pow(10, 25))
     , _origin(Origin::Center)
     , _shader(nullptr)
     , _textureIsDirty(false)
@@ -64,9 +64,7 @@ RenderablePlane::RenderablePlane(const ghoul::Dictionary& dictionary)
     , _quad(0)
     , _vertexPositionBuffer(0)
 {
-    glm::vec2 size;
-    dictionary.getValue("Size", size);
-    _size = size;
+    dictionary.getValue("Size", _size);
 
     if (dictionary.hasKey("Name")) {
         dictionary.getValue("Name", _nodeName);
@@ -127,7 +125,7 @@ RenderablePlane::RenderablePlane(const ghoul::Dictionary& dictionary)
     //_size.onChange(std::bind(&RenderablePlane::createPlane, this));
     _size.onChange([this](){ _planeIsDirty = true; });
 
-    setBoundingSphere(_size.value());
+    setBoundingSphere(_size);
 }
 
 RenderablePlane::~RenderablePlane() {
@@ -299,16 +297,15 @@ void RenderablePlane::createPlane() {
     // ============================
     //         GEOMETRY (quad)
     // ============================
-    const GLfloat size = _size.value()[0];
-    const GLfloat w = _size.value()[1];
+    const GLfloat size = _size;
     const GLfloat vertex_data[] = {
         //      x      y     z     w     s     t
-        -size, -size, 0.f, w, 0.f, 0.f,
-        size, size, 0.f, w, 1.f, 1.f,
-        -size, size, 0.f, w, 0.f, 1.f,
-        -size, -size, 0.f, w, 0.f, 0.f,
-        size, -size, 0.f, w, 1.f, 0.f,
-        size, size, 0.f, w, 1.f, 1.f,
+        -size, -size, 0.f, 0.f, 0.f, 0.f,
+        size, size, 0.f, 0.f, 1.f, 1.f,
+        -size, size, 0.f, 0.f, 0.f, 1.f,
+        -size, -size, 0.f, 0.f, 0.f, 0.f,
+        size, -size, 0.f, 0.f, 1.f, 0.f,
+        size, size, 0.f, 0.f, 1.f, 1.f,
     };
 
     glBindVertexArray(_quad); // bind array

--- a/modules/base/rendering/renderableplane.h
+++ b/modules/base/rendering/renderableplane.h
@@ -29,7 +29,6 @@
 
 #include <openspace/properties/stringproperty.h>
 #include <openspace/properties/scalar/boolproperty.h>
-#include <openspace/properties/vector/vec2property.h>
 #include <openspace/util/updatestructures.h>
 
 namespace ghoul {
@@ -75,7 +74,7 @@ private:
     properties::StringProperty _texturePath;
     properties::BoolProperty _billboard;
     properties::BoolProperty _projectionListener;
-    properties::Vec2Property _size;
+    properties::FloatProperty _size;
 
     Origin _origin;
     std::string _nodeName;

--- a/modules/base/rendering/renderablesphericalgrid.cpp
+++ b/modules/base/rendering/renderablesphericalgrid.cpp
@@ -27,6 +27,7 @@
 #include <openspace/engine/configurationmanager.h>
 #include <openspace/engine/openspaceengine.h>
 #include <openspace/util/spicemanager.h>
+#include <glm/glm.hpp>
 
 #define _USE_MATH_DEFINES
 #include <math.h>
@@ -39,11 +40,9 @@ namespace {
     const char* KeyGridSegments = "GridSegments";
     const char* KeyGridRadius = "GridRadius";
     const char* KeyGridParentsRotation = "ParentsRotation";
+    const glm::vec2 GridRadius = { 1.f, 20.f };
 }
 namespace openspace {
-
-// needs to be set from dictionary - REMEMBER
-const PowerScaledScalar radius = PowerScaledScalar(1.f, 20.f);
 
 RenderableSphericalGrid::RenderableSphericalGrid(const ghoul::Dictionary& dictionary)  
     : Renderable(dictionary)
@@ -78,7 +77,7 @@ RenderableSphericalGrid::RenderableSphericalGrid(const ghoul::Dictionary& dictio
 
     int nr = 0;
     const float fsegments = static_cast<float>(_segments);
-    const float r = static_cast<float>(radius[0]);
+    const float r = static_cast<float>(GridRadius[0]);
 
     //int nr2 = 0;
 
@@ -117,7 +116,7 @@ RenderableSphericalGrid::RenderableSphericalGrid(const ghoul::Dictionary& dictio
                 _varray[nr].location[i]  = tmp[i];
                 _varray[nr].normal[i] = normal[i];
             }
-            _varray[nr].location[3] = static_cast<GLfloat>(radius[1]);            
+            _varray[nr].location[3] = static_cast<GLfloat>(GridRadius[1]);
             ++nr;
         }
     }

--- a/modules/base/rendering/renderablesphericalgrid.h
+++ b/modules/base/rendering/renderablesphericalgrid.h
@@ -62,7 +62,6 @@ protected:
     bool staticGrid;
     std::string _parentsRotation;
     glm::dmat3 _parentMatrix;
-    PowerScaledScalar _radius;
 
     GLuint _vaoID = 3;
     GLuint _vBufferID = 4;

--- a/modules/debugging/rendering/renderabledebugplane.cpp
+++ b/modules/debugging/rendering/renderabledebugplane.cpp
@@ -49,15 +49,13 @@ RenderableDebugPlane::RenderableDebugPlane(const ghoul::Dictionary& dictionary)
     : Renderable(dictionary)
     , _texture("texture", "Texture", -1, -1, 255)
     , _billboard("billboard", "Billboard", false)
-    , _size("size", "Size", glm::vec2(1,1), glm::vec2(0.f), glm::vec2(1.f, 25.f))
+    , _size("size", "Size", 10, 0, std::pow(10, 25))
     , _origin(Origin::Center)
     , _shader(nullptr)
     , _quad(0)
     , _vertexPositionBuffer(0)
 {
-    glm::vec2 size;
-    dictionary.getValue("Size", size);
-    _size = size;
+    dictionary.getValue("Size", _size);
 
     if (dictionary.hasKey("Name")){
         dictionary.getValue("Name", _nodeName);
@@ -104,7 +102,7 @@ RenderableDebugPlane::RenderableDebugPlane(const ghoul::Dictionary& dictionary)
     addProperty(_size);
     _size.onChange([this](){ _planeIsDirty = true; });
 
-    setBoundingSphere(_size.value());
+    setBoundingSphere(_size);
 }
 
 RenderableDebugPlane::~RenderableDebugPlane() {
@@ -189,16 +187,16 @@ void RenderableDebugPlane::createPlane() {
     // ============================
     //         GEOMETRY (quad)
     // ============================
-    const GLfloat size = _size.value()[0];
-    const GLfloat w = _size.value()[1];
+    const GLfloat size = _size;
+
     const GLfloat vertex_data[] = {
         //      x      y     z     w     s     t
-        -size, -size, 0.f, w, 0.f, 0.f,
-        size, size, 0.f, w, 1.f, 1.f,
-        -size, size, 0.f, w, 0.f, 1.f,
-        -size, -size, 0.f, w, 0.f, 0.f,
-        size, -size, 0.f, w, 1.f, 0.f,
-        size, size, 0.f, w, 1.f, 1.f,
+        -size, -size, 0.f, 0.f, 0.f, 0.f,
+        size, size, 0.f, 0.f, 1.f, 1.f,
+        -size, size, 0.f, 0.f, 0.f, 1.f,
+        -size, -size, 0.f, 0.f, 0.f, 0.f,
+        size, -size, 0.f, 0.f, 1.f, 0.f,
+        size, size, 0.f, 0.f, 1.f, 1.f,
     };
 
     glBindVertexArray(_quad); // bind array

--- a/modules/debugging/rendering/renderabledebugplane.h
+++ b/modules/debugging/rendering/renderabledebugplane.h
@@ -28,7 +28,6 @@
 #include <openspace/rendering/renderable.h>
 
 #include <openspace/properties/stringproperty.h>
-#include <openspace/properties/vector/vec2property.h>
 #include <openspace/util/updatestructures.h>
 
 namespace ghoul {
@@ -67,7 +66,7 @@ private:
 
     properties::IntProperty _texture;
     properties::BoolProperty _billboard;
-    properties::Vec2Property _size;
+    properties::FloatProperty _size;
 
     Origin _origin;
     std::string _nodeName;

--- a/modules/globebrowsing/globes/renderableglobe.cpp
+++ b/modules/globebrowsing/globes/renderableglobe.cpp
@@ -78,7 +78,7 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     glm::dvec3 radii;
     dictionary.getValue(keyRadii, radii);
     _ellipsoid = Ellipsoid(radii);
-    setBoundingSphere(pss(_ellipsoid.averageRadius(), 0.0));
+    setBoundingSphere(_ellipsoid.averageRadius());
 
     // Ghoul can't read ints from lua dictionaries...
     double patchSegmentsd;

--- a/modules/globebrowsing/other/distanceswitch.cpp
+++ b/modules/globebrowsing/other/distanceswitch.cpp
@@ -23,7 +23,6 @@
  ****************************************************************************************/
 
 #include <modules/globebrowsing/other/distanceswitch.h>
-
 #include <openspace/rendering/renderable.h>
 
 namespace openspace {
@@ -52,8 +51,7 @@ void DistanceSwitch::render(const RenderData& data) {
         return;
     }
 
-    pss pssDistanceToCamera = (data.camera.position() - data.position).length();
-    double distanceToCamera = pssDistanceToCamera.lengthd();
+    double distanceToCamera = (data.camera.positionVec3() - data.position.dvec3()).length();
 
     if (distanceToCamera > _maxDistances.back() * _objectScale) {
         return;

--- a/modules/newhorizons/rendering/renderablemodelprojection.cpp
+++ b/modules/newhorizons/rendering/renderablemodelprojection.cpp
@@ -143,7 +143,7 @@ RenderableModelProjection::RenderableModelProjection(const ghoul::Dictionary& di
     
     float boundingSphereRadius = 1.0e9;
     dictionary.getValue(keyBoundingSphereRadius, boundingSphereRadius);
-    setBoundingSphere(PowerScaledScalar::CreatePSS(boundingSphereRadius));
+    setBoundingSphere(boundingSphereRadius);
 
     Renderable::addProperty(_performShading);
     Renderable::addProperty(_rotation);
@@ -187,7 +187,7 @@ bool RenderableModelProjection::initialize() {
     completeSuccess &= loadTextures();
     completeSuccess &= _projectionComponent.initializeGL();
 
-    auto bs = getBoundingSphere();
+    float bs = boundingSphere();
     completeSuccess &= _geometry->initialize(this);
     setBoundingSphere(bs); // ignore bounding sphere set by geometry.
 
@@ -397,7 +397,7 @@ void RenderableModelProjection::attitudeParameters(double time) {
     glm::vec3 cpos = position.vec3();
 
     float distance = glm::length(cpos);
-    float radius = getBoundingSphere().lengthf();
+    float radius = boundingSphere();
 
     _projectorMatrix = _projectionComponent.computeProjectorMatrix(
         cpos, boresight, _up, _instrumentMatrix,

--- a/modules/newhorizons/rendering/renderableplaneprojection.cpp
+++ b/modules/newhorizons/rendering/renderableplaneprojection.cpp
@@ -318,17 +318,4 @@ void RenderablePlaneProjection::setTarget(std::string body) {
     _target.frame = openspace::SpiceManager::ref().frameFromBody(body);
 }
 
-std::string RenderablePlaneProjection::findClosestTarget(double currentTime) {
-
-    std::vector<std::string> targets;
-
-    std::vector<SceneGraphNode*> nodes = OsEng.renderEngine().scene()->allSceneGraphNodes();
-    std::string targetBody;
-
-    PowerScaledScalar min = PowerScaledScalar::CreatePSS(REALLY_FAR);
-    PowerScaledScalar distance = PowerScaledScalar::CreatePSS(0.0);
-
-    return targetBody;
-}
-
 } // namespace openspace

--- a/modules/newhorizons/rendering/renderableplaneprojection.h
+++ b/modules/newhorizons/rendering/renderableplaneprojection.h
@@ -68,7 +68,6 @@ public:
 private:
     void loadTexture();
     void updatePlane(const Image& img, double currentTime);
-    std::string findClosestTarget(double currentTime);
     void setTarget(std::string body);
 
     std::string _texturePath;

--- a/modules/newhorizons/rendering/renderableplanetprojection.cpp
+++ b/modules/newhorizons/rendering/renderableplanetprojection.cpp
@@ -177,7 +177,7 @@ RenderablePlanetProjection::RenderablePlanetProjection(const ghoul::Dictionary& 
 
     glm::vec2 radius = glm::vec2(1.0, 9.0);
     dictionary.getValue(keyRadius, radius);
-    setBoundingSphere(pss(radius));
+    setBoundingSphere(radius[0] * std::pow(10, radius[1]));
 
     addPropertySubOwner(_geometry.get());
     addPropertySubOwner(_projectionComponent);
@@ -356,7 +356,7 @@ void RenderablePlanetProjection::attitudeParameters(double time) {
     glm::vec3 cpos = position.vec3();
 
     float distance = glm::length(cpos);
-    float radius = getBoundingSphere().lengthf();
+    float radius = boundingSphere();
 
     _projectorMatrix = _projectionComponent.computeProjectorMatrix(
         cpos,

--- a/modules/space/rendering/renderablerings.cpp
+++ b/modules/space/rendering/renderablerings.cpp
@@ -106,7 +106,7 @@ RenderableRings::RenderableRings(const ghoul::Dictionary& dictionary)
     );
 
     _size = static_cast<float>(dictionary.value<double>(KeySize));
-    setBoundingSphere(PowerScaledScalar::CreatePSS(_size));
+    setBoundingSphere(_size);
     addProperty(_size);
     _size.onChange([&]() { _planeIsDirty = true; });
 

--- a/modules/space/rendering/simplespheregeometry.h
+++ b/modules/space/rendering/simplespheregeometry.h
@@ -28,7 +28,7 @@
 #include <modules/space/rendering/planetgeometry.h>
 
 #include <openspace/properties/scalar/intproperty.h>
-#include <openspace/properties/vector/vec4property.h>
+#include <openspace/properties/vector/vec3property.h>
 
 namespace openspace {
 
@@ -42,20 +42,15 @@ public:
     SimpleSphereGeometry(const ghoul::Dictionary& dictionary);
     ~SimpleSphereGeometry();
 
-
     bool initialize(Renderable* parent) override;
     void deinitialize() override;
     void render() override;
-    PowerScaledSphere* _planet;
-
 private:
     void createSphere();
 
-    glm::vec2 _modRadius;
-    properties::Vec4Property _realRadius;
+    float _modRadius;
+    properties::Vec3Property _radius;
     properties::IntProperty _segments;
-    std::string _name;
-
     PowerScaledSphere* _sphere;
 };
 

--- a/src/interaction/interactionmode.cpp
+++ b/src/interaction/interactionmode.cpp
@@ -401,7 +401,7 @@ void OrbitalInteractionMode::updateCameraStateFromMouseStates(Camera& camera, do
         dquat totalRotation = camera.rotationQuaternion();
         dvec3 directionToCenter = normalize(centerPos - camPos);
         dvec3 lookUp = camera.lookUpVectorWorldSpace();
-        double boundingSphere = _focusNode->boundingSphere().lengthf();
+        double boundingSphere = _focusNode->boundingSphere();
         dvec3 camDirection = camera.viewDirectionWorldSpace();
 
         // Declare other variables used in interaction calculations

--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -121,12 +121,12 @@ Renderable::Renderable(const ghoul::Dictionary& dictionary)
 
 Renderable::~Renderable() {}
 
-void Renderable::setBoundingSphere(PowerScaledScalar boundingSphere) {
-    boundingSphere_ = std::move(boundingSphere);
+void Renderable::setBoundingSphere(float boundingSphere) {
+    _boundingSphere = boundingSphere;
 }
 
-PowerScaledScalar Renderable::getBoundingSphere() {
-    return boundingSphere_;
+float Renderable::boundingSphere() const {
+    return _boundingSphere;
 }
 
 void Renderable::update(const UpdateData&) {}

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -282,8 +282,6 @@ void RenderEngine::updateScene() {
         Time::ref().timeJumped(),
         _performanceManager != nullptr
     });
-
-    _scene->evaluate(_camera);
     
     LTRACE("RenderEngine::updateSceneGraph(end)");
 }

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -228,19 +228,6 @@ void Scene::update(const UpdateData& data) {
     }
 }
 
-void Scene::evaluate(Camera* camera) {
-    for (SceneGraphNode* node : _topologicallySortedNodes) {
-        try {
-            LTRACE("Scene::evaluate(begin '" + node->name() + "')");
-            node->evaluate(camera);
-            LTRACE("Scene::evaluate(end '" + node->name() + "')");
-        }
-        catch (const ghoul::RuntimeError& e) {
-            LERRORC(e.component, e.what());
-        }
-    }
-}
-
 void Scene::render(const RenderData& data, RendererTasks& tasks) {
     for (SceneGraphNode* node : _topologicallySortedNodes) {
         try {


### PR DESCRIPTION
- Removed some power scaled coordinates
- Removed some dead code
- Removed spice dependency from sphere geometry class
- Make scene graph nodes rely on their renderable to compute their bounding sphere

@jonathanbosson, this fixes the issue with the uninitialized bounding boxes for RenderablePlanet.
Not sure if we should pull in this into master before the upcoming Earth Day event, but you can merge it into your touch branch temporarily if you want.