### PR TITLE
Issue/525

### DIFF
--- a/include/openspace/engine/moduleengine.h
+++ b/include/openspace/engine/moduleengine.h
@@ -59,10 +59,20 @@ public:
     void initialize(const ghoul::Dictionary& moduleConfigurations);
 
     /**
+     * Calls the initializeGL functions of all registered OpenSpaceModule%s.
+     */
+    void initializeGL();
+
+    /**
      * Deinitializes all of the contained OpenSpaceModule%s by calling the
      * OpenSpaceModule::deinitialize methods.
      */
     void deinitialize();
+
+    /**
+     * Calls the deinitializeGL functions of all registered OpenSpaceModule%s.
+     */
+    void deinitializeGL();
 
     /**
      * Registers the passed \p module with this ModuleEngine. The OpenSpaceModule::create

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -123,6 +123,8 @@ public:
     void removeRenderProgram(
         const std::unique_ptr<ghoul::opengl::ProgramObject>& program);
 
+    void removeRenderProgram(ghoul::opengl::ProgramObject* program);
+
     /**
     * Set raycasting uniforms on the program object, and setup raycasting.
     */

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -120,9 +120,6 @@ public:
         std::string csPath,
         const ghoul::Dictionary& dictionary = ghoul::Dictionary());
 
-    void removeRenderProgram(
-        const std::unique_ptr<ghoul::opengl::ProgramObject>& program);
-
     void removeRenderProgram(ghoul::opengl::ProgramObject* program);
 
     /**

--- a/include/openspace/util/openspacemodule.h
+++ b/include/openspace/util/openspacemodule.h
@@ -66,13 +66,24 @@ public:
      * internalInitialize method for further customization for each subclass.
      */
     void initialize(const ModuleEngine* moduleEngine,
-                    const ghoul::Dictionary& configuration);
+        const ghoul::Dictionary& configuration);
+
+    /**
+     * This method calls the internalInitializeGL method for further customization for
+     * each subclass.
+     */
+    void initializeGL();
 
     /**
      * Empty deinitialization method that will call the internalDeinitialize method for
      * module-specific customization.
      */
     void deinitialize();
+
+    /**
+     * This method will call the internalDeinitializeGL method for each subclass.
+     */
+    void deinitializeGL();
 
     /**
      * Returns a list of Documentation classes that are valid for this OpenSpaceModule.
@@ -113,10 +124,24 @@ protected:
     virtual void internalInitialize(const ghoul::Dictionary& configuration);
 
     /**
+     * Customization point for each derived class. The internalInitializeGL method is
+     * called by the initializeGL method at a time when a valid OpenGL state is
+     * guaranteed.
+     */
+    virtual void internalInitializeGL();
+
+    /**
      * Customization point for each derived class. The internalDeinitialize method is
      * called by the deinitialize method.
      */
     virtual void internalDeinitialize();
