### PR TITLE
Write remaining PerformanceMeasurement logs on destruction

### DIFF
--- a/src/performance/performancemanager.cpp
+++ b/src/performance/performancemanager.cpp
@@ -172,6 +172,10 @@ PerformanceManager::PerformanceManager()
 }
 
 PerformanceManager::~PerformanceManager() {
+    if (loggingEnabled()) {
+        outputLogs();
+    }
+
     if (_performanceMemory) {
         ghoul::SharedMemory sharedMemory(GlobalSharedMemoryName);
         sharedMemory.acquireLock();
@@ -207,6 +211,7 @@ void PerformanceManager::outputLogs() {
 
     // Log Layout values
     PerformanceLayout* layout = performanceData();
+    const size_t writeStart = (PerformanceLayout::NumberValues - 1) - _tick;
 
     // Log function performance
     for (size_t n = 0; n < layout->nFunctionEntries; n++) {
@@ -215,7 +220,7 @@ void PerformanceManager::outputLogs() {
         std::ofstream out = std::ofstream(absPath(filename), std::ofstream::out | std::ofstream::app);
 
         // Comma separate data
-        for (size_t i = 0; i < PerformanceLayout::NumberValues; i++) {
+        for (size_t i = writeStart; i < PerformanceLayout::NumberValues; i++) {
             const std::vector<float> data = { function.time[i] };
             writeData(out, data);
         }
@@ -231,7 +236,7 @@ void PerformanceManager::outputLogs() {
         std::ofstream out = std::ofstream(absPath(filename), std::ofstream::out | std::ofstream::app);
         
         // Comma separate data
-        for (size_t i = 0; i < PerformanceLayout::NumberValues; i++) {
+        for (size_t i = writeStart; i < PerformanceLayout::NumberValues; i++) {
             const std::vector<float> data = {
                 node.renderTime[i],
                 node.updateRenderable[i],


### PR DESCRIPTION
even when there is not a multiple of the PerformanceLayout::NumberValues