### PR TITLE
Fix DashboardItem bugs related to unloading and loading assets at runtime

### DIFF
--- a/data/assets/dawn.scene
+++ b/data/assets/dawn.scene
@@ -13,13 +13,14 @@ asset.require('scene/solarsystem/missions/dawn/vesta')
 
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
+
 
 local DawnAsset = asset.require('scene/solarsystem/missions/dawn/dawn')
 
 asset.onInitialize(function ()
     openspace.time.setTime("2011 AUG 06 00:00:00")
 
-    openspace.setDefaultDashboard()
     openspace.setDefaultGuiSorting()
 
     openspace.markInterestingNodes({

--- a/data/assets/default.scene
+++ b/data/assets/default.scene
@@ -11,6 +11,7 @@ asset.require('scene/solarsystem/planets/mars/moons/deimos')
 assetHelper.requestAll(asset, 'scene/digitaluniverse')
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
 
 asset.request('customization/globebrowsing')
 
@@ -59,7 +60,6 @@ asset.onInitialize(function ()
     openspace.time.setTime(openspace.time.currentWallTime())
     sceneHelper.bindKeys(Keybindings)
 
-    openspace.setDefaultDashboard()
     openspace.setDefaultGuiSorting()
 
     openspace.globebrowsing.loadWMSServersFromFile(

--- a/data/assets/juno.scene
+++ b/data/assets/juno.scene
@@ -11,13 +11,13 @@ assetHelper.requireAll(asset, 'scene/solarsystem/missions/juno')
 
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
 
 local junoAsset = asset.require('scene/solarsystem/missions/juno/juno')
 
 asset.onInitialize(function ()
     openspace.time.setTime("2016-07-01T10:05:00.00")
 
-    openspace.setDefaultDashboard()
     openspace.setDefaultGuiSorting()
 
     sceneHelper.setDeltaTimeKeys({

--- a/data/assets/newhorizons.scene
+++ b/data/assets/newhorizons.scene
@@ -13,6 +13,7 @@ asset.require('scene/solarsystem/missions/newhorizons/newhorizons')
 
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
 
 -- Custom Keybindings
 local Keybindings = {
@@ -131,27 +132,32 @@ local Keybindings = {
 
 local NewHorizonsAsset = asset.require('scene/solarsystem/missions/newhorizons/model')
 
-asset.onInitialize(function ()
-    openspace.time.setTime("2015-07-14T08:00:00.00")
-    sceneHelper.bindKeys(Keybindings)
-
-    openspace.setDefaultDashboard()
-    openspace.dashboard.addDashboardItem({
+assetHelper.registerDashboardItems(asset, {
+    {
         Type = "DashboardItemSpacing",
+        Identifier = "NewHorizonsSpacing",
+        GuiName = "New Horizons Spacing",
         Spacing = 25
-    })
-
-    openspace.dashboard.addDashboardItem({
+    },
+    {
         Type = "DashboardItemDistance",
+        Identifier = "NewHorizonsPlutoDistance",
+        GuiName = "New Horizons Pluto Distance",
         SourceType = "Node",
         SourceNodeName = "NewHorizons",
         DestinationType = "Node Surface",
         DestinationNodeName = "Pluto"
-    })
+    },
+    {
+        Type = "DashboardItemInstruments",
+        Identifier = "NewHorizonsInstruments",
+        GuiName = "NewHorizons Instruments",
+    }
+})
 
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemInstruments"
-    })
+asset.onInitialize(function ()
+    openspace.time.setTime("2015-07-14T08:00:00.00")
+    sceneHelper.bindKeys(Keybindings)
 
     openspace.setDefaultGuiSorting()
 

--- a/data/assets/osirisrex.scene
+++ b/data/assets/osirisrex.scene
@@ -12,6 +12,7 @@ asset.require('scene/solarsystem/missions/osirisrex/osirisrex')
 
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
 
 -- Custom Keybindings
 local Keybindings = {
@@ -79,28 +80,33 @@ local Keybindings = {
 
 local OsirisRexAsset = asset.require('scene/solarsystem/missions/osirisrex/model')
 
-asset.onInitialize(function ()
-    -- openspace.time.setTime("2019 APR 16 12:03:00.00")
-    openspace.time.setTime("2016 SEP 8 23:00:00.500")
-    sceneHelper.bindKeys(Keybindings)
-
-    openspace.setDefaultDashboard()
-    openspace.dashboard.addDashboardItem({
+assetHelper.registerDashboardItems(asset, {
+    {
         Type = "DashboardItemSpacing",
+        Identifier = "OsirisRexSpacing",
+        GuiName = "OSIRIS-REx Spacing",
         Spacing = 25
-    })
-
-    openspace.dashboard.addDashboardItem({
+    },
+    {
         Type = "DashboardItemDistance",
+        Identifier = "OsirisRexBennuDistance",
+        GuiName = "OSIRIS-REx Bennu Distance",
         SourceType = "Node",
         SourceNodeName = "OsirisRex",
         DestinationType = "Node",
         DestinationNodeName = "BennuBarycenter"
-    })
+    },
+    {
+        Type = "DashboardItemInstruments",
+        Identifier = "OsirisRexInstruments",
+        GuiName = "OSIRIS-REx Instruments",
+    }
+})
 
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemInstruments"
-    })
+asset.onInitialize(function ()
+    -- openspace.time.setTime("2019 APR 16 12:03:00.00")
+    openspace.time.setTime("2016 SEP 8 23:00:00.500")
+    sceneHelper.bindKeys(Keybindings)
 
     openspace.setDefaultGuiSorting()
 

--- a/data/assets/rosetta.scene
+++ b/data/assets/rosetta.scene
@@ -14,6 +14,7 @@ asset.require('scene/solarsystem/missions/rosetta/rosetta')
 
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
 
 -- Custom Keybindings
 local Keybindings = {
@@ -82,27 +83,32 @@ local Keybindings = {
 
 local Comet67PAsset = asset.require('scene/solarsystem/missions/rosetta/67p')
 
-asset.onInitialize(function ()
-    openspace.time.setTime("2014-08-01T03:05:00.000")
-    sceneHelper.bindKeys(Keybindings)
-
-    openspace.setDefaultDashboard()
-    openspace.dashboard.addDashboardItem({
+assetHelper.registerDashboardItems(asset, {
+    {
         Type = "DashboardItemSpacing",
+        Identifier = "RosettaSpacing",
+        GuiName = "Rosetta Spacing",
         Spacing = 25
-    })
-
-    openspace.dashboard.addDashboardItem({
+    },
+    {
         Type = "DashboardItemDistance",
+        Identifier = "Rosetta67PDistance",
+        GuiName = "Rosetta 67P Distance",
         SourceType = "Node",
         SourceNodeName = "Rosetta",
         DestinationType = "Node",
         DestinationNodeName = "67P"
-    })
+    },
+    {
+        Type = "DashboardItemInstruments",
+        Identifier = "RosettaInstruments",
+        GuiName = "Rosetta Instruments",
+    }
+})
 
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemInstruments"
-    })
+asset.onInitialize(function ()
+    openspace.time.setTime("2014-08-01T03:05:00.000")
+    sceneHelper.bindKeys(Keybindings)
 
     openspace.setDefaultGuiSorting()
 

--- a/data/assets/util/asset_helper.asset
+++ b/data/assets/util/asset_helper.asset
@@ -42,6 +42,20 @@ local registerSceneGraphNodes = function (sceneAsset, nodes, override)
     end)
 end
 
+local registerDashboardItems = function (dashboardAsset, items)
+    dashboardAsset.onInitialize(function ()
+            for i, item in ipairs(items) do
+                openspace.dashboard.addDashboardItem(item)
+            end
+        end)
+    dashboardAsset.onDeinitialize(function ()
+        for i = #items, 1, -1 do
+            item = items[i]
+            openspace.dashboard.removeDashboardItem(item.Identifier)
+        end
+    end)
+end
+
 local registerSceneGraphNodesAndExport = function (sceneAsset, nodes, override)
     override = override or false
     if not override then
@@ -110,5 +124,6 @@ end
 asset.export("registerSceneGraphNodes", registerSceneGraphNodes)
 asset.export("registerSceneGraphNodesAndExport", registerSceneGraphNodesAndExport)
 asset.export("registerSpiceKernels", registerSpiceKernels)
+asset.export("registerDashboardItems", registerDashboardItems)
 asset.export("requireAll", requireAll)
 asset.export("requestAll", requestAll)

--- a/data/assets/util/default_dashboard.asset
+++ b/data/assets/util/default_dashboard.asset
@@ -1,0 +1,29 @@
+local assetHelper = asset.require('util/asset_helper')
+
+assetHelper.registerDashboardItems(asset, {
+    {
+        Identifier = "Date",
+        GuiName = "Date",
+        Type = "DashboardItemDate"
+    },
+    {
+        Identifier = "SimulationIncrement",
+        GuiName = "Simulation Increment",
+        Type = "DashboardItemSimulationIncrement"
+    },
+    {
+        Identifier = "Distance",
+        GuiName = "Distance",
+        Type = "DashboardItemDistance"
+    },
+    {
+        Identifier = "Framerate",
+        GuiName = "Framerate",
+        Type = "DashboardItemFramerate"
+    },
+    {
+        Identifier = "ParallelConnection",
+        GuiName = "Parallel Connection",
+        Type = "DashboardItemParallelConnection"
+    }
+})

--- a/data/assets/voyager.scene
+++ b/data/assets/voyager.scene
@@ -18,13 +18,13 @@ asset.require('scene/solarsystem/missions/voyager/voyager2')
 
 -- Load default key bindings applicable to most scenes
 asset.require('util/default_keybindings')
+asset.require('util/default_dashboard')
 
 local VoyagerAsset = asset.require('scene/solarsystem/missions/voyager/voyager1')
 
 asset.onInitialize(function ()
     openspace.time.setTime("1977 SEP 10 12:00:00")
 
-    openspace.setDefaultDashboard()
     openspace.setDefaultGuiSorting()
 
     sceneHelper.setDeltaTimeKeys({

--- a/include/openspace/rendering/dashboard.h
+++ b/include/openspace/rendering/dashboard.h
@@ -48,8 +48,9 @@ public:
     void addDashboardItem(std::unique_ptr<DashboardItem> item);
     bool hasItem(int index) const;
     const DashboardItem& item(int index) const;
+    void removeDashboardItem(const std::string& identifier);
     void removeDashboardItem(int index);
-    void removeDashboardItems();
+    void clearDashboardItems();
 
     /**
     * Returns the Lua library that contains all Lua functions available to affect the

--- a/include/openspace/rendering/dashboarditem.h
+++ b/include/openspace/rendering/dashboarditem.h
@@ -36,13 +36,17 @@
 
 namespace openspace {
 
+namespace documentation { struct Documentation; }
+
 class DashboardItem : public properties::PropertyOwner {
 public:
+    static documentation::Documentation Documentation();
+
     static std::unique_ptr<DashboardItem> createFromDictionary(
         ghoul::Dictionary dictionary
     );
 
-    DashboardItem(std::string identifier, std::string guiName = "");
+    DashboardItem(ghoul::Dictionary dictionary);
 
     bool isEnabled() const;
     virtual void render(glm::vec2& penPosition) = 0;

--- a/modules/base/dashboard/dashboarditemangle.cpp
+++ b/modules/base/dashboard/dashboarditemangle.cpp
@@ -174,7 +174,7 @@ documentation::Documentation DashboardItemAngle::Documentation() {
 }
 
 DashboardItemAngle::DashboardItemAngle(ghoul::Dictionary dictionary)
-    : DashboardItem("Angle")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
     , _source{

--- a/modules/base/dashboard/dashboarditemdate.cpp
+++ b/modules/base/dashboard/dashboarditemdate.cpp
@@ -81,7 +81,7 @@ documentation::Documentation DashboardItemDate::Documentation() {
 }
 
 DashboardItemDate::DashboardItemDate(ghoul::Dictionary dictionary)
-    : DashboardItem("Date")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
 {

--- a/modules/base/dashboard/dashboarditemdistance.cpp
+++ b/modules/base/dashboard/dashboarditemdistance.cpp
@@ -183,7 +183,7 @@ documentation::Documentation DashboardItemDistance::Documentation() {
 }
 
 DashboardItemDistance::DashboardItemDistance(ghoul::Dictionary dictionary)
-    : DashboardItem("Distance")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
     , _doSimplification(SimplificationInfo, true)

--- a/modules/base/dashboard/dashboarditemframerate.cpp
+++ b/modules/base/dashboard/dashboarditemframerate.cpp
@@ -96,7 +96,7 @@ documentation::Documentation DashboardItemFramerate::Documentation() {
 }
 
 DashboardItemFramerate::DashboardItemFramerate(ghoul::Dictionary dictionary)
-    : DashboardItem("Framerate")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
     , _frametimeType(FrametimeInfo, properties::OptionProperty::DisplayType::Dropdown)

--- a/modules/base/dashboard/dashboarditemmission.cpp
+++ b/modules/base/dashboard/dashboarditemmission.cpp
@@ -101,7 +101,7 @@ documentation::Documentation DashboardItemMission::Documentation() {
 }
 
 DashboardItemMission::DashboardItemMission(ghoul::Dictionary dictionary)
-    : DashboardItem("Mission")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
 {

--- a/modules/base/dashboard/dashboarditemparallelconnection.cpp
+++ b/modules/base/dashboard/dashboarditemparallelconnection.cpp
@@ -86,7 +86,7 @@ documentation::Documentation DashboardItemParallelConnection::Documentation() {
 
 DashboardItemParallelConnection::DashboardItemParallelConnection(
                                                              ghoul::Dictionary dictionary)
-    : DashboardItem("ParallelConnection", "Parallel Connection")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
 {

--- a/modules/base/dashboard/dashboarditemsimulationincrement.cpp
+++ b/modules/base/dashboard/dashboarditemsimulationincrement.cpp
@@ -123,7 +123,7 @@ documentation::Documentation DashboardItemSimulationIncrement::Documentation() {
 
 DashboardItemSimulationIncrement::DashboardItemSimulationIncrement(
                                                              ghoul::Dictionary dictionary)
-    : DashboardItem("SimulationIncrement", "Simulation Increment")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
     , _doSimplification(SimplificationInfo, true)

--- a/modules/base/dashboard/dashboarditemspacing.cpp
+++ b/modules/base/dashboard/dashboarditemspacing.cpp
@@ -60,7 +60,7 @@ documentation::Documentation DashboardItemSpacing::Documentation() {
 }
 
 DashboardItemSpacing::DashboardItemSpacing(ghoul::Dictionary dictionary)
-    : DashboardItem("Spacing")
+    : DashboardItem(dictionary)
     , _spacing(SpacingInfo, 15.f, 0.f, 2048.f)
 {
     documentation::testSpecificationAndThrow(

--- a/modules/base/rendering/screenspacedashboard.cpp
+++ b/modules/base/rendering/screenspacedashboard.cpp
@@ -120,7 +120,7 @@ int removeDashboardItemsFromScreenSpace(lua_State* L) {
         return luaL_error(L, "Provided name is a ScreenSpace item but not a dashboard");
     }
 
-    dash->dashboard().removeDashboardItems();
+    dash->dashboard().clearDashboardItems();
     return 0;
 }
 

--- a/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.cpp
+++ b/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.cpp
@@ -138,7 +138,7 @@ documentation::Documentation DashboardItemInstruments::Documentation() {
 }
 
 DashboardItemInstruments::DashboardItemInstruments(ghoul::Dictionary dictionary)
-    : DashboardItem("Instruments")
+    : DashboardItem(dictionary)
     , _fontName(FontNameInfo, KeyFontMono)
     , _fontSize(FontSizeInfo, DefaultFontSize, 6.f, 144.f, 1.f)
     , _activeColor(

--- a/scripts/core_scripts.lua
+++ b/scripts/core_scripts.lua
@@ -52,28 +52,6 @@ openspace.removeInterestingNodes = function(nodes)
     end
 end
 
-openspace.setDefaultDashboard = function()
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemDate"
-    })
-
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemSimulationIncrement"
-    })
-
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemDistance"
-    })
-
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemFramerate"
-    })
-
-    openspace.dashboard.addDashboardItem({
-        Type = "DashboardItemParallelConnection"
-    })
-end
-
 openspace.setDefaultGuiSorting = function()
     openspace.setPropertyValueSingle(
         'Modules.ImGUI.Main.SceneProperties.Ordering',

--- a/src/mission/missionmanager.cpp
+++ b/src/mission/missionmanager.cpp
@@ -88,6 +88,10 @@ void MissionManager::unloadMission(const std::string& missionName) {
         "missionName must name a previously loaded mission"
     );
 
+    if (it == _currentMission) {
+        _currentMission = _missionMap.end();
+    }
+
     _missionMap.erase(it);
 }
 

--- a/src/rendering/dashboard.cpp
+++ b/src/rendering/dashboard.cpp
@@ -81,6 +81,23 @@ void Dashboard::removeDashboardItem(int index) {
     _items.erase(_items.begin() + index);
 }
 
+void Dashboard::removeDashboardItem(const std::string& identifier) {
+    const auto it = std::find_if(
+        _items.begin(),
+        _items.end(),
+        [&identifier](const std::unique_ptr<DashboardItem>& i) {
+            return i->identifier() == identifier;
+        }
+    );
+
+    if (it == _items.end()) {
+        return;
+    }
+
+    removePropertySubOwner(it->get());
+    _items.erase(it);
+}
+
 bool Dashboard::hasItem(int index) const {
     return (index >= 0) && (index < static_cast<int>(_items.size()));
 }
@@ -90,7 +107,7 @@ const DashboardItem& Dashboard::item(int index) const {
     return *_items[index];
 }
 
-void Dashboard::removeDashboardItems() {
+void Dashboard::clearDashboardItems() {
     for (const std::unique_ptr<DashboardItem>& item : _items) {
         removePropertySubOwner(item.get());
     }
@@ -121,8 +138,15 @@ scripting::LuaLibrary Dashboard::luaLibrary() {
                 "Adds a new dashboard item to the main dashboard."
             },
             {
-                "removeDashboardItems",
-                &luascriptfunctions::removeDashboardItems,
+                "removeDashboardItem",
+                &luascriptfunctions::removeDashboardItem,
+                {},
+                "string",
+                "Removes the dashboard item with the specified identifier."
+            },
+            {
+                "clearDashboardItems",
+                &luascriptfunctions::clearDashboardItems,
                 {},
                 "",
                 "Removes all dashboard items from the main dashboard."

--- a/src/rendering/dashboard_lua.inl
+++ b/src/rendering/dashboard_lua.inl
@@ -60,12 +60,31 @@ int addDashboardItem(lua_State* L) {
 
 /**
 * \ingroup LuaScripts
+* removeDashboardItem(string):
+*/
+int removeDashboardItem(lua_State* L) {
+    using ghoul::lua::errorLocation;
+
+    ghoul::lua::checkArgumentsAndThrow(L, 1, "lua::removeDashbordItem");
+
+    std::string identifier = luaL_checkstring(L, -1);
+
+    OsEng.dashboard().removeDashboardItem(identifier);
+
+    lua_settop(L, 0);
+    ghoul_assert(lua_gettop(L) == 0, "Incorrect number of items left on stack");
+    return 0;
+}
+
+
+/**
+* \ingroup LuaScripts
 * removeDashboardItems():
 */
-int removeDashboardItems(lua_State* L) {
-    ghoul::lua::checkArgumentsAndThrow(L, 0, "lua::removeDashboardItems");
+int clearDashboardItems(lua_State* L) {
+    ghoul::lua::checkArgumentsAndThrow(L, 0, "lua::clearDashboardItems");
 
-    OsEng.dashboard().removeDashboardItems();
+    OsEng.dashboard().clearDashboardItems();
 
     ghoul_assert(lua_gettop(L) == 0, "Incorrect number of items left on stack");
     return 0;

--- a/src/rendering/dashboarditem.cpp
+++ b/src/rendering/dashboarditem.cpp
@@ -25,6 +25,8 @@
 #include <openspace/rendering/dashboarditem.h>
 
 #include <openspace/util/factorymanager.h>
+#include <openspace/documentation/documentation.h>
+#include <openspace/documentation/verifier.h>
 
 #include <ghoul/misc/templatefactory.h>
 
@@ -36,9 +38,55 @@ namespace {
         "Is Enabled",
         "If this value is set to 'true' this dashboard item is shown in the dashboard"
     };
+
+    static const openspace::properties::Property::PropertyInfo TypeInfo = {
+        "Type",
+        "Type",
+        ""
+    };
+
+    static const openspace::properties::Property::PropertyInfo IdentifierInfo = {
+        "Identifier",
+        "Identifier",
+        ""
+    };
+
+    static const openspace::properties::Property::PropertyInfo GuiNameInfo = {
+        "GuiName",
+        "Gui Name",
+        ""
+    };
 } // namespace
 
 namespace openspace {
+
+documentation::Documentation DashboardItem::Documentation() {
+    using namespace documentation;
+    return {
+        "DashboardItem",
+        "dashboarditem",
+        {
+            {
+                TypeInfo.identifier,
+                new StringVerifier,
+                Optional::No,
+                TypeInfo.description
+            },
+            {
+                IdentifierInfo.identifier,
+                new StringVerifier,
+                Optional::No,
+                IdentifierInfo.description
+            },
+            {
+                GuiNameInfo.identifier,
+                new StringVerifier,
+                Optional::Yes,
+                GuiNameInfo.description
+            }
+        }
+    };
+}
 
 std::unique_ptr<DashboardItem> DashboardItem::createFromDictionary(
                                                              ghoul::Dictionary dictionary)
@@ -51,10 +99,24 @@ std::unique_ptr<DashboardItem> DashboardItem::createFromDictionary(
     return factory->create(dashboardType, dictionary);
 }
 
-DashboardItem::DashboardItem(std::string identifier, std::string guiName)
-    : properties::PropertyOwner({ std::move(identifier), std::move(guiName) })
+DashboardItem::DashboardItem(ghoul::Dictionary dictionary)
+    : properties::PropertyOwner({ "", "" })
     , _isEnabled(EnabledInfo, true)
 {
+    documentation::testSpecificationAndThrow(
+        Documentation(),
+        dictionary,
+        "DashboardItem"
+    );
+
+    const std::string identifier =
+        dictionary.value<std::string>(IdentifierInfo.identifier);
+
+    const std::string guiName =
+        dictionary.value<std::string>(GuiNameInfo.identifier);
+
+    setIdentifier(identifier);
+    setGuiName(guiName);
     addProperty(_isEnabled);
 }
 


### PR DESCRIPTION
Turn the default dashboard items into an asset, to avoid copies of the same dashboard items when loading and unloading scenes.

Breaking change: removed `openspace.setDefaultDashboard` from `core_scripts`.
To load default dashboard, instead use: `asset.require('util/default_dashboard')`