### PR TITLE
StringProperty fix

### DIFF
--- a/modules/imgui/src/renderproperties.cpp
+++ b/modules/imgui/src/renderproperties.cpp
@@ -213,7 +213,7 @@ void renderStringProperty(Property* prop, const std::string& ownerName,
     std::string name = p->guiName();
     ImGui::PushID((ownerName + "." + name).c_str());
 
-    std::string value = FileSys.convertPathSeparator(p->value(), '/');
+    const std::string value = p->value();
 
     static const int bufferSize = 256;
     static char buffer[bufferSize];
@@ -235,7 +235,7 @@ void renderStringProperty(Property* prop, const std::string& ownerName,
     if (hasNewValue) {
         executeScript(
             p->fullyQualifiedIdentifier(),
-            "'" + std::string(buffer) + "'",
+            "[[" + std::string(buffer) + "]]",
             isRegular
         );
     }


### PR DESCRIPTION
Do not assume that string propeties are file paths.
Fix proper escaping in lua script generation.

Fixes https://github.com/OpenSpace/OpenSpace/issues/420