+
+    /**
+     * Customization point for each derived class. The internalDeinitializeGL method is
+     * called by the deinitializeGL method at a time when a valid OpenGL state is
+     * guaranteed.
+     */
+    virtual void internalDeinitializeGL();
 
     /**
      * Returns the path for this module, possibly containing ghoul::filesystem::FileSystem

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -141,6 +141,10 @@ void BaseModule::internalInitialize(const ghoul::Dictionary&) {
     fGeometry->registerClass<modelgeometry::MultiModelGeometry>("MultiModelGeometry");
 }
 
+void BaseModule::internalDeinitializeGL() {
+    ProgramObjectManager.releaseAll(ghoul::opengl::ProgramObjectManager::Warnings::Yes);
+}
+
 std::vector<documentation::Documentation> BaseModule::documentations() const {
     return {
         DashboardItemDate::Documentation(),

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -68,6 +68,8 @@
 
 namespace openspace {
 
+ghoul::opengl::ProgramObjectManager BaseModule::ProgramObjectManager;
+
 BaseModule::BaseModule() : OpenSpaceModule(BaseModule::Name) {}
 
 void BaseModule::internalInitialize(const ghoul::Dictionary&) {

--- a/modules/base/basemodule.h
+++ b/modules/base/basemodule.h
@@ -45,6 +45,7 @@ public:
 
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;
+    void internalDeinitializeGL() override;
 };
 
 } // namespace openspace

--- a/modules/base/basemodule.h
+++ b/modules/base/basemodule.h
@@ -27,6 +27,8 @@
 
 #include <openspace/util/openspacemodule.h>
 
+#include <ghoul/opengl/programobjectmanager.h>
+
 namespace openspace {
 
 class BaseModule : public OpenSpaceModule {
@@ -38,6 +40,8 @@ public:
 
     std::vector<documentation::Documentation> documentations() const override;
     std::vector<scripting::LuaLibrary> luaLibraries() const override;
+
+    static ghoul::opengl::ProgramObjectManager ProgramObjectManager;
 
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -24,8 +24,8 @@
 
 #include <modules/base/rendering/renderablemodel.h>
 
+#include <modules/base/basemodule.h>
 #include <modules/base/rendering/modelgeometry.h>
-
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/configurationmanager.h>
@@ -43,7 +43,8 @@
 #include <ghoul/opengl/textureunit.h>
 
 namespace {
-    const char* KeyGeometry = "Geometry";
+    constexpr const char* ProgramName = "ModelProgram";
+    constexpr const char* KeyGeometry = "Geometry";
 
     static const openspace::properties::Property::PropertyInfo TextureInfo = {
         "ColorTexture",
@@ -157,10 +158,15 @@ bool RenderableModel::isReady() const {
 }
 
 void RenderableModel::initializeGL() {
-    _programObject = OsEng.renderEngine().buildRenderProgram(
-        "ModelProgram",
-        absPath("${MODULE_BASE}/shaders/model_vs.glsl"),
-        absPath("${MODULE_BASE}/shaders/model_fs.glsl")
+    _programObject = BaseModule::ProgramObjectManager.requestProgramObject(
+        ProgramName,
+        []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+            return OsEng.renderEngine().buildRenderProgram(
+                ProgramName,
+                absPath("${MODULE_BASE}/shaders/model_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/model_fs.glsl")
+            );
+        }
     );
 
     _uniformCache.directionToSunViewSpace = _programObject->uniformLocation(
@@ -188,10 +194,13 @@ void RenderableModel::deinitializeGL() {
     }
     _texture = nullptr;
 
-    if (_programObject) {
-        OsEng.renderEngine().removeRenderProgram(_programObject.get());
-        _programObject = nullptr;
-    }
+    BaseModule::ProgramObjectManager.releaseProgramObject(
+        ProgramName,
+        [](ghoul::opengl::ProgramObject* p) {
+            OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
+    _programObject = nullptr;
 }
 
 void RenderableModel::render(const RenderData& data, RendererTasks&) {

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -189,7 +189,7 @@ void RenderableModel::deinitializeGL() {
     _texture = nullptr;
 
     if (_programObject) {
-        OsEng.renderEngine().removeRenderProgram(_programObject);
+        OsEng.renderEngine().removeRenderProgram(_programObject.get());
         _programObject = nullptr;
     }
 }

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -73,7 +73,7 @@ private:
     properties::BoolProperty _performShading;
     properties::Mat3Property _modelTransform;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _programObject;
+    ghoul::opengl::ProgramObject* _programObject;
     UniformCache(directionToSunViewSpace, modelViewTransform, projectionTransform,
         performShading, texture) _uniformCache;
 

--- a/modules/base/rendering/renderableplane.cpp
+++ b/modules/base/rendering/renderableplane.cpp
@@ -177,7 +177,7 @@ void RenderablePlane::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 }

--- a/modules/base/rendering/renderableplane.cpp
+++ b/modules/base/rendering/renderableplane.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/base/rendering/renderableplane.h>
 
+#include <modules/base/basemodule.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/openspaceengine.h>
@@ -39,6 +40,8 @@
 #include <ghoul/opengl/textureunit.h>
 
 namespace {
+    constexpr const char* ProgramName = "Plane";
+
     enum BlendMode {
         BlendModeNormal = 0,
         BlendModeAdditive
@@ -161,11 +164,16 @@ void RenderablePlane::initializeGL() {
     glGenBuffers(1, &_vertexPositionBuffer); // generate buffer
     createPlane();
 
-    _shader = OsEng.renderEngine().buildRenderProgram(
-        "PlaneProgram",
-        absPath("${MODULE_BASE}/shaders/plane_vs.glsl"),
-        absPath("${MODULE_BASE}/shaders/plane_fs.glsl")
-    );
+    _shader = BaseModule::ProgramObjectManager.requestProgramObject(
+        ProgramName,
+        []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+            return OsEng.renderEngine().buildRenderProgram(
+                ProgramName,
+                absPath("${MODULE_BASE}/shaders/plane_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/plane_fs.glsl")
+            );
+        }
+    ); 
 }
 
 void RenderablePlane::deinitializeGL() {
@@ -175,11 +183,13 @@ void RenderablePlane::deinitializeGL() {
     glDeleteBuffers(1, &_vertexPositionBuffer);
     _vertexPositionBuffer = 0;
 
-    RenderEngine& renderEngine = OsEng.renderEngine();
-    if (_shader) {
-        renderEngine.removeRenderProgram(_shader.get());
-        _shader = nullptr;
-    }
+    BaseModule::ProgramObjectManager.releaseProgramObject(
+        ProgramName,
+        [](ghoul::opengl::ProgramObject* p) {
+        OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
+    _shader = nullptr;
 }
 
 void RenderablePlane::render(const RenderData& data, RendererTasks&) {

--- a/modules/base/rendering/renderableplane.h
+++ b/modules/base/rendering/renderableplane.h
@@ -73,7 +73,7 @@ private:
     properties::FloatProperty _size;
     properties::OptionProperty _blendMode;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
+    ghoul::opengl::ProgramObject* _shader;
 
     GLuint _quad;
     GLuint _vertexPositionBuffer;

--- a/modules/base/rendering/renderablesphere.cpp
+++ b/modules/base/rendering/renderablesphere.cpp
@@ -279,7 +279,7 @@ void RenderableSphere::deinitializeGL() {
     _texture = nullptr;
 
     if (_shader) {
-        OsEng.renderEngine().removeRenderProgram(_shader);
+        OsEng.renderEngine().removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 }

--- a/modules/base/rendering/renderablesphere.cpp
+++ b/modules/base/rendering/renderablesphere.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/base/rendering/renderablesphere.h>
 
+#include <modules/base/basemodule.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/openspaceengine.h>
@@ -39,6 +40,8 @@
 #include <ghoul/opengl/programobject.h>
 
 namespace {
+    constexpr const char* ProgramName = "Sphere";
+
     enum Orientation {
         Outside = 1,
         Inside = 2
@@ -265,11 +268,15 @@ void RenderableSphere::initializeGL() {
     );
     _sphere->initialize();
 
-    // pscstandard
-    _shader = OsEng.renderEngine().buildRenderProgram(
-        "Sphere",
-        absPath("${MODULE_BASE}/shaders/sphere_vs.glsl"),
-        absPath("${MODULE_BASE}/shaders/sphere_fs.glsl")
+    _shader = BaseModule::ProgramObjectManager.requestProgramObject(
+        ProgramName,
+        []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+            return OsEng.renderEngine().buildRenderProgram(
+                ProgramName,
+                absPath("${MODULE_BASE}/shaders/sphere_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/sphere_fs.glsl")
+            );
+        }
     );
 
     loadTexture();
@@ -278,10 +285,13 @@ void RenderableSphere::initializeGL() {
 void RenderableSphere::deinitializeGL() {
     _texture = nullptr;
 
-    if (_shader) {
-        OsEng.renderEngine().removeRenderProgram(_shader.get());
-        _shader = nullptr;
-    }
+    BaseModule::ProgramObjectManager.releaseProgramObject(
+        ProgramName,
+        [](ghoul::opengl::ProgramObject* p) {
+            OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
+    _shader = nullptr;
 }
 
 void RenderableSphere::render(const RenderData& data, RendererTasks&) {
@@ -297,7 +307,7 @@ void RenderableSphere::render(const RenderData& data, RendererTasks&) {
     _shader->setUniform("ViewProjection", data.camera.viewProjectionMatrix());
     _shader->setUniform("ModelTransform", transform);
 
-    setPscUniforms(*_shader.get(), data.camera, data.position);
+    setPscUniforms(*_shader, data.camera, data.position);
 
     float adjustedTransparency = _transparency;
 

--- a/modules/base/rendering/renderablesphere.h
+++ b/modules/base/rendering/renderablesphere.h
@@ -75,7 +75,7 @@ private:
     float _fadeOutThreshold;
     float _fadeInThreshold;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
+    ghoul::opengl::ProgramObject* _shader;
     std::unique_ptr<ghoul::opengl::Texture> _texture;
 
     std::unique_ptr<PowerScaledSphere> _sphere;

--- a/modules/base/rendering/renderablesphericalgrid.cpp
+++ b/modules/base/rendering/renderablesphericalgrid.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/base/rendering/renderablesphericalgrid.h>
 
+#include <modules/base/basemodule.h>
 #include <openspace/engine/configurationmanager.h>
 #include <openspace/engine/openspaceengine.h>
 #include <openspace/rendering/renderengine.h>
@@ -36,6 +37,8 @@
 #include <ghoul/opengl/programobject.h>
 
 namespace {
+    constexpr const char* ProgramName = "GridProgram";
+
     static const openspace::properties::Property::PropertyInfo GridColorInfo = {
         "GridColor",
         "Grid Color",
@@ -179,10 +182,15 @@ bool RenderableSphericalGrid::isReady() const {
 }
 
 void RenderableSphericalGrid::initializeGL() {
-    _gridProgram = OsEng.renderEngine().buildRenderProgram(
-        "GridProgram",
-        absPath("${MODULE_BASE}/shaders/grid_vs.glsl"),
-        absPath("${MODULE_BASE}/shaders/grid_fs.glsl")
+    _gridProgram = BaseModule::ProgramObjectManager.requestProgramObject(
+        ProgramName,
+        []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+            return OsEng.renderEngine().buildRenderProgram(
+                ProgramName,
+                absPath("${MODULE_BASE}/shaders/grid_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/grid_fs.glsl")
+            );
+        }
     );
 
     glGenVertexArrays(1, &_vaoID);
@@ -205,6 +213,14 @@ void RenderableSphericalGrid::deinitializeGL() {
 
     glDeleteBuffers(1, &_iBufferID);
     _iBufferID = 0;
+
+    BaseModule::ProgramObjectManager.releaseProgramObject(
+        ProgramName,
+        [](ghoul::opengl::ProgramObject* p) {
+            OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
+    _gridProgram = nullptr;
 }
 
 void RenderableSphericalGrid::render(const RenderData& data, RendererTasks&){

--- a/modules/base/rendering/renderablesphericalgrid.h
+++ b/modules/base/rendering/renderablesphericalgrid.h
@@ -63,7 +63,7 @@ protected:
         float location[3];
     };
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _gridProgram;
+    ghoul::opengl::ProgramObject* _gridProgram;
 
     properties::DMat4Property _gridMatrix;
     properties::Vec4Property _gridColor;

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -244,7 +244,7 @@ void RenderableTrail::initializeGL() {
 void RenderableTrail::deinitializeGL() {
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_programObject) {
-        renderEngine.removeRenderProgram(_programObject);
+        renderEngine.removeRenderProgram(_programObject.get());
         _programObject = nullptr;
     }
 }

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/base/rendering/renderabletrail.h>
 
+#include <modules/base/basemodule.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/openspaceengine.h>
@@ -35,7 +36,8 @@
 #include <ghoul/opengl/programobject.h>
 
 namespace {
-    const char* KeyTranslation = "Translation";
+    constexpr const char* ProgramName = "EphemerisProgram";
+    constexpr const char* KeyTranslation = "Translation";
 
     // The possible values for the _renderingModes property
     enum RenderingMode {
@@ -219,11 +221,15 @@ RenderableTrail::RenderableTrail(const ghoul::Dictionary& dictionary)
 }
 
 void RenderableTrail::initializeGL() {
-    RenderEngine& renderEngine = OsEng.renderEngine();
-    _programObject = renderEngine.buildRenderProgram(
-        "EphemerisProgram",
-        absPath("${MODULE_BASE}/shaders/renderabletrail_vs.glsl"),
-        absPath("${MODULE_BASE}/shaders/renderabletrail_fs.glsl")
+    _programObject = BaseModule::ProgramObjectManager.requestProgramObject(
+        ProgramName,
+        []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+            return OsEng.renderEngine().buildRenderProgram(
+                ProgramName,
+                absPath("${MODULE_BASE}/shaders/renderabletrail_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/renderabletrail_fs.glsl")
+            );
+        }
     );
 
     _uniformCache.modelView = _programObject->uniformLocation("modelViewTransform");
@@ -242,11 +248,13 @@ void RenderableTrail::initializeGL() {
 }
 
 void RenderableTrail::deinitializeGL() {
-    RenderEngine& renderEngine = OsEng.renderEngine();
-    if (_programObject) {
-        renderEngine.removeRenderProgram(_programObject.get());
-        _programObject = nullptr;
-    }
+    BaseModule::ProgramObjectManager.releaseProgramObject(
+        ProgramName,
+        [](ghoul::opengl::ProgramObject* p) {
+            OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
+    _programObject = nullptr;
 }
 
 bool RenderableTrail::isReady() const {
@@ -300,7 +308,7 @@ void RenderableTrail::render(const RenderData& data, RendererTasks&) {
         glEnable(GL_PROGRAM_POINT_SIZE);
     }
 
-    auto render = [renderLines, renderPoints, p = _programObject.get(), &data,
+    auto render = [renderLines, renderPoints, p = _programObject, &data,
                    &modelTransform, pointSize = _pointSize.value(), c = _uniformCache]
                   (RenderInformation& info, int nVertices, int offset)
     {

--- a/modules/base/rendering/renderabletrail.h
+++ b/modules/base/rendering/renderabletrail.h
@@ -158,7 +158,7 @@ private:
     properties::OptionProperty _renderingModes;
 
     /// Program object used to render the data stored in RenderInformation
-    std::unique_ptr<ghoul::opengl::ProgramObject> _programObject;
+    ghoul::opengl::ProgramObject* _programObject;
 
     UniformCache(modelView, projection, color, useLineFade, lineFade, vertexSorting,
         idOffset, nVertices, stride, pointSize, renderPhase) _uniformCache;

--- a/modules/debugging/rendering/renderabledebugplane.cpp
+++ b/modules/debugging/rendering/renderabledebugplane.cpp
@@ -213,7 +213,7 @@ void RenderableDebugPlane::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 }

--- a/modules/digitaluniverse/digitaluniversemodule.cpp
+++ b/modules/digitaluniverse/digitaluniversemodule.cpp
@@ -40,6 +40,8 @@
 
 namespace openspace {
 
+ghoul::opengl::ProgramObjectManager DigitalUniverseModule::ProgramObjectManager;
+
 DigitalUniverseModule::DigitalUniverseModule()
     : OpenSpaceModule(DigitalUniverseModule::Name)
 {}

--- a/modules/digitaluniverse/digitaluniversemodule.cpp
+++ b/modules/digitaluniverse/digitaluniversemodule.cpp
@@ -56,6 +56,10 @@ void DigitalUniverseModule::internalInitialize(const ghoul::Dictionary&) {
     fRenderable->registerClass<RenderableDUMeshes>("RenderableDUMeshes");
 }
 
+void DigitalUniverseModule::internalDeinitializeGL() {
+    ProgramObjectManager.releaseAll(ghoul::opengl::ProgramObjectManager::Warnings::Yes);
+}
+
 std::vector<documentation::Documentation> DigitalUniverseModule::documentations() const {
     return {
         RenderablePoints::Documentation(),

--- a/modules/digitaluniverse/digitaluniversemodule.h
+++ b/modules/digitaluniverse/digitaluniversemodule.h
@@ -27,6 +27,8 @@
 
 #include <openspace/util/openspacemodule.h>
 
+#include <ghoul/opengl/programobjectmanager.h>
+
 namespace openspace {
 
 class DigitalUniverseModule : public OpenSpaceModule {
@@ -36,6 +38,8 @@ public:
     DigitalUniverseModule();
     virtual ~DigitalUniverseModule() = default;
     std::vector<documentation::Documentation> documentations() const override;
+
+    static ghoul::opengl::ProgramObjectManager ProgramObjectManager;
 
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;

--- a/modules/digitaluniverse/digitaluniversemodule.h
+++ b/modules/digitaluniverse/digitaluniversemodule.h
@@ -43,6 +43,7 @@ public:
 
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;
+    void internalDeinitializeGL() override;
 };
 
 } // namespace openspace

--- a/modules/digitaluniverse/rendering/renderablebillboardscloud.h
+++ b/modules/digitaluniverse/rendering/renderablebillboardscloud.h
@@ -142,6 +142,8 @@ private:
     std::unique_ptr<ghoul::opengl::Texture> _spriteTexture;
     std::unique_ptr<ghoul::filesystem::File> _spriteTextureFile;
     ghoul::opengl::ProgramObject* _program;
+    ghoul::opengl::ProgramObject* _renderToPolygonProgram;
+
     UniformCache(modelViewProjection, cameraPos, cameraLookup,
         renderOption, centerSceenInWorldPos, minBillboardSize, maxBillboardSize,
         color, sides, alphaValue, scaleFactor, up, right, fadeInValue, screenSize,

--- a/modules/digitaluniverse/rendering/renderablebillboardscloud.h
+++ b/modules/digitaluniverse/rendering/renderablebillboardscloud.h
@@ -141,7 +141,7 @@ private:
     std::unique_ptr<ghoul::opengl::Texture> _polygonTexture;
     std::unique_ptr<ghoul::opengl::Texture> _spriteTexture;
     std::unique_ptr<ghoul::filesystem::File> _spriteTextureFile;
-    std::unique_ptr<ghoul::opengl::ProgramObject> _program;
+    ghoul::opengl::ProgramObject* _program;
     UniformCache(modelViewProjection, cameraPos, cameraLookup,
         renderOption, centerSceenInWorldPos, minBillboardSize, maxBillboardSize,
         color, sides, alphaValue, scaleFactor, up, right, fadeInValue, screenSize,

--- a/modules/digitaluniverse/rendering/renderabledumeshes.h
+++ b/modules/digitaluniverse/rendering/renderabledumeshes.h
@@ -139,7 +139,7 @@ private:
     // DEBUG:
     properties::OptionProperty _renderOption;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _program;
+    ghoul::opengl::ProgramObject* _program;
     UniformCache(modelViewTransform, projectionTransform, alphaValue,
         /*scaleFactor,*/ color) _uniformCache;
     std::shared_ptr<ghoul::fontrendering::Font> _font;

