### PR TITLE
Issue/87

### DIFF
--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -202,7 +202,7 @@ public:
      */
     void removePropertyInterpolation(properties::Property* prop);
 
-    void addTimeInterpolation(float targetTime, double durationSeconds);
+    void addTimeInterpolation(double targetTime, double durationSeconds);
     void removeTimeInterpolation();
 
     /**

--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -188,7 +188,7 @@ public:
      * \pre \p durationSeconds must be positive and not 0
      * \post A new interpolation record exists for \p that is not expired 
      */
-    void addInterpolation(properties::Property* prop, float durationSeconds,
+    void addPropertyInterpolation(properties::Property* prop, float durationSeconds,
         ghoul::EasingFunction easingFunction = ghoul::EasingFunction::Linear);
 
     /**
@@ -200,7 +200,10 @@ public:
      * \pre \prop must not be nullptr
      * \post No interpolation record exists for \p prop
      */
-    void removeInterpolation(properties::Property* prop);
+    void removePropertyInterpolation(properties::Property* prop);
+
+    void addTimeInterpolation(float targetTime, double durationSeconds);
+    void removeTimeInterpolation();
 
     /**
      * Informs all Property%s with active interpolations about applying a new update tick
@@ -245,14 +248,25 @@ private:
     std::set<ghoul::opengl::ProgramObject*> _programsToUpdate;
     std::vector<std::unique_ptr<ghoul::opengl::ProgramObject>> _programs;
 
-    struct InterpolationInfo {
+    struct PropertyInterpolationInfo {
         properties::Property* prop;
         std::chrono::time_point<std::chrono::steady_clock> beginTime;
         float durationSeconds;
         ghoul::EasingFunc<float> easingFunction;
         bool isExpired = false;
     };
-    std::vector<InterpolationInfo> _interpolationInfos;
+    std::vector<PropertyInterpolationInfo> _propertyInterpolationInfos;
+
+    struct TimeInterpolationInfo {
+        std::chrono::time_point<std::chrono::steady_clock> beginTime;
+
+        float durationSeconds;
+        float easingTime;
+
+        double interpolationStart;
+        double interpolationEnd;
+    };
+    std::unique_ptr<TimeInterpolationInfo> _timeInterpolationInfo = nullptr;
 };
 
 } // namespace openspace

--- a/include/openspace/util/timemanager.h
+++ b/include/openspace/util/timemanager.h
@@ -54,6 +54,8 @@ public:
     CallbackHandle addDeltaTimeChangeCallback(TimeChangeCallback cb);
     void removeTimeChangeCallback(CallbackHandle handle);
     void removeDeltaTimeChangeCallback(CallbackHandle handle);
+
+
 private:
     bool _shouldSetTime = false;
     Time _timeNextFrame;

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -532,8 +532,9 @@ void Scene::addTimeInterpolation(float targetTime, double durationSeconds) {
     else {
         i.easingTime = i.durationSeconds * 0.25f;
     }
+    //i.easingTime = 0.f;
 
-    i.interpolationStart = Time::now().j2000Seconds();
+    i.interpolationStart = OsEng.timeManager().time().j2000Seconds();
     i.interpolationEnd = targetTime;
 
     //Time::now().setPause(false);
@@ -600,7 +601,7 @@ void Scene::updateInterpolations() {
             0.f,
             1.f
         );
-        LINFOC("t", std::to_string(t));
+        //LINFOC("t", std::to_string(t));
 
         //
         // t_1: duration
@@ -631,35 +632,38 @@ void Scene::updateInterpolations() {
         const float a = i.easingTime;
         const float aprime = a / t1;
 
-        LINFOC("e", std::to_string(e));
-        LINFOC("s", std::to_string(s));
-        LINFOC("t1", std::to_string(t1));
-        LINFOC("a", std::to_string(a));
-        LINFOC("aprime", std::to_string(aprime));
+        //LINFOC("e", std::to_string(e));
+        //LINFOC("s", std::to_string(s));
+        //LINFOC("t1", std::to_string(t1));
+        //LINFOC("a", std::to_string(a));
+        //LINFOC("aprime", std::to_string(aprime));
 
 
         const double x = (e - s) / (t1 - a);
-        LINFOC("x", std::to_string(x));
+        //LINFOC("x", std::to_string(x));
 
         double targetDelta = x;
         if (t < aprime) {
             float localT = t / aprime;
-            LINFOC("localT", std::to_string(localT));
+            //LINFOC("localT", std::to_string(localT));
             targetDelta = localT * x;
         }
 
         if (t > (1.f - aprime)) {
             //float localT = (t - t1 - a) / a;
             float localT = (t - (1.f - aprime)) / (aprime);
-            LINFOC("localT", std::to_string(localT));
+            //LINFOC("localT", std::to_string(localT));
             targetDelta = (1 - localT) * x;
         }
-        LINFOC("targetDelta", std::to_string(targetDelta));
-        LINFOC("=====", "=========");
+        //LINFOC("targetDelta", std::to_string(targetDelta));
+        //LINFOC("=====", "=========");
 
-        OsEng.timeManager().time().setDeltaTime(targetDelta);
         if (t == 1.f) {
+            OsEng.timeManager().time().setDeltaTime(0.0);
             _timeInterpolationInfo = nullptr;
+        }
+        else {
+            OsEng.timeManager().time().setDeltaTime(targetDelta);
         }
     }
 }

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -536,11 +536,6 @@ void Scene::addTimeInterpolation(double targetTime, double durationSeconds) {
     i.interpolationStart = OsEng.timeManager().time().j2000Seconds();
     i.interpolationEnd = targetTime;
 
-    LINFOC("S", Time(i.interpolationStart).ISO8601());
-    LINFOC("St", std::to_string(i.interpolationStart));
-    LINFOC("E", Time(i.interpolationEnd).ISO8601());
-    LINFOC("Et", std::to_string(i.interpolationEnd));
-
     OsEng.timeManager().time().setPause(false);
 }
 
@@ -598,13 +593,10 @@ void Scene::updateInterpolations() {
             now - i.beginTime
         ).count();
 
-        const float t = glm::clamp(
-            static_cast<float>(
-                static_cast<double>(usPassed) /
-                static_cast<double>(i.durationSeconds * 1000000)
-            ),
-            0.f,
-            1.f
+        const double t = glm::clamp(
+            static_cast<double>(usPassed) / (i.durationSeconds * 1000000.0),
+            0.0,
+            1.0
         );
 
         if (t == 1.f) {
@@ -641,18 +633,18 @@ void Scene::updateInterpolations() {
         const double s = i.interpolationStart;
         const float t1 = i.durationSeconds;
         const float a = i.easingTime;
-        const float aprime = a / t1;
+        const double aprime = a / t1;
 
         const double x = (e - s) / (t1 - a);
 
         double targetDelta = x;
-        if (t < aprime) {
-            float localT = t / aprime;
+        if (t <= aprime) {
+            double localT = t / aprime;
             targetDelta = localT * x;
         }
 
-        if (t > (1.f - aprime)) {
-            float localT = (t - (1.f - aprime)) / (aprime);
+        if (t >= (1.f - aprime)) {
+            double localT = (t - (1.f - aprime)) / (aprime);
             targetDelta = (1 - localT) * x;
         }
 

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -514,7 +514,7 @@ void Scene::removePropertyInterpolation(properties::Property* prop) {
     );
 }
 
-void Scene::addTimeInterpolation(float targetTime, double durationSeconds) {
+void Scene::addTimeInterpolation(double targetTime, double durationSeconds) {
     ghoul_precondition(durationSeconds > 0.f, "durationSeconds must be positive");
 
     if (!_timeInterpolationInfo) {
@@ -532,12 +532,16 @@ void Scene::addTimeInterpolation(float targetTime, double durationSeconds) {
     else {
         i.easingTime = i.durationSeconds * 0.25f;
     }
-    //i.easingTime = 0.f;
 
     i.interpolationStart = OsEng.timeManager().time().j2000Seconds();
     i.interpolationEnd = targetTime;
 
-    //Time::now().setPause(false);
+    LINFOC("S", Time(i.interpolationStart).ISO8601());
+    LINFOC("St", std::to_string(i.interpolationStart));
+    LINFOC("E", Time(i.interpolationEnd).ISO8601());
+    LINFOC("Et", std::to_string(i.interpolationEnd));
+
+    OsEng.timeManager().time().setPause(false);
 }
 
 void Scene::removeTimeInterpolation() {
@@ -586,6 +590,7 @@ void Scene::updateInterpolations() {
         _propertyInterpolationInfos.end()
     );
 
+
     // Then update the time interpolation
     if (_timeInterpolationInfo) {
         TimeInterpolationInfo& i = *_timeInterpolationInfo;
@@ -601,7 +606,13 @@ void Scene::updateInterpolations() {
             0.f,
             1.f
         );
-        //LINFOC("t", std::to_string(t));
+
+        if (t == 1.f) {
+            OsEng.timeManager().time().setDeltaTime(0.0);
+            _timeInterpolationInfo = nullptr;
+
+            return;
+        }
 
         //
         // t_1: duration
@@ -632,39 +643,20 @@ void Scene::updateInterpolations() {
         const float a = i.easingTime;
         const float aprime = a / t1;
 
-        //LINFOC("e", std::to_string(e));
-        //LINFOC("s", std::to_string(s));
-        //LINFOC("t1", std::to_string(t1));
-        //LINFOC("a", std::to_string(a));
-        //LINFOC("aprime", std::to_string(aprime));
-
-
         const double x = (e - s) / (t1 - a);
-        //LINFOC("x", std::to_string(x));
 
         double targetDelta = x;
         if (t < aprime) {
             float localT = t / aprime;
-            //LINFOC("localT", std::to_string(localT));
             targetDelta = localT * x;
         }
 
         if (t > (1.f - aprime)) {
-            //float localT = (t - t1 - a) / a;
             float localT = (t - (1.f - aprime)) / (aprime);
-            //LINFOC("localT", std::to_string(localT));
             targetDelta = (1 - localT) * x;
         }
-        //LINFOC("targetDelta", std::to_string(targetDelta));
-        //LINFOC("=====", "=========");
 
-        if (t == 1.f) {
-            OsEng.timeManager().time().setDeltaTime(0.0);
-            _timeInterpolationInfo = nullptr;
-        }
-        else {
-            OsEng.timeManager().time().setDeltaTime(targetDelta);
-        }
+        OsEng.timeManager().time().setDeltaTime(targetDelta);
     }
 }
 

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -106,12 +106,12 @@ void applyRegularExpression(lua_State* L, const std::string& regex,
                 foundMatching = true;
 
                 if (interpolationDuration == 0.0) {
-                    OsEng.renderEngine().scene()->removeInterpolation(prop);
+                    OsEng.renderEngine().scene()->removePropertyInterpolation(prop);
                     prop->setLuaValue(L);
                 }
                 else {
                     prop->setLuaInterpolationTarget(L);
-                    OsEng.renderEngine().scene()->addInterpolation(
+                    OsEng.renderEngine().scene()->addPropertyInterpolation(
                         prop,
                         static_cast<float>(interpolationDuration),
                         easingFunction
@@ -183,12 +183,12 @@ int setPropertyCall_single(properties::Property& prop, const std::string& uri,
     }
     else {
         if (duration == 0.0) {
-            OsEng.renderEngine().scene()->removeInterpolation(&prop);
+            OsEng.renderEngine().scene()->removePropertyInterpolation(&prop);
             prop.setLuaValue(L);
         }
         else {
             prop.setLuaInterpolationTarget(L);
-            OsEng.renderEngine().scene()->addInterpolation(
+            OsEng.renderEngine().scene()->addPropertyInterpolation(
                 &prop,
                 static_cast<float>(duration),
                 eastingFunction

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -106,7 +106,10 @@ bool Time::togglePause() {
 }
 
 void Time::setTime(std::string time, bool requireJump) {
+    LINFOC("A", time);
     _time = SpiceManager::ref().ephemerisTimeFromDate(std::move(time));
+    LINFOC("B", std::to_string(_time));
+
     _timeJumped = requireJump;
 }
 

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -106,9 +106,7 @@ bool Time::togglePause() {
 }
 
 void Time::setTime(std::string time, bool requireJump) {
-    LINFOC("A", time);
     _time = SpiceManager::ref().ephemerisTimeFromDate(std::move(time));
-    LINFOC("B", std::to_string(_time));
 
     _timeJumped = requireJump;
 }


### PR DESCRIPTION
Time interpolation instead of fixed jump

@emiax   Could you give this a spin and give feedback?  The time interpolation doesn't end at the correct time, and the difference seems to depend both on the total time travelled as well as the framerate.

To test:
```lua
openspace.time.setDeltaTime(0);
openspace.time.setTime("2018 JUL 01");
openspace.time.setTime("2018 JUL 02", 5);
```