### PR TITLE
Fix crash caused by setting properties using regex

### DIFF
--- a/include/openspace/properties/numericalproperty.h
+++ b/include/openspace/properties/numericalproperty.h
@@ -42,7 +42,7 @@ public:
         T maximumValue, T steppingValue, float exponent);
 
     bool getLuaValue(lua_State* state) const override;
-    bool setLuaValue(lua_State* state) override;
+    bool setLuaValue(lua_State* state, bool leaveOnStack = false) override;
     int typeLua() const override;
 
     bool getStringValue(std::string& value) const override;
@@ -68,7 +68,7 @@ public:
 
 
     void setInterpolationTarget(ghoul::any value) override;
-    void setLuaInterpolationTarget(lua_State* state) override;
+    void setLuaInterpolationTarget(lua_State* state, bool leaveOnStack = false) override;
     void setStringInterpolationTarget(std::string value) override;
     
     void interpolateValue(float t,

--- a/include/openspace/properties/numericalproperty.inl
+++ b/include/openspace/properties/numericalproperty.inl
@@ -54,10 +54,12 @@ namespace openspace::properties {
     template <>                                                                          \
     template <>                                                                          \
     TYPE PropertyDelegate<TemplateProperty<TYPE>>::fromLuaValue(lua_State* state,        \
+                                                                bool leaveOnStack,       \
                                                                 bool& success);          \
     template <>                                                                          \
     template <>                                                                          \
     TYPE PropertyDelegate<NumericalProperty<TYPE>>::fromLuaValue(lua_State* state,       \
+                                                                 bool leaveOnStack,      \
                                                                  bool& success);         \
     template <>                                                                          \
     template <>                                                                          \
@@ -142,18 +144,20 @@ namespace openspace::properties {
     template <>                                                                          \
     template <>                                                                          \
     TYPE PropertyDelegate<TemplateProperty<TYPE>>::fromLuaValue<TYPE>(lua_State* lua,    \
+                                                                      bool leaveOnStack, \
                                                                       bool& successful)  \
     {                                                                                    \
-        return FROM_LUA_LAMBDA_EXPRESSION(lua, successful);                              \
+        return FROM_LUA_LAMBDA_EXPRESSION(lua, leaveOnStack, successful);                \
     }                                                                                    \
                                                                                          \
     template <>                                                                          \
     template <>                                                                          \
     TYPE PropertyDelegate<NumericalProperty<TYPE>>::fromLuaValue<TYPE>(lua_State* lua,   \
+                                                                       bool leaveOnStack,\
                                                                        bool& successful) \
     {                                                                                    \
         return PropertyDelegate<TemplateProperty<TYPE>>::fromLuaValue<TYPE>(             \
-          lua, successful);                                                              \
+          lua, leaveOnStack, successful);                                                \
     }                                                                                    \
                                                                                          \
     template <>                                                                          \
@@ -303,10 +307,10 @@ std::string NumericalProperty<T>::className() const {
 }
 
 template <typename T>
-bool NumericalProperty<T>::setLuaValue(lua_State* state) {
+bool NumericalProperty<T>::setLuaValue(lua_State* state, bool leaveOnStack) {
     bool success = false;
     T value = PropertyDelegate<NumericalProperty<T>>::template fromLuaValue<T>(
-        state, success
+        state, leaveOnStack, success
     );
     if (success)
         TemplateProperty<T>::setValue(std::move(value));
@@ -435,10 +439,12 @@ void NumericalProperty<T>::setInterpolationTarget(ghoul::any value) {
 }
 
 template <typename T>
-void NumericalProperty<T>::setLuaInterpolationTarget(lua_State* state) {
+void NumericalProperty<T>::setLuaInterpolationTarget(lua_State* state, bool leaveOnStack)
+{
     bool success = false;
     T thisValue = PropertyDelegate<NumericalProperty<T>>::template fromLuaValue<T>(
         state,
+        leaveOnStack,
         success
     );
     if (success) {

--- a/include/openspace/properties/property.h
+++ b/include/openspace/properties/property.h
@@ -176,7 +176,7 @@ public:
      * \return <code>true</code> if the decoding and setting of the value succeeded,
      * <code>false</code> otherwise
      */
-    virtual bool setLuaValue(lua_State* state);
+    virtual bool setLuaValue(lua_State* state, bool leaveOnStack = false);
 
     /**
      * Returns the Lua type that will be put onto the stack in the Property::getLua method
@@ -410,7 +410,7 @@ public:
 
     /// Interpolation methods
     virtual void setInterpolationTarget(ghoul::any value);
-    virtual void setLuaInterpolationTarget(lua_State* state);
+    virtual void setLuaInterpolationTarget(lua_State* state, bool leaveOnStack = false);
     virtual void setStringInterpolationTarget(std::string value);
     
     virtual void interpolateValue(float t,

--- a/include/openspace/properties/propertydelegate.h
+++ b/include/openspace/properties/propertydelegate.h
@@ -111,6 +111,8 @@ public:
      * implementation will lead to a compile-time error if the class method is not
      * specialized.
      * \param state The Lua state from which the value is retrieved
+     * \param leaveOnStack If true, the values will be left on the lua stack.
+     * If false, the value will be popped.
      * \param success Will be <code>true</code> if the conversion succeeded;
      * <code>false</code> otherwise
      * \return The value that was created by converting the top value from the stack
@@ -118,7 +120,7 @@ public:
      * <code>T = TemplateProperty<std::string></code>, then <code>U = std::string</code>
      */
     template <typename U>
-    static U fromLuaValue(lua_State* state, bool& success);
+    static U fromLuaValue(lua_State* state, bool leaveOnStack, bool& success);
 
     /**
      * This method converts the passed <code>value</code>, encodes it and places it on the

--- a/include/openspace/properties/propertydelegate.inl
+++ b/include/openspace/properties/propertydelegate.inl
@@ -63,7 +63,7 @@ U PropertyDelegate<T>::defaultSteppingValue() {
 
 template <typename T>
 template <typename U>
-U PropertyDelegate<T>::fromLuaValue(lua_State*, bool&) {
+U PropertyDelegate<T>::fromLuaValue(lua_State*, bool, bool&) {
     static_assert(sizeof(T) == 0,
         "Unimplemented PropertyDelegate::fromLuaValue specialization");
 }

--- a/include/openspace/properties/selectionproperty.h
+++ b/include/openspace/properties/selectionproperty.h
@@ -64,7 +64,7 @@ std::string PropertyDelegate<TemplateProperty<std::vector<int>>>::className();
 template <>
 template <>
 std::vector<int> PropertyDelegate<TemplateProperty<std::vector<int>>>::fromLuaValue(
-    lua_State* state, bool& success);
+    lua_State* state, bool leaveOnStack, bool& success);
 
 template <>
 template <>

--- a/include/openspace/properties/templateproperty.h
+++ b/include/openspace/properties/templateproperty.h
@@ -113,9 +113,10 @@ public:
      * parameter <code>T</code> as argument. If the decoding is successful, the new value
      * is set, otherwise it remains unchanged.
      * \param state The Lua state from which the value will be decoded
+     * \param leaveOnStack If true, the value will be left on the lua stack
      * \return <code>true</code> if the decoding succeeded; <code>false</code> otherwise
      */
-    bool setLuaValue(lua_State* state) override;
+    bool setLuaValue(lua_State* state, bool leaveOnStack = false) override;
 
     /// \see Property::typeLua
     int typeLua() const override;

--- a/include/openspace/properties/templateproperty.inl
+++ b/include/openspace/properties/templateproperty.inl
@@ -50,6 +50,7 @@ namespace openspace::properties {
     template <>                                                                          \
     template <>                                                                          \
     TYPE PropertyDelegate<TemplateProperty<TYPE>>::fromLuaValue(lua_State* state,        \
+                                                                bool leaveOnStack,       \
                                                                 bool& success);          \
                                                                                          \
     template <>                                                                          \
@@ -107,9 +108,10 @@ namespace openspace::properties {
     template <>                                                                          \
     template <>                                                                          \
     TYPE PropertyDelegate<TemplateProperty<TYPE>>::fromLuaValue<TYPE>(lua_State* l,      \
+                                                                      bool leaveOnStack, \
                                                                       bool& successful)  \
     {                                                                                    \
-        return FROM_LUA_LAMBDA_EXPRESSION(l, successful);                                \
+        return FROM_LUA_LAMBDA_EXPRESSION(l, leaveOnStack, successful);                  \
     }                                                                                    \
                                                                                          \
     template <>                                                                          \
@@ -229,10 +231,11 @@ bool TemplateProperty<T>::getLuaValue(lua_State* state) const {
 }
 
 template <typename T>
-bool TemplateProperty<T>::setLuaValue(lua_State* state) {
+bool TemplateProperty<T>::setLuaValue(lua_State* state, bool leaveOnStack) {
     bool success = false;
     T thisValue = PropertyDelegate<TemplateProperty<T>>::template fromLuaValue<T>(
         state,
+        leaveOnStack,
         success
     );
     if (success) {

--- a/include/openspace/properties/triggerproperty.h
+++ b/include/openspace/properties/triggerproperty.h
@@ -57,7 +57,7 @@ public:
      * \param state The unused Lua state
      * \return Returns always <code>true</code>
      */
-    bool setLuaValue(lua_State* state) override;
+    bool setLuaValue(lua_State* state, bool leaveOnStack = false) override;
 
     /**
      * Silently ignores any value that is passed into this function and will trigger the

--- a/src/properties/binaryproperty.cpp
+++ b/src/properties/binaryproperty.cpp
@@ -32,7 +32,7 @@ REGISTER_TEMPLATEPROPERTY_SOURCE(
     BinaryProperty,
     std::vector<char>,
     std::vector<char>(0),
-    [](lua_State* state, bool& success) -> std::vector<char> {
+    [](lua_State* state, bool leaveOnStack, bool& success) -> std::vector<char> {
         // TODO: Convert from lua
         std::vector<char> result;
         success = true;

--- a/src/properties/matrix/dmat2property.cpp
+++ b/src/properties/matrix/dmat2property.cpp
@@ -32,7 +32,8 @@
 
 namespace {
 
-glm::dmat2x2 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat2x2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success)
+{
     glm::dmat2x2 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +56,7 @@ glm::dmat2x2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat2x3property.cpp
+++ b/src/properties/matrix/dmat2x3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat2x3 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat2x3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat2x3 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::dmat2x3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat2x4property.cpp
+++ b/src/properties/matrix/dmat2x4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat2x4 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat2x4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat2x4 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::dmat2x4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat3property.cpp
+++ b/src/properties/matrix/dmat3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat3x3 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat3x3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat3x3 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::dmat3x3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat3x2property.cpp
+++ b/src/properties/matrix/dmat3x2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat3x2 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat3x2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat3x2 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::dmat3x2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat3x4property.cpp
+++ b/src/properties/matrix/dmat3x4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat3x4 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat3x4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat3x4 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::dmat3x4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat4property.cpp
+++ b/src/properties/matrix/dmat4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat4x4 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat4x4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat4x4 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::dmat4x4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat4x2property.cpp
+++ b/src/properties/matrix/dmat4x2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat4x2 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat4x2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat4x2 result;
     lua_pushnil(state);
     int number = 1;
@@ -56,7 +56,7 @@ glm::dmat4x2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/dmat4x3property.cpp
+++ b/src/properties/matrix/dmat4x3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dmat4x3 fromLuaConversion(lua_State* state, bool& success) {
+glm::dmat4x3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dmat4x3 result;
     lua_pushnil(state);
     int number = 1;
@@ -54,7 +54,7 @@ glm::dmat4x3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat2property.cpp
+++ b/src/properties/matrix/mat2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat2x2 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat2x2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat2x2 result;
     lua_pushnil(state);
     int number = 1;
@@ -56,7 +56,7 @@ glm::mat2x2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat2x3property.cpp
+++ b/src/properties/matrix/mat2x3property.cpp
@@ -34,7 +34,7 @@ using std::numeric_limits;
 
 namespace {
 
-glm::mat2x3 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat2x3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat2x3 result;
     lua_pushnil(state);
     int number = 1;
@@ -58,7 +58,7 @@ glm::mat2x3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat2x4property.cpp
+++ b/src/properties/matrix/mat2x4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat2x4 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat2x4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat2x4 result;
     lua_pushnil(state);
     int number = 1;
@@ -56,7 +56,7 @@ glm::mat2x4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat3property.cpp
+++ b/src/properties/matrix/mat3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat3x3 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat3x3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat3x3 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::mat3x3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat3x2property.cpp
+++ b/src/properties/matrix/mat3x2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat3x2 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat3x2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat3x2 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::mat3x2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat3x4property.cpp
+++ b/src/properties/matrix/mat3x4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat3x4 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat3x4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat3x4 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::mat3x4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat4property.cpp
+++ b/src/properties/matrix/mat4property.cpp
@@ -34,7 +34,7 @@ using std::numeric_limits;
 
 namespace {
 
-glm::mat4x4 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat4x4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat4x4 result;
     lua_pushnil(state);
     int number = 1;
@@ -57,7 +57,7 @@ glm::mat4x4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat4x2property.cpp
+++ b/src/properties/matrix/mat4x2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat4x2 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat4x2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat4x2 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::mat4x2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/matrix/mat4x3property.cpp
+++ b/src/properties/matrix/mat4x3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::mat4x3 fromLuaConversion(lua_State* state, bool& success) {
+glm::mat4x3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::mat4x3 result;
     lua_pushnil(state);
     int number = 1;
@@ -55,7 +55,7 @@ glm::mat4x3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/property.cpp
+++ b/src/properties/property.cpp
@@ -107,7 +107,7 @@ bool Property::getLuaValue(lua_State*) const {
 
 void Property::set(ghoul::any) {}
 
-bool Property::setLuaValue(lua_State*) {
+bool Property::setLuaValue(lua_State*, bool) {
     return false;
 }
 
@@ -318,7 +318,7 @@ std::string Property::generateAdditionalJsonDescription() const {
 }
 
 void Property::setInterpolationTarget(ghoul::any) {}
-void Property::setLuaInterpolationTarget(lua_State*) {}
+void Property::setLuaInterpolationTarget(lua_State*, bool) {}
 void Property::setStringInterpolationTarget(std::string) {}
 void Property::interpolateValue(float, ghoul::EasingFunc<float>) {}
 

--- a/src/properties/scalar/boolproperty.cpp
+++ b/src/properties/scalar/boolproperty.cpp
@@ -31,10 +31,12 @@
 
 namespace {
 
-bool fromLuaConversion(lua_State* state, bool& success) {
+bool fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isboolean(state, -1) == 1);
     if (success) {
-        return lua_toboolean(state, -1) == 1;
+        bool b = lua_toboolean(state, -1) == 1;
+        lua_pop(state, leaveOnStack ? 0 : 1);
+        return b;
     }
     else {
         return false;

--- a/src/properties/scalar/charproperty.cpp
+++ b/src/properties/scalar/charproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-char fromLuaConversion(lua_State* state, bool& success) {
+char fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         char val = static_cast<char>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/doubleproperty.cpp
+++ b/src/properties/scalar/doubleproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-double fromLuaConversion(lua_State* state, bool& success) {
+double fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         double val = lua_tonumber(state, -1);
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/floatproperty.cpp
+++ b/src/properties/scalar/floatproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-float fromLuaConversion(lua_State* state, bool& success) {
+float fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         float val = static_cast<float>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/intproperty.cpp
+++ b/src/properties/scalar/intproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-int fromLuaConversion(lua_State* state, bool& success) {
+int fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         int val = static_cast<int>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/longdoubleproperty.cpp
+++ b/src/properties/scalar/longdoubleproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-long double fromLuaConversion(lua_State* state, bool& success) {
+long double fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         long double val = static_cast<long double>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/longlongproperty.cpp
+++ b/src/properties/scalar/longlongproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-long long fromLuaConversion(lua_State* state, bool& success) {
+long long fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         long long val = static_cast<long long>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/longproperty.cpp
+++ b/src/properties/scalar/longproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-long fromLuaConversion(lua_State* state, bool& success) {
+long fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         long val = static_cast<long>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/shortproperty.cpp
+++ b/src/properties/scalar/shortproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-short fromLuaConversion(lua_State* state, bool& success) {
+short fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         short val = static_cast<short>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/signedcharproperty.cpp
+++ b/src/properties/scalar/signedcharproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-signed char fromLuaConversion(lua_State* state, bool& success) {
+signed char fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         signed char val = static_cast<signed char>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/ucharproperty.cpp
+++ b/src/properties/scalar/ucharproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-unsigned char fromLuaConversion(lua_State* state, bool& success) {
+unsigned char fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         unsigned char val = static_cast<unsigned char>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/uintproperty.cpp
+++ b/src/properties/scalar/uintproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-unsigned int fromLuaConversion(lua_State* state, bool& success) {
+unsigned int fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         unsigned int val = static_cast<unsigned int>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/ulonglongproperty.cpp
+++ b/src/properties/scalar/ulonglongproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-unsigned long long fromLuaConversion(lua_State* state, bool& success) {
+unsigned long long fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         unsigned long long val = static_cast<unsigned long long>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/ulongproperty.cpp
+++ b/src/properties/scalar/ulongproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-unsigned long fromLuaConversion(lua_State* state, bool& success) {
+unsigned long fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         unsigned long val = static_cast<unsigned long>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/scalar/ushortproperty.cpp
+++ b/src/properties/scalar/ushortproperty.cpp
@@ -31,11 +31,11 @@
 
 namespace {
 
-unsigned short fromLuaConversion(lua_State* state, bool& success) {
+unsigned short fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = (lua_isnumber(state, -1) == 1);
     if (success) {
         unsigned short val = static_cast<unsigned short>(lua_tonumber(state, -1));
-        lua_pop(state, 1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
         return val;
     }
     else {

--- a/src/properties/selectionproperty.cpp
+++ b/src/properties/selectionproperty.cpp
@@ -73,7 +73,7 @@ std::string PropertyDelegate<TemplateProperty<std::vector<int>>>::className() {
 template <>
 template <>
 std::vector<int> PropertyDelegate<TemplateProperty<std::vector<int>>>::fromLuaValue(
-                                                          lua_State* state, bool& success)
+                                       lua_State* state, bool leaveOnStack, bool& success)
 {
     static const int KEY = -2;
     static const int VAL = -1;
@@ -100,7 +100,9 @@ std::vector<int> PropertyDelegate<TemplateProperty<std::vector<int>>>::fromLuaVa
         lua_pop(state, 1);
     }
 
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
+
     return result;
 }
 

--- a/src/properties/stringlistproperty.cpp
+++ b/src/properties/stringlistproperty.cpp
@@ -31,7 +31,9 @@
 
 namespace {
 
-std::vector<std::string> fromLuaConversion(lua_State* state, bool& success) {
+std::vector<std::string> fromLuaConversion(
+                                       lua_State* state, bool leaveOnStack, bool& success)
+{
     if (!lua_istable(state, -1)) {
         success = false;
         return {};
@@ -49,6 +51,9 @@ std::vector<std::string> fromLuaConversion(lua_State* state, bool& success) {
         }
         lua_pop(state, 1);
     }
+
+    lua_pop(state, leaveOnStack ? 1 : 2);
+
     success = true;
     return result;
 }

--- a/src/properties/stringproperty.cpp
+++ b/src/properties/stringproperty.cpp
@@ -28,10 +28,12 @@
 
 namespace {
 
-std::string fromLuaConversion(lua_State* state, bool& success) {
+std::string fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     success = lua_isstring(state, -1) == 1;
     if (success) {
-        return lua_tostring(state, -1);
+        std::string s = lua_tostring(state, -1);
+        lua_pop(state, leaveOnStack ? 0 : 1);
+        return s;
     }
     else {
         return "";

--- a/src/properties/triggerproperty.cpp
+++ b/src/properties/triggerproperty.cpp
@@ -34,7 +34,7 @@ std::string TriggerProperty::className() const {
     return "TriggerProperty";
 }
 
-bool TriggerProperty::setLuaValue(lua_State*) {
+bool TriggerProperty::setLuaValue(lua_State*, bool) {
     notifyChangeListeners();
     return true;
 }

--- a/src/properties/vector/bvec2property.cpp
+++ b/src/properties/vector/bvec2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::bvec2 fromLuaConversion(lua_State* state, bool& success) {
+glm::bvec2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::bvec2 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::bvec2>::value; ++i) {
@@ -51,6 +51,8 @@ glm::bvec2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     success = true;
+    lua_pop(state, leaveOnStack ? 1 : 2);
+
     return result;
 }
 

--- a/src/properties/vector/bvec3property.cpp
+++ b/src/properties/vector/bvec3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::bvec3 fromLuaConversion(lua_State* state, bool& success) {
+glm::bvec3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::bvec3 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::bvec3>::value; ++i) {
@@ -51,6 +51,8 @@ glm::bvec3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     success = true;
+    lua_pop(state, leaveOnStack ? 1 : 2);
+
     return result;
 }
 

--- a/src/properties/vector/bvec4property.cpp
+++ b/src/properties/vector/bvec4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::bvec4 fromLuaConversion(lua_State* state, bool& success) {
+glm::bvec4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::bvec4 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::bvec4>::value; ++i) {
@@ -51,6 +51,8 @@ glm::bvec4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     success = true;
+    lua_pop(state, leaveOnStack ? 1 : 2);
+
     return result;
 }
 

--- a/src/properties/vector/dvec2property.cpp
+++ b/src/properties/vector/dvec2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dvec2 fromLuaConversion(lua_State* state, bool& success) {
+glm::dvec2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dvec2 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::dvec2>::value; ++i) {
@@ -51,7 +51,7 @@ glm::dvec2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/dvec3property.cpp
+++ b/src/properties/vector/dvec3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dvec3 fromLuaConversion(lua_State* state, bool& success) {
+glm::dvec3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dvec3 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::dvec3>::value; ++i) {
@@ -51,7 +51,7 @@ glm::dvec3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/dvec4property.cpp
+++ b/src/properties/vector/dvec4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::dvec4 fromLuaConversion(lua_State* state, bool& success) {
+glm::dvec4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::dvec4 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::dvec4>::value; ++i) {
@@ -51,7 +51,7 @@ glm::dvec4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/ivec2property.cpp
+++ b/src/properties/vector/ivec2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::ivec2 fromLuaConversion(lua_State* state, bool& success) {
+glm::ivec2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::ivec2 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::ivec2>::value; ++i) {
@@ -51,7 +51,7 @@ glm::ivec2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/ivec3property.cpp
+++ b/src/properties/vector/ivec3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::ivec3 fromLuaConversion(lua_State* state, bool& success) {
+glm::ivec3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::ivec3 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::ivec3>::value; ++i) {
@@ -51,7 +51,7 @@ glm::ivec3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/ivec4property.cpp
+++ b/src/properties/vector/ivec4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::ivec4 fromLuaConversion(lua_State* state, bool& success) {
+glm::ivec4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::ivec4 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::ivec4>::value; ++i) {
@@ -51,7 +51,7 @@ glm::ivec4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/uvec2property.cpp
+++ b/src/properties/vector/uvec2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::uvec2 fromLuaConversion(lua_State* state, bool& success) {
+glm::uvec2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::uvec2 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::uvec2>::value; ++i) {
@@ -51,7 +51,7 @@ glm::uvec2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/uvec3property.cpp
+++ b/src/properties/vector/uvec3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::uvec3 fromLuaConversion(lua_State* state, bool& success) {
+glm::uvec3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::uvec3 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::uvec3>::value; ++i) {
@@ -51,7 +51,7 @@ glm::uvec3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/uvec4property.cpp
+++ b/src/properties/vector/uvec4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::uvec4 fromLuaConversion(lua_State* state, bool& success) {
+glm::uvec4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::uvec4 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::uvec4>::value; ++i) {
@@ -51,7 +51,7 @@ glm::uvec4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/vec2property.cpp
+++ b/src/properties/vector/vec2property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::vec2 fromLuaConversion(lua_State* state, bool& success) {
+glm::vec2 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::vec2 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::vec2>::value; ++i) {
@@ -51,7 +51,7 @@ glm::vec2 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/vec3property.cpp
+++ b/src/properties/vector/vec3property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::vec3 fromLuaConversion(lua_State* state, bool& success) {
+glm::vec3 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::vec3 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::vec3>::value; ++i) {
@@ -51,7 +51,7 @@ glm::vec3 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/properties/vector/vec4property.cpp
+++ b/src/properties/vector/vec4property.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-glm::vec4 fromLuaConversion(lua_State* state, bool& success) {
+glm::vec4 fromLuaConversion(lua_State* state, bool leaveOnStack, bool& success) {
     glm::vec4 result;
     lua_pushnil(state);
     for (glm::length_t i = 0; i < ghoul::glm_components<glm::vec4>::value; ++i) {
@@ -51,7 +51,7 @@ glm::vec4 fromLuaConversion(lua_State* state, bool& success) {
         }
     }
     // The last accessor argument and the table are still on the stack
-    lua_pop(state, 2);
+    lua_pop(state, leaveOnStack ? 1 : 2);
     success = true;
     return result;
 }

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -73,6 +73,7 @@ void applyRegularExpression(lua_State* L, const std::string& regex,
     bool foundMatching = false;
     std::regex r(regex);
     for (properties::Property* prop : properties) {
+        bool isLastIteration = (prop == properties.back());
         // Check the regular expression for all properties
         std::string id = prop->fullyQualifiedIdentifier();
 
@@ -107,10 +108,10 @@ void applyRegularExpression(lua_State* L, const std::string& regex,
 
                 if (interpolationDuration == 0.0) {
                     OsEng.renderEngine().scene()->removeInterpolation(prop);
-                    prop->setLuaValue(L);
+                    prop->setLuaValue(L, !isLastIteration);
                 }
                 else {
-                    prop->setLuaInterpolationTarget(L);
+                    prop->setLuaInterpolationTarget(L, !isLastIteration);
                     OsEng.renderEngine().scene()->addInterpolation(
                         prop,
                         static_cast<float>(interpolationDuration),
@@ -184,10 +185,10 @@ int setPropertyCall_single(properties::Property& prop, const std::string& uri,
     else {
         if (duration == 0.0) {
             OsEng.renderEngine().scene()->removeInterpolation(&prop);
-            prop.setLuaValue(L);
+            prop.setLuaValue(L, false);
         }
         else {
-            prop.setLuaInterpolationTarget(L);
+            prop.setLuaInterpolationTarget(L, false);
             OsEng.renderEngine().scene()->addInterpolation(
                 &prop,
                 static_cast<float>(duration),

--- a/tests/test_luaconversions.inl
+++ b/tests/test_luaconversions.inl
@@ -70,6 +70,7 @@ TEST_F(LuaConversionTest, Bool) {
     bool value = static_cast<bool>(0);
     value = PropertyDelegate<TemplateProperty<bool>>::fromLuaValue<bool>(
         state,
+        false,
         success
     );
     EXPECT_TRUE(success) << "fromLuaValue";
@@ -88,6 +89,7 @@ TEST_F(LuaConversionTest, Char) {
     EXPECT_TRUE(success) << "toLuaValue";
     T value = PropertyDelegate<NumericalProperty<T>>::fromLuaValue<T>(
         state,
+        false,
         success
     );
     EXPECT_TRUE(success) << "fromLuaValue";
@@ -114,6 +116,7 @@ TEST_F(LuaConversionTest, CharFuzz) {
         EXPECT_TRUE(success) << "toLuaValue";
         T value = PropertyDelegate<NumericalProperty<T>>::fromLuaValue<T>(
             state,
+            false,
             success
         );
         EXPECT_TRUE(success) << "fromLuaValue";
@@ -134,6 +137,7 @@ TEST_F(LuaConversionTest, CharFuzz) {
 //    EXPECT_TRUE(success) << "toLuaValue";
 //    T value = PropertyDelegate<NumericalProperty<T>>::fromLuaValue<T>(
 //        state,
+//        false,
 //        success
 //    );
 //    EXPECT_TRUE(success) << "fromLuaValue";
@@ -161,6 +165,7 @@ TEST_F(LuaConversionTest, CharFuzz) {
 //        EXPECT_TRUE(success) << "toLuaValue";
 //        T value = PropertyDelegate<NumericalProperty<T>>::fromLuaValue<T>(
 //            state,
+//            false,
 //            success
 //        );
 //        EXPECT_TRUE(success) << "fromLuaValue";
@@ -180,6 +185,7 @@ TEST_F(LuaConversionTest, SignedChar) {
     EXPECT_TRUE(success) << "toLuaValue";
     T value = PropertyDelegate<NumericalProperty<T>>::fromLuaValue<T>(
         state,
+        false,
         success
     );
     EXPECT_TRUE(success) << "fromLuaValue";


### PR DESCRIPTION
The Lua stack was thrown away after setting the first matching property, causing the system to crash when trying to set the other matching properties.
Fixed by introducing a `leaveOnStack` parameter to `setLuaValue` for properties.