--- a/modules/digitaluniverse/rendering/renderableplanescloud.h
+++ b/modules/digitaluniverse/rendering/renderableplanescloud.h
@@ -50,111 +50,112 @@ namespace ghoul::opengl {
 } // namespace ghoul::opengl
 
 namespace openspace {
-    // (x, y, z, w, s, t) * 6 = 36
-    const int PLANES_VERTEX_DATA_SIZE = 36;
 
-    namespace documentation { struct Documentation; }
+// (x, y, z, w, s, t) * 6 = 36
+const int PLANES_VERTEX_DATA_SIZE = 36;
 
-    class RenderablePlanesCloud : public Renderable {
-    public:
-        explicit RenderablePlanesCloud(const ghoul::Dictionary& dictionary);
-        ~RenderablePlanesCloud() = default;
+namespace documentation { struct Documentation; }
 
-        void initialize() override;
-        void initializeGL() override;
-        void deinitializeGL() override;
+class RenderablePlanesCloud : public Renderable {
+public:
+    explicit RenderablePlanesCloud(const ghoul::Dictionary& dictionary);
+    ~RenderablePlanesCloud() = default;
 
-        bool isReady() const override;
+    void initialize() override;
+    void initializeGL() override;
+    void deinitializeGL() override;
 
-        void render(const RenderData& data, RendererTasks& rendererTask) override;
-        void update(const UpdateData& data) override;
+    bool isReady() const override;
 
-        static documentation::Documentation Documentation();
+    void render(const RenderData& data, RendererTasks& rendererTask) override;
+    void update(const UpdateData& data) override;
 
-    private:
-        enum Unit {
-            Meter = 0,
-            Kilometer = 1,
-            Parsec = 2,
-            Kiloparsec = 3,
-            Megaparsec = 4,
-            Gigaparsec = 5,
+    static documentation::Documentation Documentation();
 
-            GigalightYears = 6
-        };
+private:
+    enum Unit {
+        Meter = 0,
+        Kilometer = 1,
+        Parsec = 2,
+        Kiloparsec = 3,
+        Megaparsec = 4,
+        Gigaparsec = 5,
 
-        struct RenderingPlane {
-            int planeIndex;
-            GLuint vao;
-            GLuint vbo;
-            GLfloat vertexData[PLANES_VERTEX_DATA_SIZE];
-        };
-
-        void deleteDataGPU();
-        void createPlanes();
-        void renderPlanes(const RenderData& data, const glm::dmat4& modelViewMatrix,
-            const glm::dmat4& projectionMatrix, float fadeInVariable);
-        void renderLabels(const RenderData& data,
-            const glm::dmat4& modelViewProjectionMatrix, const glm::dvec3& orthoRight,
-            const glm::dvec3& orthoUp, float fadeInVarible);
-
-        bool loadData();
-        bool loadTextures();
-        bool readSpeckFile();
-        bool readLabelFile();
-        bool loadCachedFile(const std::string& file);
-        bool saveCachedFile(const std::string& file) const;
-
-        bool _hasSpeckFile;
-        bool _dataIsDirty;
-        bool _textColorIsDirty;
-        bool _hasLabel;
-        bool _labelDataIsDirty;
-
-        int _textMinSize;
-        int _textMaxSize;
-        int _planeStartingIndexPos;
-        int _textureVariableIndex;
-
-        properties::FloatProperty _alphaValue;
-        properties::FloatProperty _scaleFactor;
-        properties::Vec4Property _textColor;
-        properties::FloatProperty _textSize;
-        properties::BoolProperty _drawElements;
-        properties::OptionProperty _blendMode;
-        properties::Vec2Property _fadeInDistance;
-        properties::BoolProperty _disableFadeInDistance;
-        properties::FloatProperty _planeMinSize;
-
-        // DEBUG:
-        properties::OptionProperty _renderOption;
-
-        std::unique_ptr<ghoul::opengl::ProgramObject> _program;
-        UniformCache(modelViewProjectionTransform, alphaValue, scaleFactor, fadeInValue,
-            galaxyTexture) _uniformCache;
-        std::shared_ptr<ghoul::fontrendering::Font> _font;
-        std::unordered_map<int, std::unique_ptr<ghoul::opengl::Texture>> _textureMap;
-        std::unordered_map<int, std::string> _textureFileMap;
-
-        std::string _speckFile;
-        std::string _labelFile;
-        std::string _texturesPath;
-        std::string _luminosityVar;
-
-        Unit _unit;
-
-        std::vector<float> _fullData;
-        std::vector<std::pair<glm::vec3, std::string>> _labelData;
-        std::unordered_map<std::string, int> _variableDataPositionMap;
-
-        int _nValuesPerAstronomicalObject;
-
-        float _sluminosity;
-
-        glm::dmat4 _transformationMatrix;
-
-        std::vector<RenderingPlane> _renderingPlanesArray;
+        GigalightYears = 6
     };
+
+    struct RenderingPlane {
+        int planeIndex;
+        GLuint vao;
+        GLuint vbo;
+        GLfloat vertexData[PLANES_VERTEX_DATA_SIZE];
+    };
+
+    void deleteDataGPU();
+    void createPlanes();
+    void renderPlanes(const RenderData& data, const glm::dmat4& modelViewMatrix,
+        const glm::dmat4& projectionMatrix, float fadeInVariable);
+    void renderLabels(const RenderData& data,
+        const glm::dmat4& modelViewProjectionMatrix, const glm::dvec3& orthoRight,
+        const glm::dvec3& orthoUp, float fadeInVarible);
+
+    bool loadData();
+    bool loadTextures();
+    bool readSpeckFile();
+    bool readLabelFile();
+    bool loadCachedFile(const std::string& file);
+    bool saveCachedFile(const std::string& file) const;
+
+    bool _hasSpeckFile;
+    bool _dataIsDirty;
+    bool _textColorIsDirty;
+    bool _hasLabel;
+    bool _labelDataIsDirty;
+
+    int _textMinSize;
+    int _textMaxSize;
+    int _planeStartingIndexPos;
+    int _textureVariableIndex;
+
+    properties::FloatProperty _alphaValue;
+    properties::FloatProperty _scaleFactor;
+    properties::Vec4Property _textColor;
+    properties::FloatProperty _textSize;
+    properties::BoolProperty _drawElements;
+    properties::OptionProperty _blendMode;
+    properties::Vec2Property _fadeInDistance;
+    properties::BoolProperty _disableFadeInDistance;
+    properties::FloatProperty _planeMinSize;
+
+    // DEBUG:
+    properties::OptionProperty _renderOption;
+
+    ghoul::opengl::ProgramObject* _program;
+    UniformCache(modelViewProjectionTransform, alphaValue, scaleFactor, fadeInValue,
+        galaxyTexture) _uniformCache;
+    std::shared_ptr<ghoul::fontrendering::Font> _font;
+    std::unordered_map<int, std::unique_ptr<ghoul::opengl::Texture>> _textureMap;
+    std::unordered_map<int, std::string> _textureFileMap;
+
+    std::string _speckFile;
+    std::string _labelFile;
+    std::string _texturesPath;
+    std::string _luminosityVar;
+
+    Unit _unit;
+
+    std::vector<float> _fullData;
+    std::vector<std::pair<glm::vec3, std::string>> _labelData;
+    std::unordered_map<std::string, int> _variableDataPositionMap;
+
+    int _nValuesPerAstronomicalObject;
+
+    float _sluminosity;
+
+    glm::dmat4 _transformationMatrix;
+
+    std::vector<RenderingPlane> _renderingPlanesArray;
+};
 
 
 } // namespace openspace

--- a/modules/digitaluniverse/rendering/renderablepoints.cpp
+++ b/modules/digitaluniverse/rendering/renderablepoints.cpp
@@ -24,19 +24,18 @@
 
 #include <modules/digitaluniverse/rendering/renderablepoints.h>
 
+#include <modules/digitaluniverse/digitaluniversemodule.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/util/updatestructures.h>
 #include <openspace/engine/openspaceengine.h>
 #include <openspace/rendering/renderengine.h>
-
 #include <ghoul/filesystem/filesystem>
 #include <ghoul/misc/templatefactory.h>
 #include <ghoul/io/texture/texturereader.h>
 #include <ghoul/opengl/programobject.h>
 #include <ghoul/opengl/texture.h>
 #include <ghoul/opengl/textureunit.h>
-
 #include <array>
 #include <fstream>
 #include <stdint.h>
@@ -45,6 +44,7 @@
 
 namespace {
     constexpr const char* _loggerCat        = "RenderablePoints";
+
     constexpr const char* KeyFile           = "File";
     constexpr const char* keyColor          = "Color";
     constexpr const char* keyUnit           = "Unit";
@@ -266,12 +266,21 @@ void RenderablePoints::initialize() {
 }
 
 void RenderablePoints::initializeGL() {
-    RenderEngine& renderEngine = OsEng.renderEngine();
+    // OBS:  The ProgramObject name is later used to release the program as well, so the
+    //       name parameter to requestProgramObject and the first parameter to
+    //       buildRenderProgram has to be the same or an assertion will be thrown at the
+    //       end of the program.
+
     if (_hasSpriteTexture) {
-        _program = renderEngine.buildRenderProgram(
-            "RenderablePoints",
-            absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_vs.glsl"),
-            absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_sprite_fs.glsl")
+        _program = DigitalUniverseModule::ProgramObjectManager.requestProgramObject(
+            "RenderablePoints Sprite",
+            []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+                return OsEng.renderEngine().buildRenderProgram(
+                    "RenderablePoints Sprite",
+                    absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_vs.glsl"),
+                    absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_sprite_fs.glsl")
+                );
+            }
         );
 
         _uniformCache.modelViewProjectionTransform = _program->uniformLocation(
@@ -285,10 +294,15 @@ void RenderablePoints::initializeGL() {
         _uniformCache.hasColorMap = _program->uniformLocation("hasColorMap");
     }
     else {
-        _program = renderEngine.buildRenderProgram(
+        _program = DigitalUniverseModule::ProgramObjectManager.requestProgramObject(
             "RenderablePoints",
-            absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_vs.glsl"),
-            absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_fs.glsl")
+            []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+                return OsEng.renderEngine().buildRenderProgram(
+                    "RenderablePoints",
+                    absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_vs.glsl"),
+                    absPath("${MODULE_DIGITALUNIVERSE}/shaders/points_sprite_fs.glsl")
+                );
+            }
         );
 
         _uniformCache.modelViewProjectionTransform = _program->uniformLocation(
@@ -308,11 +322,13 @@ void RenderablePoints::deinitializeGL() {
     glDeleteVertexArrays(1, &_vao);
     _vao = 0;
 
-    RenderEngine& renderEngine = OsEng.renderEngine();
-    if (_program) {
-        renderEngine.removeRenderProgram(_program);
-        _program = nullptr;
-    }
+
+    DigitalUniverseModule::ProgramObjectManager.releaseProgramObject(
+        _program->name(),
+        [](ghoul::opengl::ProgramObject* p) {
+            OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
 
     if (_hasSpriteTexture) {
         _spriteTexture = nullptr;

--- a/modules/digitaluniverse/rendering/renderablepoints.h
+++ b/modules/digitaluniverse/rendering/renderablepoints.h
@@ -98,7 +98,7 @@ namespace openspace {
 
         std::unique_ptr<ghoul::opengl::Texture> _spriteTexture;
         std::unique_ptr<ghoul::filesystem::File> _spriteTextureFile;
-        std::unique_ptr<ghoul::opengl::ProgramObject> _program;
+        ghoul::opengl::ProgramObject* _program;
         UniformCache(modelViewProjectionTransform, color, sides, alphaValue, scaleFactor,
             spriteTexture, hasColorMap) _uniformCache;
 

--- a/modules/fieldlines/rendering/renderablefieldlines.cpp
+++ b/modules/fieldlines/rendering/renderablefieldlines.cpp
@@ -257,7 +257,7 @@ void RenderableFieldlines::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_program) {
-        renderEngine.removeRenderProgram(_program);
+        renderEngine.removeRenderProgram(_program.get());
         _program = nullptr;
     }
 }

--- a/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
+++ b/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
@@ -971,7 +971,7 @@ void RenderableFieldlinesSequence::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shaderProgram) {
-        renderEngine.removeRenderProgram(_shaderProgram);
+        renderEngine.removeRenderProgram(_shaderProgram.get());
         _shaderProgram = nullptr;
     }
 

--- a/modules/globebrowsing/rendering/layershadermanager.cpp
+++ b/modules/globebrowsing/rendering/layershadermanager.cpp
@@ -144,7 +144,7 @@ LayerShaderManager::LayerShaderManager(const std::string& shaderName,
 LayerShaderManager::~LayerShaderManager() {
     if (_programObject) {
         RenderEngine& renderEngine = OsEng.renderEngine();
-        renderEngine.removeRenderProgram(_programObject);
+        renderEngine.removeRenderProgram(_programObject.get());
         _programObject = nullptr;
     }
 }
@@ -230,7 +230,7 @@ void LayerShaderManager::recompileShaderProgram(
     }
 
     // Remove old program
-    OsEng.renderEngine().removeRenderProgram(_programObject);
+    OsEng.renderEngine().removeRenderProgram(_programObject.get());
 
     _programObject = OsEng.renderEngine().buildRenderProgram(
         _shaderName,

--- a/modules/iswa/rendering/iswacygnet.cpp
+++ b/modules/iswa/rendering/iswacygnet.cpp
@@ -240,7 +240,7 @@ void IswaCygnet::update(const UpdateData&) {
 bool IswaCygnet::destroyShader() {
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
     return true;

--- a/modules/space/rendering/renderableconstellationbounds.cpp
+++ b/modules/space/rendering/renderableconstellationbounds.cpp
@@ -229,7 +229,7 @@ void RenderableConstellationBounds::deinitializeGL() {
     _vao = 0;
 
     if (_program) {
-        OsEng.renderEngine().removeRenderProgram(_program);
+        OsEng.renderEngine().removeRenderProgram(_program.get());
         _program = nullptr;
     }
 }

--- a/modules/space/rendering/renderableplanet.cpp
+++ b/modules/space/rendering/renderableplanet.cpp
@@ -24,24 +24,22 @@
 
 #include <modules/space/rendering/renderableplanet.h>
 
+#include <modules/space/spacemodule.h>
+#include <modules/space/rendering/planetgeometry.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
-
-#include <modules/space/rendering/planetgeometry.h>
-#include <openspace/util/time.h>
-#include <openspace/util/spicemanager.h>
-#include <openspace/scene/scenegraphnode.h>
 #include <openspace/engine/openspaceengine.h>
 #include <openspace/rendering/renderengine.h>
-
+#include <openspace/scene/scenegraphnode.h>
+#include <openspace/util/time.h>
+#include <openspace/util/spicemanager.h>
 #include <ghoul/filesystem/filesystem.h>
-#include <ghoul/misc/assert.h>
 #include <ghoul/io/texture/texturereader.h>
+#include <ghoul/misc/assert.h>
+#include <ghoul/misc/invariants.h>
 #include <ghoul/opengl/programobject.h>
 #include <ghoul/opengl/texture.h>
 #include <ghoul/opengl/textureunit.h>
-#include <ghoul/misc/invariants.h>
-
 #include <memory>
 #include <fstream>
 
@@ -51,6 +49,11 @@
 #include <math.h>
 
 namespace {
+    constexpr const char* PlainProgramName = "PlanetProgram";
+    constexpr const char* ShadowNightProgramName = "ShadowNightPlanetProgram";
+    constexpr const char* NightProgramName = "NightPlanetProgram";
+    constexpr const char* ShadowProgramName = "ShadowPlanetProgram";
+
     constexpr const char* KeyGeometry     = "Geometry";
     constexpr const char* KeyRadius       = "Radius";
     constexpr const char* _loggerCat      = "RenderablePlanet";
@@ -333,38 +336,57 @@ RenderablePlanet::RenderablePlanet(const ghoul::Dictionary& dictionary)
 }
 
 void RenderablePlanet::initializeGL() {
-    RenderEngine& renderEngine = OsEng.renderEngine();
+    // @FRAGILE: The shader deinitialization below relies on the name names for the
+    //           request and the parameters to buildRenderProgram. That way, we can use
+    //           the ProgramObject name in the releaseProgramObject method and release the
+    //           correct one.
 
     if (_programObject == nullptr && _shadowEnabled && _hasNightTexture) {
-        // shadow program
-        _programObject = renderEngine.buildRenderProgram(
-            "shadowNightProgram",
-            absPath("${MODULE_SPACE}/shaders/shadow_nighttexture_vs.glsl"),
-            absPath("${MODULE_SPACE}/shaders/shadow_nighttexture_fs.glsl")
+        _programObject = SpaceModule::ProgramObjectManager.requestProgramObject(
+            ShadowNightProgramName,
+            []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+                return OsEng.renderEngine().buildRenderProgram(
+                    ShadowNightProgramName,
+                    absPath("${MODULE_SPACE}/shaders/shadow_nighttexture_vs.glsl"),
+                    absPath("${MODULE_SPACE}/shaders/shadow_nighttexture_fs.glsl")
+                );
+            }
         );
     }
     else if (_programObject == nullptr && _shadowEnabled) {
-        // shadow program
-        _programObject = renderEngine.buildRenderProgram(
-            "shadowProgram",
-            absPath("${MODULE_SPACE}/shaders/shadow_vs.glsl"),
-            absPath("${MODULE_SPACE}/shaders/shadow_fs.glsl")
+        _programObject = SpaceModule::ProgramObjectManager.requestProgramObject(
+            ShadowProgramName,
+            []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+                return OsEng.renderEngine().buildRenderProgram(
+                        ShadowProgramName,
+                        absPath("${MODULE_SPACE}/shaders/shadow_vs.glsl"),
+                        absPath("${MODULE_SPACE}/shaders/shadow_fs.glsl")
+                );
+            }
         );
     }
     else if (_programObject == nullptr && _hasNightTexture) {
-        // Night texture program
-        _programObject = renderEngine.buildRenderProgram(
-            "nightTextureProgram",
-            absPath("${MODULE_SPACE}/shaders/nighttexture_vs.glsl"),
-            absPath("${MODULE_SPACE}/shaders/nighttexture_fs.glsl")
+        _programObject = SpaceModule::ProgramObjectManager.requestProgramObject(
+            NightProgramName,
+            []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+                return OsEng.renderEngine().buildRenderProgram(
+                    NightProgramName,
+                    absPath("${MODULE_SPACE}/shaders/nighttexture_vs.glsl"),
+                    absPath("${MODULE_SPACE}/shaders/nighttexture_fs.glsl")
+                );
+            }
         );
     }
     else if (_programObject == nullptr) {
-        // pscstandard
-        _programObject = renderEngine.buildRenderProgram(
-            "pscstandard",
-            absPath("${MODULE_SPACE}/shaders/renderableplanet_vs.glsl"),
-            absPath("${MODULE_SPACE}/shaders/renderableplanet_fs.glsl")
+        _programObject = SpaceModule::ProgramObjectManager.requestProgramObject(
+            PlainProgramName,
+            []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+                return OsEng.renderEngine().buildRenderProgram(
+                    PlainProgramName,
+                    absPath("${MODULE_SPACE}/shaders/renderableplanet_vs.glsl"),
+                    absPath("${MODULE_SPACE}/shaders/renderableplanet_fs.glsl")
+                );
+            }
         );
     }
 
@@ -386,11 +408,12 @@ void RenderablePlanet::deinitializeGL() {
         _geometry = nullptr;
     }
 
-    RenderEngine& renderEngine = OsEng.renderEngine();
-    if (_programObject) {
-        renderEngine.removeRenderProgram(_programObject.get());
-        _programObject = nullptr;
-    }
+    SpaceModule::ProgramObjectManager.releaseProgramObject(
+        _programObject->name(),
+        [](ghoul::opengl::ProgramObject* p) {
+            OsEng.renderEngine().removeRenderProgram(p);
+        }
+    );
 
     _geometry = nullptr;
     _texture = nullptr;
@@ -463,7 +486,7 @@ void RenderablePlanet::render(const RenderData& data, RendererTasks&) {
 //    glm::mat4 ModelViewTrans = data.camera.viewMatrix() * scaleCamTrans *
 //        translateCamTrans * translateObjTrans * glm::mat4(modelTransform);
 
-    setPscUniforms(*_programObject.get(), data.camera, data.position);
+    setPscUniforms(*_programObject, data.camera, data.position);
 
     _programObject->setUniform("_performShading", _performShading);
     _programObject->setUniform("_hasHeightMap", _hasHeightTexture);

--- a/modules/space/rendering/renderableplanet.cpp
+++ b/modules/space/rendering/renderableplanet.cpp
@@ -388,7 +388,7 @@ void RenderablePlanet::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_programObject) {
-        renderEngine.removeRenderProgram(_programObject);
+        renderEngine.removeRenderProgram(_programObject.get());
         _programObject = nullptr;
     }
 

--- a/modules/space/rendering/renderableplanet.h
+++ b/modules/space/rendering/renderableplanet.h
@@ -94,7 +94,7 @@ private:
     properties::StringProperty _nightTexturePath;
     properties::StringProperty _heightMapTexturePath;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _programObject;
+    ghoul::opengl::ProgramObject* _programObject;
 
     std::unique_ptr<ghoul::opengl::Texture> _texture;
     std::unique_ptr<ghoul::opengl::Texture> _nightTexture;

--- a/modules/space/rendering/renderablerings.cpp
+++ b/modules/space/rendering/renderablerings.cpp
@@ -216,7 +216,7 @@ void RenderableRings::deinitializeGL() {
     _textureFile = nullptr;
     _texture = nullptr;
 
-    OsEng.renderEngine().removeRenderProgram(_shader);
+    OsEng.renderEngine().removeRenderProgram(_shader.get());
     _shader = nullptr;
 }
 

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -322,7 +322,7 @@ void RenderableStars::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_program) {
-        renderEngine.removeRenderProgram(_program);
+        renderEngine.removeRenderProgram(_program.get());
         _program = nullptr;
     }
 }

--- a/modules/space/spacemodule.cpp
+++ b/modules/space/spacemodule.cpp
@@ -45,6 +45,8 @@
 
 namespace openspace {
 
+ghoul::opengl::ProgramObjectManager SpaceModule::ProgramObjectManager;
+
 SpaceModule::SpaceModule() : OpenSpaceModule(Name) {}
 
 void SpaceModule::internalInitialize(const ghoul::Dictionary&) {

--- a/modules/space/spacemodule.cpp
+++ b/modules/space/spacemodule.cpp
@@ -82,6 +82,10 @@ void SpaceModule::internalInitialize(const ghoul::Dictionary&) {
     fGeometry->registerClass<planetgeometry::SimpleSphereGeometry>("SimpleSphere");
 }
 
+void SpaceModule::internalDeinitializeGL() {
+    ProgramObjectManager.releaseAll(ghoul::opengl::ProgramObjectManager::Warnings::Yes);
+}
+
 std::vector<documentation::Documentation> SpaceModule::documentations() const {
     return {
         RenderableConstellationBounds::Documentation(),

--- a/modules/space/spacemodule.h
+++ b/modules/space/spacemodule.h
@@ -27,6 +27,8 @@
 
 #include <openspace/util/openspacemodule.h>
 
+#include <ghoul/opengl/programobjectmanager.h>
+
 namespace openspace {
 
 class SpaceModule : public OpenSpaceModule {
@@ -36,6 +38,8 @@ public:
     SpaceModule();
     virtual ~SpaceModule() = default;
     std::vector<documentation::Documentation> documentations() const override;
+
+    static ghoul::opengl::ProgramObjectManager ProgramObjectManager;
 
 private:
     void internalInitialize(const ghoul::Dictionary&) override;

--- a/modules/space/spacemodule.h
+++ b/modules/space/spacemodule.h
@@ -43,6 +43,7 @@ public:
 
 private:
     void internalInitialize(const ghoul::Dictionary&) override;
+    void internalDeinitializeGL() override;
 };
 
 } // namespace openspace

--- a/modules/spacecraftinstruments/rendering/renderablecrawlingline.cpp
+++ b/modules/spacecraftinstruments/rendering/renderablecrawlingline.cpp
@@ -175,7 +175,7 @@ void RenderableCrawlingLine::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_program) {
-        renderEngine.removeRenderProgram(_program);
+        renderEngine.removeRenderProgram(_program.get());
         _program = nullptr;
     }
 }

--- a/modules/spacecraftinstruments/rendering/renderablefov.cpp
+++ b/modules/spacecraftinstruments/rendering/renderablefov.cpp
@@ -478,7 +478,7 @@ void RenderableFov::initializeGL() {
 }
 
 void RenderableFov::deinitializeGL() {
-    OsEng.renderEngine().removeRenderProgram(_programObject);
+    OsEng.renderEngine().removeRenderProgram(_programObject.get());
     _programObject = nullptr;
 
     glDeleteBuffers(1, &_orthogonalPlane.vbo);

--- a/modules/spacecraftinstruments/rendering/renderablefov.h
+++ b/modules/spacecraftinstruments/rendering/renderablefov.h
@@ -92,7 +92,7 @@ private:
     properties::FloatProperty _lineWidth;
     properties::BoolProperty _drawSolid;
     properties::DoubleProperty _standOffDistance;
-    std::unique_ptr<ghoul::opengl::ProgramObject> _programObject;
+    ghoul::opengl::ProgramObject* _programObject;
     UniformCache(modelViewProjection, defaultColorStart, defaultColorEnd, activeColor,
         targetInFieldOfViewColor, intersectionStartColor, intersectionEndColor,
         squareColor, interpolation) _uniformCache;

--- a/modules/spacecraftinstruments/rendering/renderablemodelprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderablemodelprojection.cpp
@@ -261,7 +261,7 @@ void RenderableModelProjection::deinitializeGL() {
 
     _projectionComponent.deinitialize();
 
-    OsEng.renderEngine().removeRenderProgram(_programObject);
+    OsEng.renderEngine().removeRenderProgram(_programObject.get());
     _programObject = nullptr;
 }
 

--- a/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
@@ -111,7 +111,7 @@ void RenderablePlaneProjection::initializeGL() {
 void RenderablePlaneProjection::deinitializeGL() {
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 

--- a/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
@@ -427,7 +427,7 @@ void RenderablePlanetProjection::deinitializeGL() {
     glDeleteVertexArrays(1, &_quad);
     glDeleteBuffers(1, &_vertexPositionBuffer);
 
-    OsEng.renderEngine().removeRenderProgram(_programObject);
+    OsEng.renderEngine().removeRenderProgram(_programObject.get());
     _programObject = nullptr;
 
     _fboProgramObject = nullptr;

--- a/modules/spacecraftinstruments/rendering/renderableplanetprojection.h
+++ b/modules/spacecraftinstruments/rendering/renderableplanetprojection.h
@@ -76,8 +76,8 @@ private:
     properties::StringProperty _addHeightMapTexturePath;
     bool _heightMapTextureDirty;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _programObject;
-    std::unique_ptr<ghoul::opengl::ProgramObject> _fboProgramObject;
+    ghoul::opengl::ProgramObject* _programObject;
+    ghoul::opengl::ProgramObject* _fboProgramObject;
     UniformCache(sunPos, modelTransform, modelViewProjectionTransform, hasBaseMap,
         hasHeightMap, heightExaggeration, meridianShift, ambientBrightness,
         projectionFading, baseTexture, projectionTexture, heightTexture)

--- a/modules/spacecraftinstruments/rendering/renderableshadowcylinder.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableshadowcylinder.cpp
@@ -283,7 +283,7 @@ void RenderableShadowCylinder::initializeGL() {
 void RenderableShadowCylinder::deinitializeGL() {
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 

--- a/modules/spacecraftinstruments/rendering/renderableshadowcylinder.h
+++ b/modules/spacecraftinstruments/rendering/renderableshadowcylinder.h
@@ -78,7 +78,7 @@ private:
     properties::StringProperty _bodyFrame;
     properties::OptionProperty _aberration;
 
-    std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
+    ghoul::opengl::ProgramObject* _shader;
     UniformCache(modelViewProjectionTransform, shadowColor) _uniformCache;
 
     glm::dmat3 _stateMatrix;

--- a/modules/spacecraftinstruments/spacecraftinstrumentsmodule.cpp
+++ b/modules/spacecraftinstruments/spacecraftinstrumentsmodule.cpp
@@ -45,6 +45,8 @@
 
 namespace openspace {
 
+ghoul::opengl::ProgramObjectManager SpacecraftInstrumentsModule::ProgramObjectManager;
+
 SpacecraftInstrumentsModule::SpacecraftInstrumentsModule() : OpenSpaceModule(Name) {}
 
 void SpacecraftInstrumentsModule::internalInitialize(const ghoul::Dictionary&) {

--- a/modules/spacecraftinstruments/spacecraftinstrumentsmodule.cpp
+++ b/modules/spacecraftinstruments/spacecraftinstrumentsmodule.cpp
@@ -81,6 +81,10 @@ void SpacecraftInstrumentsModule::internalDeinitialize() {
     ImageSequencer::deinitialize();
 }
 
+void SpacecraftInstrumentsModule::internalDeinitializeGL() {
+    ProgramObjectManager.releaseAll(ghoul::opengl::ProgramObjectManager::Warnings::Yes);
+}
+
 std::vector<documentation::Documentation>
 SpacecraftInstrumentsModule::documentations() const
 {

--- a/modules/spacecraftinstruments/spacecraftinstrumentsmodule.h
+++ b/modules/spacecraftinstruments/spacecraftinstrumentsmodule.h
@@ -27,6 +27,8 @@
 
 #include <openspace/util/openspacemodule.h>
 
+#include <ghoul/opengl/programobjectmanager.h>
+
 namespace openspace {
 
 class SpacecraftInstrumentsModule : public OpenSpaceModule {
@@ -36,6 +38,8 @@ public:
     SpacecraftInstrumentsModule();
 
     std::vector<documentation::Documentation> documentations() const override;
+
+    static ghoul::opengl::ProgramObjectManager ProgramObjectManager;
 
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;

--- a/modules/spacecraftinstruments/spacecraftinstrumentsmodule.h
+++ b/modules/spacecraftinstruments/spacecraftinstrumentsmodule.h
@@ -44,6 +44,7 @@ public:
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;
     void internalDeinitialize() override;
+    void internalDeinitializeGL() override;
 };
 
 } // namespace openspace

--- a/modules/touch/src/touchmarker.cpp
+++ b/modules/touch/src/touchmarker.cpp
@@ -114,7 +114,7 @@ void TouchMarker::deinitialize() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 }

--- a/src/engine/moduleengine.cpp
+++ b/src/engine/moduleengine.cpp
@@ -53,14 +53,33 @@ void ModuleEngine::initialize(const ghoul::Dictionary& moduleConfigurations) {
     }
 }
 
+void ModuleEngine::initializeGL() {
+    LDEBUG("Initializing OpenGL of modules");
+    for (std::unique_ptr<OpenSpaceModule>& m : _modules) {
+        LDEBUG("Initializing OpenGL of module '" << m->name() << "'");
+        m->initializeGL();
+    }
+    LDEBUG("Finished initializing OpenGL of modules");
+}
+
 void ModuleEngine::deinitialize() {
     LDEBUG("Deinitializing modules");
-    for (auto& m : _modules) {
+    for (std::unique_ptr<OpenSpaceModule>& m : _modules) {
         LDEBUG("Deinitializing module '" << m->name() << "'");
         m->deinitialize();
     }
     _modules.clear();
-    LDEBUG("Finished destroying modules");
+    LDEBUG("Finished deinitializing modules");
+}
+
+void ModuleEngine::deinitializeGL() {
+    LDEBUG("Deinitializing OpenGL of modules");
+    for (std::unique_ptr<OpenSpaceModule>& m : _modules) {
+        LDEBUG("Deinitializing OpenGL of module '" << m->name() << "'");
+        m->deinitializeGL();
+
+    }
+    LDEBUG("Finished deinitializing OpenGL of modules");
 }
 
 void ModuleEngine::registerModule(std::unique_ptr<OpenSpaceModule> m,

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -455,6 +455,7 @@ void OpenSpaceEngine::destroy() {
 
     _engine->_renderEngine->deinitializeGL();
 
+    _engine->_moduleEngine->deinitializeGL();
     _engine->_moduleEngine->deinitialize();
     _engine->_console->deinitialize();
 
@@ -1208,6 +1209,8 @@ void OpenSpaceEngine::initializeGL() {
 
     LDEBUG("Initializing Rendering Engine");
     _renderEngine->initializeGL();
+
+    _moduleEngine->initializeGL();
 
     for (const auto& func : _moduleCallbacks.initializeGL) {
         func();

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -817,6 +817,10 @@ std::unique_ptr<ghoul::opengl::ProgramObject> RenderEngine::buildRenderProgram(
 void RenderEngine::removeRenderProgram(
     const std::unique_ptr<ghoul::opengl::ProgramObject>& program)
 {
+    removeRenderProgram(program.get());
+}
+
+void RenderEngine::removeRenderProgram(ghoul::opengl::ProgramObject* program) {
     if (!program) {
         return;
     }
@@ -824,7 +828,7 @@ void RenderEngine::removeRenderProgram(
     auto it = std::find(
         _programs.begin(),
         _programs.end(),
-        program.get()
+        program
     );
 
     if (it != _programs.end()) {

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -814,12 +814,6 @@ std::unique_ptr<ghoul::opengl::ProgramObject> RenderEngine::buildRenderProgram(
     return program;
 }
 
-void RenderEngine::removeRenderProgram(
-    const std::unique_ptr<ghoul::opengl::ProgramObject>& program)
-{
-    removeRenderProgram(program.get());
-}
-
 void RenderEngine::removeRenderProgram(ghoul::opengl::ProgramObject* program) {
     if (!program) {
         return;

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -759,7 +759,6 @@ std::unique_ptr<ghoul::opengl::ProgramObject> RenderEngine::buildRenderProgram(
     std::string name, std::string vsPath,
     std::string fsPath, const ghoul::Dictionary& data)
 {
-
     ghoul::Dictionary dict = data;
 
     // set path to the current renderer's main fragment shader

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -331,7 +331,7 @@ bool ScreenSpaceRenderable::deinitializeGL() {
 
     RenderEngine& renderEngine = OsEng.renderEngine();
     if (_shader) {
-        renderEngine.removeRenderProgram(_shader);
+        renderEngine.removeRenderProgram(_shader.get());
         _shader = nullptr;
     }
 

--- a/src/util/openspacemodule.cpp
+++ b/src/util/openspacemodule.cpp
@@ -70,8 +70,16 @@ void OpenSpaceModule::initialize(const ModuleEngine* moduleEngine,
     internalInitialize(configuration);
 }
 
+void OpenSpaceModule::initializeGL() {
+    internalInitializeGL();
+}
+
 void OpenSpaceModule::deinitialize() {
     internalDeinitialize();
+}
+
+void OpenSpaceModule::deinitializeGL() {
+    internalDeinitializeGL();
 }
 
 std::vector<documentation::Documentation> OpenSpaceModule::documentations() const {
@@ -125,6 +133,10 @@ const ModuleEngine* OpenSpaceModule::moduleEngine() const {
 
 void OpenSpaceModule::internalInitialize(const ghoul::Dictionary&) {}
 
+void OpenSpaceModule::internalInitializeGL() {}
+
 void OpenSpaceModule::internalDeinitialize() {}
+
+void OpenSpaceModule::internalDeinitializeGL() {}
 
 } // namespace openspace


### PR DESCRIPTION
Introduce ProgramObjectManager static variable to some OpenSpaceModule classes to handle reusing ProgramObjects between multiple instances of the same Renderable, drastically reducing startup time due to reducing shader compilation times (about 200+ shaders less compiled on default_full,  saving about 10-15 seconds startup time on default).

ProgramObjects are indexed by unique name which is a anonymous namespace variable for each Renderable; ProgramObjectManager keeps a reference count of the program objects and deletes them when the last Renderable loses interest in them.

Considerations:
1. Using static ghoul::opengl::Program* wasn't feasible as it would require a second variable to keep the reference count and make the code messy
2. std::shared_ptr wasn't an issue as code was getting messy to make sure that the ProgramObject would be deleted at the correct time when there was still an OpenGL context available

