### PR TITLE
Feature/model lighting

### DIFF
--- a/data/assets/scene/solarsystem/missions/dawn/dawn.asset
+++ b/data/assets/scene/solarsystem/missions/dawn/dawn.asset
@@ -1,7 +1,7 @@
 local assetHelper = asset.require('util/asset_helper')
 local transforms = asset.require('scene/solarsystem/sun/transforms')
 local kernels = asset.require('./dawn_kernels').Kernels
-
+local sunTransforms = asset.require('scene/solarsystem/sun/transforms')
 
 
 local textures = asset.syncedResource({
@@ -616,6 +616,20 @@ local KernelFiles = {
     -- kernels .. "/dawn_sa_120910_120916.bc",
 }
 
+local LightSources = {
+    {
+        Type = "SceneGraphLightSource",
+        Identifier = "Sun",
+        Node = sunTransforms.SolarSystemBarycenter.Identifier,
+        Intensity = 1.0
+    },
+    {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 0.5
+    }
+}
+
 local Dawn = {
     Identifier = "Dawn",
     Parent = transforms.SolarSystemBarycenter.Identifier,
@@ -640,7 +654,8 @@ local Dawn = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/mainbodydawn.obj"
         },
-        ColorTexture = textures .. "/gray.png"
+        ColorTexture = textures .. "/gray.png",
+        LightSources = LightSources
     },
     GUI = {
         Path = "/Solar System/Missions/Dawn"
@@ -665,7 +680,8 @@ local DawnSolarArray1 = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/solarpanelleft.obj"
         },
-        ColorTexture = textures .. "/gray.png"
+        ColorTexture = textures .. "/gray.png",
+        LightSources = LightSources
     },
     GUI = {
         Name = "Dawn Solar 1",
@@ -691,7 +707,8 @@ local DawnSolarArray2 = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/solarpanelright.obj"
         },
-        ColorTexture = textures .. "/gray.png"
+        ColorTexture = textures .. "/gray.png",
+        LightSources = LightSources
     },
     GUI = {
         Name = "Dawn Solar 2",

--- a/data/assets/scene/solarsystem/missions/juno/juno.asset
+++ b/data/assets/scene/solarsystem/missions/juno/juno.asset
@@ -1,5 +1,6 @@
 local assetHelper = asset.require('util/asset_helper')
 local transforms = asset.require('scene/solarsystem/planets/jupiter/transforms')
+local sunTransforms = asset.require('scene/solarsystem/sun/transforms')
 
 
 local textures = asset.syncedResource({
@@ -159,7 +160,20 @@ local Juno = {
             GeometryFile = model .. "/Juno.obj"
         }, 
         ColorTexture =  textures .. "/gray.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = {
+            {
+                Type = "SceneGraphLightSource",
+                Identifier = "Sun",
+                Node = sunTransforms.SolarSystemBarycenter.Identifier,
+                Intensity = 1.0
+            },
+            {
+                Identifier = "Camera",
+                Type = "CameraLightSource",
+                Intensity = 0.5
+            }
+        }
     },
     GUI = {
         Path = "/Solar System/Missions/Juno"

--- a/data/assets/scene/solarsystem/missions/messenger/messengerSC.asset
+++ b/data/assets/scene/solarsystem/missions/messenger/messengerSC.asset
@@ -55,6 +55,20 @@ local RotationMatrix = {
     1, 0, 0
 }
 
+local LightSources = {
+    {
+        Type = "SceneGraphLightSource",
+        Identifier = "Sun",
+        Node = sunTransforms.SolarSystemBarycenter.Identifier,
+        Intensity = 1.0
+    },
+    {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 0.5
+    }
+}
+
 local Messenger = {
     Identifier = "Messenger",
     Parent = sunTransforms.SolarSystemBarycenter.Identifier,
@@ -87,7 +101,8 @@ local MessengerProbeBlack = {
             GeometryFile = models .. "/MessengerProbe_black.obj"
         },
         ColorTexture = models .. "/Tex_black.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "MessengerProbe Black",
@@ -105,7 +120,8 @@ local MessengerProbeFoil = {
             GeometryFile = models .. "/MessengerProbe_foil.obj"
         },
         ColorTexture = models .. "/foil_n2.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "MessengerProbe foil",
@@ -123,7 +139,8 @@ local MessengerProbeHeatShield = {
             GeometryFile = models .. "/MessengerProbe_heatShield.obj"
         },
         ColorTexture = models .. "/AO_heatshield4.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "MessengerProbe Heat Sheild",
@@ -142,7 +159,8 @@ local MessengerProbeMetal = {
             GeometryFile = models .. "/MessengerProbe_metal.obj"
         },
         ColorTexture = models .. "/Tex_grey.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "MessengerProbe Metal",
@@ -161,7 +179,8 @@ local MessengerProbePanels = {
             GeometryFile = models .. "/MessengerProbe_panels.obj"
         },
         ColorTexture = models .. "/Messenger_tex.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "MessengerProbe Panels",

--- a/data/assets/scene/solarsystem/missions/newhorizons/label.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/label.asset
@@ -18,7 +18,7 @@ local Labels = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/Labels.obj"
         }, 
-        ColorTexture =  textures .. "/labels.png"
+        ColorTexture =  textures .. "/labels.png",
         AmbientIntensity = 0.8,
         DiffuseIntensity = 1.0,
         SpecularIntensity = 1.0

--- a/data/assets/scene/solarsystem/missions/newhorizons/label.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/label.asset
@@ -19,9 +19,7 @@ local Labels = {
             GeometryFile = models .. "/Labels.obj"
         }, 
         ColorTexture =  textures .. "/labels.png",
-        AmbientIntensity = 0.8,
-        DiffuseIntensity = 1.0,
-        SpecularIntensity = 1.0
+        AmbientIntensity = 0.8
     },
     GUI = {
         Path = "/Solar System/Missions/New Horizons"

--- a/data/assets/scene/solarsystem/missions/newhorizons/label.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/label.asset
@@ -19,6 +19,9 @@ local Labels = {
             GeometryFile = models .. "/Labels.obj"
         }, 
         ColorTexture =  textures .. "/labels.png"
+        AmbientIntensity = 0.8,
+        DiffuseIntensity = 1.0,
+        SpecularIntensity = 1.0
     },
     GUI = {
         Path = "/Solar System/Missions/New Horizons"

--- a/data/assets/scene/solarsystem/missions/newhorizons/model.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/model.asset
@@ -7,7 +7,7 @@ local textures = asset.syncedResource({
     Name = "New Horizons Textures",
     Type = "HttpSynchronization",
     Identifier = "newhorizons_textures",
-    Version = 2
+    Version = 3
 })
 
 local models = asset.syncedResource({
@@ -27,7 +27,10 @@ local NewHorizons = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/NewHorizonsCleanModel.obj"
         }, 
-        ColorTexture = textures .. "/NHTexture.jpg"
+        ColorTexture = textures .. "/NHTexture.jpg",
+        AmbientIntensity = 0.4,
+        DiffuseIntensity = 1.0,
+        SpecularIntensity = 1.0
     },
     GUI = {
         Name = "New Horizons",

--- a/data/assets/scene/solarsystem/missions/newhorizons/model.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/model.asset
@@ -27,21 +27,21 @@ local NewHorizons = {
             GeometryFile = models .. "/NewHorizonsCleanModel.obj"
         }, 
         ColorTexture = textures .. "/NHTexture.jpg",
-        AmbientIntensity = 0.4,
+        AmbientIntensity = 0.0,
         DiffuseIntensity = 1.0,
         SpecularIntensity = 1.0,
         LightSources = {
             {
                 Type = "SceneGraphLightSource",
                 Identifier = "Sun",
-                Reference = sunTransforms.SolarSystemBarycenter.Identifier,
+                Node = sunTransforms.SolarSystemBarycenter.Identifier,
                 Intensity = 1.0
+            },
+            {
+                Identifier = "Camera",
+                Type = "CameraLightSource",
+                Intensity = 0.5
             }
-            --{
-            --    Identifier = "Sun"
-            --    Type = "CameraLightSource",
-            --    Intensity = 1.0
-            --}
         }
     },
     GUI = {

--- a/data/assets/scene/solarsystem/missions/newhorizons/model.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/model.asset
@@ -1,7 +1,6 @@
 local assetHelper = asset.require('util/asset_helper')
 local transforms = asset.require('./transforms')
-
-
+local sunTransforms = asset.require('scene/solarsystem/sun/transforms')
 
 local textures = asset.syncedResource({
     Name = "New Horizons Textures",
@@ -30,7 +29,20 @@ local NewHorizons = {
         ColorTexture = textures .. "/NHTexture.jpg",
         AmbientIntensity = 0.4,
         DiffuseIntensity = 1.0,
-        SpecularIntensity = 1.0
+        SpecularIntensity = 1.0,
+        LightSources = {
+            {
+                Type = "SceneGraphLightSource",
+                Identifier = "Sun",
+                Reference = sunTransforms.SolarSystemBarycenter.Identifier,
+                Intensity = 1.0
+            }
+            --{
+            --    Identifier = "Sun"
+            --    Type = "CameraLightSource",
+            --    Intensity = 1.0
+            --}
+        }
     },
     GUI = {
         Name = "New Horizons",

--- a/data/assets/scene/solarsystem/missions/osirisrex/model.asset
+++ b/data/assets/scene/solarsystem/missions/osirisrex/model.asset
@@ -178,6 +178,20 @@ local OsirisRexKernels = {
     --openspace.spice.loadKernel(kernels .. "/Case11_60negLatitude.wmv")
 }
 
+local LightSources = {
+    {
+        Type = "SceneGraphLightSource",
+        Identifier = "Sun",
+        Node = sunTransforms.SolarSystemBarycenter.Identifier,
+        Intensity = 1.0
+    },
+    {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 0.5
+    }
+}
+
 -- Append the CaseDependentKernels at the end of the OsirisRexKernels set
 for i = 0, #CaseDependentKernels do
     OsirisRexKernels[#OsirisRexKernels + 1] = CaseDependentKernels[i]
@@ -206,7 +220,8 @@ local OsirisRex = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/orx_base_resized_12_sep_2016.obj"
         },
-        ColorTexture = textures .. "/osirisTex.png"
+        ColorTexture = textures .. "/osirisTex.png",
+        LightSources = LightSources
     },
     GUI = {
         Name = "OSIRIS REx",
@@ -235,7 +250,8 @@ local PolyCam = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/orx_polycam_resized_12_sep_2016.obj"
         }, 
-        ColorTexture = textures .. "/osirisTex.png"
+        ColorTexture = textures .. "/osirisTex.png",
+        LightSources = LightSources
     },
     GUI = {
         Name = "OCAMS POLYCAM",
@@ -253,7 +269,8 @@ local Rexis = {
             Type = "MultiModelGeometry",
             GeometryFile = models .. "/orx_rexis_resized_12_sep_2016.obj"
         }, 
-        ColorTexture = textures .. "/osirisTex.png"
+        ColorTexture = textures .. "/osirisTex.png",
+        LightSources = LightSources
     },
     Transform = {
         Translation = {

--- a/data/assets/scene/solarsystem/missions/rosetta/rosetta.asset
+++ b/data/assets/scene/solarsystem/missions/rosetta/rosetta.asset
@@ -75,6 +75,20 @@ local RosettaKernels = {
     kernels .. "/ROS_CGS_RSOC_V03.TPC"
 }
 
+local LightSources = {
+    {
+        Type = "SceneGraphLightSource",
+        Identifier = "Sun",
+        Node = sunTransforms.SolarSystemBarycenter.Identifier,
+        Intensity = 1.0
+    },
+    {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 0.5
+    }
+}
+
 local RotationMatrix = {
     0, 1, 0,
     0, 0, 1,
@@ -129,7 +143,8 @@ local RosettaBlackFoil = {
             GeometryFile = models .. "/black_foil.obj"
         },
         ColorTexture = textures .. "/foil_silver_ramp.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Black Foil",
@@ -148,7 +163,8 @@ local RosettaBlackParts = {
             GeometryFile = models .. "/black_parts.obj"
         },
         ColorTexture = textures .. "/foil_silver_ramp.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Black Parts",
@@ -167,7 +183,8 @@ local RosettaDish = {
             GeometryFile = models .. "/dish.obj"
         },
         ColorTexture = textures .. "/dish_AO.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Dish",
@@ -186,7 +203,8 @@ local RosettaParts = {
             GeometryFile = models .. "/parts.obj"
         },
         ColorTexture = textures .. "/parts2_AO.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Parts",
@@ -205,7 +223,8 @@ local RosettaSilverFoil = {
             GeometryFile = models .. "/silver_foil.obj"
         },
         ColorTexture = textures .. "/foil_silver_ramp.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Silver Foil",
@@ -224,7 +243,8 @@ local RosettaVents = {
             GeometryFile = models .. "/vents.obj"
         },
         ColorTexture = textures .. "/tex_01.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Vents",
@@ -243,7 +263,8 @@ local RosettaWingA = {
             GeometryFile = models .."/wingA.obj"
         },
         ColorTexture = textures .. "/tex_01.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Wing A",
@@ -262,7 +283,8 @@ local RosettaWingB = {
             GeometryFile = models .. "/wingB.obj"
         },
         ColorTexture = textures .. "/tex_01.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Wing B",
@@ -281,7 +303,8 @@ local RosettaYellowFoil = {
             GeometryFile = models .. "/yellow_foil.obj"
         },
         ColorTexture = textures .. "/foil_gold_ramp.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Rosetta Model Part Yellow Foil",
@@ -329,7 +352,8 @@ local PhilaeFoil = {
             GeometryFile = models .. "/lander_foil.obj"
         },
         ColorTexture = textures .. "/foil_silver_ramp.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Philae Model Part Foil",
@@ -348,7 +372,8 @@ local PhilaeLids = {
             GeometryFile = models .. "/lander_lids.obj"
         },
         ColorTexture = textures .. "/parts2_AO.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Philae Model Part Lids",
@@ -367,7 +392,8 @@ local PhilaeParts = {
             GeometryFile = models .. "/lander_parts.obj"
         },
         ColorTexture = textures .. "/foil_silver_ramp.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Philae Model Part Parts",
@@ -386,7 +412,8 @@ local PhilaeSolarPanels = {
             GeometryFile = models .. "/lander_solarp.obj"
         },
         ColorTexture = textures .. "/tex_01.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Philae Model Parts Solar Panels",

--- a/data/assets/scene/solarsystem/missions/voyager/voyager1.asset
+++ b/data/assets/scene/solarsystem/missions/voyager/voyager1.asset
@@ -34,6 +34,20 @@ local RotationMatrix = {
     0, -1, 0
 }
 
+local LightSources = {
+    {
+        Type = "SceneGraphLightSource",
+        Identifier = "Sun",
+        Node = sunTransforms.SolarSystemBarycenter.Identifier,
+        Intensity = 1.0
+    },
+    {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 0.5
+    }
+}
+
 local Voyager1 = {
     Identifier = "Voyager_1",
     Parent = sunTransforms.SolarSystemBarycenter.Identifier,
@@ -66,7 +80,8 @@ local Voyager1Main = {
             GeometryFile = models .. "/voyager-main.obj"
         },
         ColorTexture = models .. "/voyager-main.jpg",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Voyager 1 Main",
@@ -84,7 +99,8 @@ local Voyager1Antenna = {
             GeometryFile = models .. "/voyager-antenna.obj"
         },
         ColorTexture = models .. "/voyager-antenna.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Voyager 1 Antanna",

--- a/data/assets/scene/solarsystem/missions/voyager/voyager2.asset
+++ b/data/assets/scene/solarsystem/missions/voyager/voyager2.asset
@@ -36,6 +36,21 @@ local RotationMatrix = {
     0, -1, 0
 }
 
+
+local LightSources = {
+    {
+        Type = "SceneGraphLightSource",
+        Identifier = "Sun",
+        Node = sunTransforms.SolarSystemBarycenter.Identifier,
+        Intensity = 1.0
+    },
+    {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 0.5
+    }
+}
+
 local Voyager2 = {
     Identifier = "Voyager_2",
     Parent = sunTransforms.SolarSystemBarycenter.Identifier,
@@ -68,7 +83,8 @@ local Voyager2Main = {
             GeometryFile = models .. "/voyager-main.obj"
         },
         ColorTexture = models .. "/voyager-main.jpg",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Voyager 2 Main",
@@ -86,7 +102,8 @@ local Voyager2Antenna = {
             GeometryFile = models .. "/voyager-antenna.obj"
         },
         ColorTexture = models .. "/voyager-antenna.png",
-        ModelTransform = RotationMatrix
+        ModelTransform = RotationMatrix,
+        LightSources = LightSources
     },
     GUI = {
         Name = "Voyager 2 Antanna",

--- a/include/openspace/scene/lightsource.h
+++ b/include/openspace/scene/lightsource.h
@@ -49,8 +49,7 @@ public:
     LightSource(const ghoul::Dictionary& dictionary);
     virtual ~LightSource() = default;
 
-    virtual glm::vec3 positionRelativeTo(const SceneGraphNode& node,
-                                         const RenderData& renderData) const = 0;
+    virtual glm::vec3 directionViewSpace(const RenderData& renderData) const = 0;
 
     virtual float intensity() const = 0;
 

--- a/modules/base/CMakeLists.txt
+++ b/modules/base/CMakeLists.txt
@@ -34,6 +34,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditempropertyvalue.h
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemsimulationincrement.h
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemspacing.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/lightsource/cameralightsource.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lightsource/scenegraphlightsource.h
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/modelgeometry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/multimodelgeometry.h
@@ -72,6 +73,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditempropertyvalue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemsimulationincrement.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemspacing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lightsource/cameralightsource.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lightsource/scenegraphlightsource.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/modelgeometry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/multimodelgeometry.cpp

--- a/modules/base/CMakeLists.txt
+++ b/modules/base/CMakeLists.txt
@@ -34,6 +34,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditempropertyvalue.h
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemsimulationincrement.h
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemspacing.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/lightsource/scenegraphlightsource.h
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/modelgeometry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/multimodelgeometry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/renderablemodel.h
@@ -71,6 +72,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditempropertyvalue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemsimulationincrement.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dashboarditemspacing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lightsource/scenegraphlightsource.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/modelgeometry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/multimodelgeometry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rendering/renderablemodel.cpp

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -33,6 +33,7 @@
 #include <modules/base/dashboard/dashboarditempropertyvalue.h>
 #include <modules/base/dashboard/dashboarditemsimulationincrement.h>
 #include <modules/base/dashboard/dashboarditemspacing.h>
+#include <modules/base/lightsource/cameralightsource.h>
 #include <modules/base/lightsource/scenegraphlightsource.h>
 #include <modules/base/rendering/renderablemodel.h>
 #include <modules/base/rendering/renderablesphere.h>
@@ -146,6 +147,7 @@ void BaseModule::internalInitialize(const ghoul::Dictionary&) {
     auto fLightSource = FactoryManager::ref().factory<LightSource>();
     ghoul_assert(fLightSource, "Light Source factory was not created");
 
+    fLightSource->registerClass<CameraLightSource>("CameraLightSource");
     fLightSource->registerClass<SceneGraphLightSource>("SceneGraphLightSource");
 
     auto fGeometry = FactoryManager::ref().factory<modelgeometry::ModelGeometry>();
@@ -191,6 +193,9 @@ std::vector<documentation::Documentation> BaseModule::documentations() const {
 
         TimeFrameInterval::Documentation(),
         TimeFrameUnion::Documentation(),
+
+        SceneGraphLightSource::Documentation(),
+        CameraLightSource::Documentation(),
 
         modelgeometry::ModelGeometry::Documentation(),
     };

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -33,6 +33,7 @@
 #include <modules/base/dashboard/dashboarditempropertyvalue.h>
 #include <modules/base/dashboard/dashboarditemsimulationincrement.h>
 #include <modules/base/dashboard/dashboarditemspacing.h>
+#include <modules/base/lightsource/scenegraphlightsource.h>
 #include <modules/base/rendering/renderablemodel.h>
 #include <modules/base/rendering/renderablesphere.h>
 #include <modules/base/rendering/renderablesphericalgrid.h>
@@ -141,6 +142,11 @@ void BaseModule::internalInitialize(const ghoul::Dictionary&) {
 
     fTimeFrame->registerClass<TimeFrameInterval>("TimeFrameInterval");
     fTimeFrame->registerClass<TimeFrameUnion>("TimeFrameUnion");
+
+    auto fLightSource = FactoryManager::ref().factory<LightSource>();
+    ghoul_assert(fLightSource, "Light Source factory was not created");
+
+    fLightSource->registerClass<SceneGraphLightSource>("SceneGraphLightSource");
 
     auto fGeometry = FactoryManager::ref().factory<modelgeometry::ModelGeometry>();
     ghoul_assert(fGeometry, "Model geometry factory was not created");

--- a/modules/base/lightsource/cameralightsource.cpp
+++ b/modules/base/lightsource/cameralightsource.cpp
@@ -29,7 +29,7 @@
 #include <openspace/util/updatestructures.h>
 
 namespace {
-    constexpr const openspace::properties::Property::PropertyInfo IntensityInfo = {
+    constexpr openspace::properties::Property::PropertyInfo IntensityInfo = {
         "Intensity",
         "Intensity",
         "The intensity of this light source"
@@ -90,7 +90,7 @@ float CameraLightSource::intensity() const {
 }
 
 glm::vec3 CameraLightSource::directionViewSpace(const RenderData& renderData) const {
-    return glm::vec3(0.0, 0.0, 1.0);
+    return glm::vec3(0.f, 0.f, 1.f);
 }
 
 

--- a/modules/base/lightsource/cameralightsource.cpp
+++ b/modules/base/lightsource/cameralightsource.cpp
@@ -45,6 +45,12 @@ documentation::Documentation CameraLightSource::Documentation() {
         "base_camera_light_source",
         {
             {
+                "Type",
+                new StringEqualVerifier("CameraLightSource"),
+                Optional::No,
+                "The type of this light source"
+            },
+            {
                 IntensityInfo.identifier,
                 new DoubleVerifier,
                 Optional::Yes,

--- a/modules/base/lightsource/cameralightsource.h
+++ b/modules/base/lightsource/cameralightsource.h
@@ -22,80 +22,32 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#ifndef __OPENSPACE_MODULE_BASE___RENDERABLEMODEL___H__
-#define __OPENSPACE_MODULE_BASE___RENDERABLEMODEL___H__
+#ifndef __OPENSPACE_MODULE_BASE___CAMREALIGHTSOURCE___H__
+#define __OPENSPACE_MODULE_BASE___CAMREALIGHTSOURCE___H__
 
-#include <openspace/rendering/renderable.h>
+#include <openspace/scene/lightsource.h>
 
-#include <openspace/properties/stringproperty.h>
-#include <openspace/properties/matrix/mat3property.h>
-#include <openspace/properties/scalar/boolproperty.h>
 #include <openspace/properties/scalar/floatproperty.h>
-#include <ghoul/opengl/uniformcache.h>
-#include <memory>
-
-namespace ghoul::opengl {
-    class ProgramObject;
-    class Texture;
-} // namespace ghoul::opengl
+#include <openspace/properties/stringproperty.h>
 
 namespace openspace {
 
-struct RenderData;
-struct UpdateData;
-class LightSource;
-
 namespace documentation { struct Documentation; }
-namespace modelgeometry { class ModelGeometry; }
 
-class RenderableModel : public Renderable {
+class CameraLightSource : public LightSource {
 public:
-    RenderableModel(const ghoul::Dictionary& dictionary);
-    ~RenderableModel();
-
-    void initialize() override;
-    void initializeGL() override;
-    void deinitializeGL() override;
-
-    bool isReady() const override;
-
-    void render(const RenderData& data, RendererTasks& rendererTask) override;
-    void update(const UpdateData& data) override;
+    CameraLightSource();
+    CameraLightSource(const ghoul::Dictionary& dictionary);
 
     static documentation::Documentation Documentation();
 
-protected:
-    void loadTexture();
+    glm::vec3 directionViewSpace(const RenderData& renderData) const override;
 
+    float intensity() const override;
 private:
-    void updateUniformCache();
-
-    std::unique_ptr<modelgeometry::ModelGeometry> _geometry;
-
-    properties::StringProperty _colorTexturePath;
-
-    properties::FloatProperty _ambientIntensity;
-    properties::FloatProperty _diffuseIntensity;
-    properties::FloatProperty _specularIntensity;
-
-    properties::BoolProperty _performShading;
-    properties::Mat3Property _modelTransform;
-
-    ghoul::opengl::ProgramObject* _programObject = nullptr;
-    UniformCache(opacity, nLightSources, lightDirectionsViewSpace, lightIntensities,
-        modelViewTransform, projectionTransform, performShading, texture,
-        ambientIntensity, diffuseIntensity, specularIntensity) _uniformCache;
-
-    std::unique_ptr<ghoul::opengl::Texture> _texture;
-    std::vector<std::unique_ptr<LightSource>> _lightSources;
-
-    // Buffers for uniform uploading
-    std::vector<float> _lightIntensitiesBuffer;
-    std::vector<glm::vec3> _lightDirectionsViewSpaceBuffer;
-
-    properties::PropertyOwner _lightSourcePropertyOwner;
+    properties::FloatProperty _intensity;
 };
 
-}  // namespace openspace
+} // namespace openspace
 
-#endif // __OPENSPACE_MODULE_BASE___RENDERABLEMODEL___H__
+#endif // __OPENSPACE_MODULE_BASE___CAMREALIGHTSOURCE___H__

--- a/modules/base/lightsource/cameralightsource.h
+++ b/modules/base/lightsource/cameralightsource.h
@@ -22,8 +22,8 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#ifndef __OPENSPACE_MODULE_BASE___CAMREALIGHTSOURCE___H__
-#define __OPENSPACE_MODULE_BASE___CAMREALIGHTSOURCE___H__
+#ifndef __OPENSPACE_MODULE_BASE___CAMERALIGHTSOURCE___H__
+#define __OPENSPACE_MODULE_BASE___CAMERALIGHTSOURCE___H__
 
 #include <openspace/scene/lightsource.h>
 
@@ -42,12 +42,12 @@ public:
     static documentation::Documentation Documentation();
 
     glm::vec3 directionViewSpace(const RenderData& renderData) const override;
-
     float intensity() const override;
+
 private:
     properties::FloatProperty _intensity;
 };
 
 } // namespace openspace
 
-#endif // __OPENSPACE_MODULE_BASE___CAMREALIGHTSOURCE___H__
+#endif // __OPENSPACE_MODULE_BASE___CAMERALIGHTSOURCE___H__

--- a/modules/base/lightsource/scenegraphlightsource.cpp
+++ b/modules/base/lightsource/scenegraphlightsource.cpp
@@ -32,13 +32,13 @@
 #include <openspace/util/updatestructures.h>
 
 namespace {
-    constexpr const openspace::properties::Property::PropertyInfo IntensityInfo = {
+    constexpr openspace::properties::Property::PropertyInfo IntensityInfo = {
         "Intensity",
         "Intensity",
         "The intensity of this light source"
     };
 
-    constexpr const openspace::properties::Property::PropertyInfo NodeInfo = {
+    constexpr openspace::properties::Property::PropertyInfo NodeInfo = {
         "Node",
         "Node",
         "The identifier of the scene graph node to follow"
@@ -127,16 +127,15 @@ float SceneGraphLightSource::intensity() const {
 
 glm::vec3 SceneGraphLightSource::directionViewSpace(const RenderData& renderData) const {
     if (!_sceneGraphNode) {
-        return glm::vec3(0.0);
+        return glm::vec3(0.f);
     }
 
-    glm::dvec3 lightPosition = glm::vec4(
-        _sceneGraphNode->modelTransform() * glm::dvec4(0.0, 0.0, 0.0, 1.0)
-    );
+    const glm::dvec3 lightPosition =
+        _sceneGraphNode->modelTransform() * glm::dvec4(0.0, 0.0, 0.0, 1.0);
 
-    glm::dvec3 renderNodePosition = renderData.modelTransform.translation;
+    const glm::dvec3 renderNodePosition = renderData.modelTransform.translation;
 
-    glm::dvec3 lightDirectionViewSpace = renderData.camera.viewRotationMatrix() *
+    const glm::dvec3 lightDirectionViewSpace = renderData.camera.viewRotationMatrix() *
         glm::dvec4((lightPosition - renderNodePosition), 1.0);
 
     return glm::normalize(lightDirectionViewSpace);

--- a/modules/base/lightsource/scenegraphlightsource.cpp
+++ b/modules/base/lightsource/scenegraphlightsource.cpp
@@ -1,0 +1,119 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2018                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <modules/base/lightsource/scenegraphlightsource.h>
+
+#include <openspace/documentation/documentation.h>
+#include <openspace/documentation/verifier.h>
+#include <openspace/util/spicemanager.h>
+
+namespace {
+    constexpr const openspace::properties::Property::PropertyInfo IntensityInfo = {
+        "Intensity",
+        "Intensity",
+        "The intensity of this light source"
+    };
+
+    constexpr const openspace::properties::Property::PropertyInfo ReferenceInfo = {
+        "Reference",
+        "Reference",
+        "The identifier of the scene graph node to follow"
+    };
+} // namespace
+
+namespace openspace {
+
+documentation::Documentation SceneGraphLightSource::Documentation() {
+    using namespace openspace::documentation;
+    return {
+        "Scene Graph Light Source",
+        "base_scene_graph_light_source",
+        {
+            {
+                IntensityInfo.identifier,
+                new DoubleVerifier,
+                Optional::Yes,
+                IntensityInfo.description
+            },
+            {
+                ReferenceInfo.identifier,
+                new StringVerifier,
+                Optional::No,
+                ReferenceInfo.description
+            },
+        }
+    };
+}
+
+SceneGraphLightSource::SceneGraphLightSource()
+    : LightSource()
+    , _intensity(IntensityInfo, 1.f, 0.f, 1.f)
+    , _sceneGraphNodeReference(IntensityInfo, "")
+{
+    addProperty(_intensity);
+    addProperty(_sceneGraphNodeReference);
+}
+
+SceneGraphLightSource::SceneGraphLightSource(const ghoul::Dictionary& dictionary)
+    : LightSource(dictionary)
+    , _intensity(IntensityInfo, 1.f, 0.f, 1.f)
+    , _sceneGraphNodeReference(ReferenceInfo, "")
+{
+    addProperty(_intensity);
+    addProperty(_sceneGraphNodeReference);
+ 
+    documentation::testSpecificationAndThrow(Documentation(),
+                                             dictionary,
+                                             "SceneGraphLightSource");
+
+
+    if (dictionary.hasValue<std::string>(IntensityInfo.identifier)) {
+        _intensity = static_cast<float>(
+            dictionary.value<double>(IntensityInfo.identifier)
+        );
+    }
+
+    if (dictionary.hasValue<std::string>(ReferenceInfo.identifier)) {
+        _sceneGraphNodeReference =
+            dictionary.value<std::string>(ReferenceInfo.identifier);
+    }
+}
+
+bool SceneGraphLightSource::initialize() {
+    // Set up pointer to real scene graph node.
+    return true;
+}
+
+float SceneGraphLightSource::intensity() const {
+    return _intensity;
+}
+
+glm::vec3 SceneGraphLightSource::positionRelativeTo(
+    const SceneGraphNode& node,
+    const RenderData& renderData) const
+{
+    return glm::vec3(0.0);
+}
+
+} // namespace openspace

--- a/modules/base/lightsource/scenegraphlightsource.cpp
+++ b/modules/base/lightsource/scenegraphlightsource.cpp
@@ -54,6 +54,12 @@ documentation::Documentation SceneGraphLightSource::Documentation() {
         "base_scene_graph_light_source",
         {
             {
+                "Type",
+                new StringEqualVerifier("SceneGraphLightSource"),
+                Optional::No,
+                "The type of this light source"
+            },
+            {
                 IntensityInfo.identifier,
                 new DoubleVerifier,
                 Optional::Yes,

--- a/modules/base/lightsource/scenegraphlightsource.h
+++ b/modules/base/lightsource/scenegraphlightsource.h
@@ -22,73 +22,37 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#include "fragment.glsl"
+#ifndef __OPENSPACE_MODULE_BASE___SCENEGRAPHLIGHTSOURCE___H__
+#define __OPENSPACE_MODULE_BASE___SCENEGRAPHLIGHTSOURCE___H__
 
-in vec2 vs_st;
-in vec3 vs_normalViewSpace;
-in vec4 vs_positionCameraSpace;
-in float vs_screenSpaceDepth;
+#include <openspace/scene/lightsource.h>
 
-uniform float ambientIntensity = 0.2;
-uniform float diffuseIntensity = 1.0;
-uniform float specularIntensity = 1.0;
+#include <openspace/properties/scalar/floatproperty.h>
+#include <openspace/properties/scalar/boolproperty.h>
+#include <openspace/properties/stringproperty.h>
 
-uniform bool performShading = true;
+namespace openspace {
 
-uniform sampler2D texture1;
+namespace documentation { struct Documentation; }
 
-uniform int nLightSources;
-uniform vec3 lightDirectionsViewSpace[8];
-uniform float lightIntensities[8];
+class SceneGraphLightSource : public LightSource {
+public:
+    SceneGraphLightSource();
+    SceneGraphLightSource(const ghoul::Dictionary& dictionary);
 
-uniform float opacity = 1.0;
+    static documentation::Documentation Documentation();
 
-const vec3 SpecularAlbedo = vec3(1.0);
+    glm::vec3 positionRelativeTo(const SceneGraphNode& node,
+                                 const RenderData& renderData) const override;
 
-Fragment getFragment() {
-    vec3 diffuseAlbedo = texture(texture1, vs_st).rgb;
+    float intensity() const override;
 
-    Fragment frag;
+    bool initialize();
+private:
+    properties::FloatProperty _intensity;
+    properties::StringProperty _sceneGraphNodeReference;
+};
 
-    if (performShading) {
-        // Some of these values could be passed in as uniforms
-        const vec3 lightColorAmbient = vec3(1.0);
-        const vec3 lightColor = vec3(1.0);
-        
-        vec3 n = normalize(vs_normalViewSpace);
-        vec3 c = normalize(vs_positionCameraSpace.xyz);
+} // namespace openspace
 
-        vec3 color = ambientIntensity * lightColorAmbient * diffuseAlbedo;
-
-        for (int i = 0; i < nLightSources; ++i) {
-            vec3 l = lightDirectionsViewSpace[i];
-            vec3 r = reflect(l, n);
-
-            float diffuseCosineFactor = dot(n,l);
-            float specularCosineFactor = dot(c,r);
-            const float specularPower = 100.0;
-
-            vec3 diffuseColor =
-                diffuseIntensity * lightColor * diffuseAlbedo *
-                max(diffuseCosineFactor, 0);
-
-            vec3 specularColor =
-                specularIntensity * lightColor * SpecularAlbedo *
-                pow(max(specularCosineFactor, 0), specularPower);
-
-            color += lightIntensities[i] * (diffuseColor + specularColor);
-        }
-        frag.color.rgb = color;
-    }
-    else {
-        frag.color.rgb = diffuseAlbedo;
-    }
-
-    frag.color.a    = opacity;
-    frag.depth      = vs_screenSpaceDepth;
-    frag.gPosition  = vs_positionCameraSpace;
-    frag.gNormal    = vec4(vs_normalViewSpace, 1.0);
-
-
-    return frag;
-}
+#endif // __OPENSPACE_MODULE_BASE___SCENEGRAPHLIGHTSOURCE___H__

--- a/modules/base/lightsource/scenegraphlightsource.h
+++ b/modules/base/lightsource/scenegraphlightsource.h
@@ -41,16 +41,15 @@ public:
 
     static documentation::Documentation Documentation();
 
+    bool initialize() override;
     glm::vec3 directionViewSpace(const RenderData& renderData) const override;
-
     float intensity() const override;
 
-    bool initialize() override;
 private:
     properties::FloatProperty _intensity;
     properties::StringProperty _sceneGraphNodeReference;
 
-    SceneGraphNode* _sceneGraphNode;
+    SceneGraphNode* _sceneGraphNode = nullptr;
 };
 
 } // namespace openspace

--- a/modules/base/lightsource/scenegraphlightsource.h
+++ b/modules/base/lightsource/scenegraphlightsource.h
@@ -28,7 +28,6 @@
 #include <openspace/scene/lightsource.h>
 
 #include <openspace/properties/scalar/floatproperty.h>
-#include <openspace/properties/scalar/boolproperty.h>
 #include <openspace/properties/stringproperty.h>
 
 namespace openspace {
@@ -42,15 +41,16 @@ public:
 
     static documentation::Documentation Documentation();
 
-    glm::vec3 positionRelativeTo(const SceneGraphNode& node,
-                                 const RenderData& renderData) const override;
+    glm::vec3 directionViewSpace(const RenderData& renderData) const override;
 
     float intensity() const override;
 
-    bool initialize();
+    bool initialize() override;
 private:
     properties::FloatProperty _intensity;
     properties::StringProperty _sceneGraphNodeReference;
+
+    SceneGraphNode* _sceneGraphNode;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -240,6 +240,12 @@ bool RenderableModel::isReady() const {
     return _programObject && _texture;
 }
 
+void RenderableModel::initialize() {
+    for (auto& ls : _lightSources) {
+        ls->initialize();
+    }
+}
+
 void RenderableModel::initializeGL() {
     _programObject = BaseModule::ProgramObjectManager.requestProgramObject(
         ProgramName,
@@ -289,13 +295,6 @@ void RenderableModel::render(const RenderData& data, RendererTasks&) {
     const glm::dmat4 modelViewTransform = data.camera.combinedViewMatrix() *
                                           modelTransform;
 
-    /*const glm::vec3 directionToSun = glm::normalize(
-        _sunPos - data.modelTransform.translation
-    );
-    const glm::vec3 directionToSunViewSpace =
-        glm::normalize(glm::mat3(data.camera.combinedViewMatrix()) * directionToSun);*/
-
-
     int nLightSources = 0;
     _lightIntensitiesBuffer.resize(_lightSources.size());
     _lightDirectionsViewSpaceBuffer.resize(_lightSources.size());
@@ -304,7 +303,7 @@ void RenderableModel::render(const RenderData& data, RendererTasks&) {
             continue;
         }
         _lightIntensitiesBuffer[nLightSources] = lightSource->intensity();
-        _lightDirectionsViewSpaceBuffer[nLightSources] = glm::normalize(glm::vec3(1.0));
+        _lightDirectionsViewSpaceBuffer[nLightSources] = lightSource->directionViewSpace(data);
         ++nLightSources;
     }
 

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -241,7 +241,7 @@ bool RenderableModel::isReady() const {
 }
 
 void RenderableModel::initialize() {
-    for (auto& ls : _lightSources) {
+    for (const std::unique_ptr<LightSource>& ls : _lightSources) {
         ls->initialize();
     }
 }
@@ -298,12 +298,14 @@ void RenderableModel::render(const RenderData& data, RendererTasks&) {
     int nLightSources = 0;
     _lightIntensitiesBuffer.resize(_lightSources.size());
     _lightDirectionsViewSpaceBuffer.resize(_lightSources.size());
-    for (const auto& lightSource : _lightSources) {
+    for (const std::unique_ptr<LightSource>& lightSource : _lightSources) {
         if (!lightSource->isEnabled()) {
             continue;
         }
         _lightIntensitiesBuffer[nLightSources] = lightSource->intensity();
-        _lightDirectionsViewSpaceBuffer[nLightSources] = lightSource->directionViewSpace(data);
+        _lightDirectionsViewSpaceBuffer[nLightSources] =
+            lightSource->directionViewSpace(data);
+
         ++nLightSources;
     }
 

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -65,15 +65,23 @@ protected:
     void loadTexture();
 
 private:
+    void updateUniformCache();
+
     std::unique_ptr<modelgeometry::ModelGeometry> _geometry;
 
     properties::StringProperty _colorTexturePath;
+
+    properties::FloatProperty _ambientIntensity;
+    properties::FloatProperty _diffuseIntensity;
+    properties::FloatProperty _specularIntensity;
+
     properties::BoolProperty _performShading;
     properties::Mat3Property _modelTransform;
 
     ghoul::opengl::ProgramObject* _programObject = nullptr;
     UniformCache(opacity, directionToSunViewSpace, modelViewTransform,
-        projectionTransform, performShading, texture) _uniformCache;
+        projectionTransform, performShading, texture, ambientIntensity,
+        diffuseIntensity, specularIntensity) _uniformCache;
 
     std::unique_ptr<ghoul::opengl::Texture> _texture;
 

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -43,6 +43,7 @@ namespace openspace {
 
 struct RenderData;
 struct UpdateData;
+class LightSource;
 
 namespace documentation { struct Documentation; }
 namespace modelgeometry { class ModelGeometry; }
@@ -50,6 +51,7 @@ namespace modelgeometry { class ModelGeometry; }
 class RenderableModel : public Renderable {
 public:
     RenderableModel(const ghoul::Dictionary& dictionary);
+    ~RenderableModel();
 
     void initializeGL() override;
     void deinitializeGL() override;
@@ -79,13 +81,18 @@ private:
     properties::Mat3Property _modelTransform;
 
     ghoul::opengl::ProgramObject* _programObject = nullptr;
-    UniformCache(opacity, directionToSunViewSpace, modelViewTransform,
-        projectionTransform, performShading, texture, ambientIntensity,
-        diffuseIntensity, specularIntensity) _uniformCache;
+    UniformCache(opacity, nLightSources, lightDirectionsViewSpace, lightIntensities,
+        modelViewTransform, projectionTransform, performShading, texture,
+        ambientIntensity, diffuseIntensity, specularIntensity) _uniformCache;
 
     std::unique_ptr<ghoul::opengl::Texture> _texture;
+    std::vector<std::unique_ptr<LightSource>> _lightSources;
 
-    glm::dvec3 _sunPos;
+    // Buffers for uniform uploading
+    std::vector<float> _lightIntensitiesBuffer;
+    std::vector<glm::vec3> _lightDirectionsViewSpaceBuffer;
+
+    properties::PropertyOwner _lightSourcePropertyOwner;
 };
 
 }  // namespace openspace

--- a/modules/base/shaders/model_fs.glsl
+++ b/modules/base/shaders/model_fs.glsl
@@ -29,6 +29,10 @@ in vec3 vs_normalViewSpace;
 in vec4 vs_positionCameraSpace;
 in float vs_screenSpaceDepth;
 
+uniform float ambientIntensity = 0.2;
+uniform float diffuseIntensity = 1.0;
+uniform float specularIntensity = 1.0;
+
 uniform bool performShading = true;
 uniform vec3 directionToSunViewSpace;
 uniform sampler2D texture1;
@@ -50,10 +54,6 @@ Fragment getFragment() {
         vec3 l = directionToSunViewSpace;
         vec3 c = normalize(vs_positionCameraSpace.xyz);
         vec3 r = reflect(l, n);
-
-        const float ambientIntensity = 0.2;
-        const float diffuseIntensity = 1;
-        const float specularIntensity = 1;
 
         float diffuseCosineFactor = dot(n,l);
         float specularCosineFactor = dot(c,r);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,7 +144,7 @@ set(OPENSPACE_SOURCE
     ${OPENSPACE_BASE_DIR}/src/scene/assetloader_lua.inl
     ${OPENSPACE_BASE_DIR}/src/scene/assetmanager.cpp
     ${OPENSPACE_BASE_DIR}/src/scene/assetmanager_lua.inl
-    ${OPENSPACE_BASE_DIR}/src/scene/translation.cpp
+    ${OPENSPACE_BASE_DIR}/src/scene/lightsource.cpp
     ${OPENSPACE_BASE_DIR}/src/scene/rotation.cpp
     ${OPENSPACE_BASE_DIR}/src/scene/scale.cpp
     ${OPENSPACE_BASE_DIR}/src/scene/scene.cpp
@@ -155,6 +155,7 @@ set(OPENSPACE_SOURCE
     ${OPENSPACE_BASE_DIR}/src/scene/scenegraphnode.cpp
     ${OPENSPACE_BASE_DIR}/src/scene/scenegraphnode_doc.inl
     ${OPENSPACE_BASE_DIR}/src/scene/timeframe.cpp
+    ${OPENSPACE_BASE_DIR}/src/scene/translation.cpp
     ${OPENSPACE_BASE_DIR}/src/scripting/lualibrary.cpp
     ${OPENSPACE_BASE_DIR}/src/scripting/scriptengine.cpp
     ${OPENSPACE_BASE_DIR}/src/scripting/scriptengine_lua.inl
@@ -325,7 +326,7 @@ set(OPENSPACE_HEADER
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/assetlistener.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/assetloader.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/assetmanager.h
-    ${OPENSPACE_BASE_DIR}/include/openspace/scene/translation.h
+    ${OPENSPACE_BASE_DIR}/include/openspace/scene/lightsource.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/rotation.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/scale.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/scene.h
@@ -334,6 +335,7 @@ set(OPENSPACE_HEADER
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/scenelicensewriter.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/scenegraphnode.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scene/timeframe.h
+    ${OPENSPACE_BASE_DIR}/include/openspace/scene/translation.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scripting/lualibrary.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scripting/scriptengine.h
     ${OPENSPACE_BASE_DIR}/include/openspace/scripting/scriptscheduler.h

--- a/src/documentation/core_registration.cpp
+++ b/src/documentation/core_registration.cpp
@@ -38,6 +38,7 @@
 #include <openspace/rendering/renderable.h>
 #include <openspace/rendering/renderengine.h>
 #include <openspace/rendering/screenspacerenderable.h>
+#include <openspace/scene/lightsource.h>
 #include <openspace/scene/rotation.h>
 #include <openspace/scene/scene.h>
 #include <openspace/scene/scenegraphnode.h>
@@ -64,6 +65,7 @@ void registerCoreClasses(documentation::DocumentationEngine& engine) {
     engine.addDocumentation(TimeRange::Documentation());
     engine.addDocumentation(Translation::Documentation());
     engine.addDocumentation(TimeFrame::Documentation());
+    engine.addDocumentation(LightSource::Documentation());
 }
 
 void registerCoreClasses(scripting::ScriptEngine& engine) {

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -51,6 +51,7 @@
 #include <openspace/scene/rotation.h>
 #include <openspace/scene/scale.h>
 #include <openspace/scene/timeframe.h>
+#include <openspace/scene/lightsource.h>
 #include <openspace/scene/sceneinitializer.h>
 #include <openspace/scene/translation.h>
 #include <openspace/scripting/scriptscheduler.h>
@@ -206,6 +207,10 @@ OpenSpaceEngine::OpenSpaceEngine(std::string programName,
     FactoryManager::ref().addFactory(
         std::make_unique<ghoul::TemplateFactory<TimeFrame>>(),
         "TimeFrame"
+    );
+    FactoryManager::ref().addFactory(
+        std::make_unique<ghoul::TemplateFactory<LightSource>>(),
+        "LightSource"
     );
     FactoryManager::ref().addFactory(
         std::make_unique<ghoul::TemplateFactory<Task>>(),

--- a/src/scene/lightsource.cpp
+++ b/src/scene/lightsource.cpp
@@ -1,0 +1,126 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2018                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <openspace/scene/lightsource.h>
+
+#include <openspace/documentation/documentation.h>
+#include <openspace/documentation/verifier.h>
+#include <openspace/util/factorymanager.h>
+
+#include <openspace/scene/scenegraphnode.h>
+#include <openspace/util/updatestructures.h>
+
+#include <ghoul/logging/logmanager.h>
+#include <ghoul/misc/dictionary.h>
+#include <ghoul/misc/templatefactory.h>
+
+namespace {
+    constexpr const char* KeyType = "Type";
+
+    constexpr const char* KeyIdentifier = "Identifier";
+
+    constexpr const openspace::properties::Property::PropertyInfo EnabledInfo = {
+        "Enabled",
+        "Enabled",
+        "Whether the light source is enabled or not"
+    };
+} // namespace
+
+namespace openspace {
+
+bool LightSource::isEnabled() const
+{
+    return _enabled;
+}
+
+documentation::Documentation LightSource::Documentation() {
+    using namespace openspace::documentation;
+
+    return {
+        "Light Source",
+        "core_light_source",
+        {
+
+            {
+                KeyType,
+                new StringAnnotationVerifier("Must name a valid LightSource type"),
+                Optional::No,
+                "The type of the light source that is described in this element. "
+                "The available types of light sources depend on the configuration "
+                "of the application and can be written to disk on "
+                "application startup into the FactoryDocumentation."
+            },
+            {
+                KeyIdentifier,
+                new StringVerifier,
+                Optional::No,
+                "The identifier of the light source."
+            },
+            {
+                EnabledInfo.identifier,
+                new BoolVerifier,
+                Optional::Yes,
+                EnabledInfo.description
+            }
+        }
+    };
+}
+
+std::unique_ptr<LightSource> LightSource::createFromDictionary(const ghoul::Dictionary& dictionary) {
+    documentation::testSpecificationAndThrow(Documentation(), dictionary, "LightSource");
+
+    const std::string timeFrameType = dictionary.value<std::string>(KeyType);
+
+    auto factory = FactoryManager::ref().factory<LightSource>();
+    std::unique_ptr<LightSource> result = factory->create(timeFrameType, dictionary);
+
+    const std::string identifier = dictionary.value<std::string>(KeyIdentifier);
+    result->setIdentifier(identifier);
+
+    return result;
+}
+
+LightSource::LightSource()
+    : properties::PropertyOwner({ "LightSource" })
+    , _enabled(EnabledInfo, true)
+{
+    addProperty(_enabled);
+}
+
+LightSource::LightSource(const ghoul::Dictionary& dictionary)
+    : properties::PropertyOwner({ "LightSource" })
+    , _enabled(EnabledInfo, true)
+{
+    if (dictionary.hasValue<std::string>(EnabledInfo.identifier)) {
+        _enabled = dictionary.value<bool>(EnabledInfo.identifier);
+    }
+
+    addProperty(_enabled);
+}
+
+bool LightSource::initialize() {
+    return true;
+}
+
+} // namespace openspace

--- a/src/scene/lightsource.cpp
+++ b/src/scene/lightsource.cpp
@@ -27,10 +27,8 @@
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/util/factorymanager.h>
-
 #include <openspace/scene/scenegraphnode.h>
 #include <openspace/util/updatestructures.h>
-
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/dictionary.h>
 #include <ghoul/misc/templatefactory.h>
@@ -40,7 +38,7 @@ namespace {
 
     constexpr const char* KeyIdentifier = "Identifier";
 
-    constexpr const openspace::properties::Property::PropertyInfo EnabledInfo = {
+    constexpr openspace::properties::Property::PropertyInfo EnabledInfo = {
         "Enabled",
         "Enabled",
         "Whether the light source is enabled or not"
@@ -49,8 +47,7 @@ namespace {
 
 namespace openspace {
 
-bool LightSource::isEnabled() const
-{
+bool LightSource::isEnabled() const {
     return _enabled;
 }
 
@@ -61,7 +58,6 @@ documentation::Documentation LightSource::Documentation() {
         "Light Source",
         "core_light_source",
         {
-
             {
                 KeyType,
                 new StringAnnotationVerifier("Must name a valid LightSource type"),
@@ -87,7 +83,9 @@ documentation::Documentation LightSource::Documentation() {
     };
 }
 
-std::unique_ptr<LightSource> LightSource::createFromDictionary(const ghoul::Dictionary& dictionary) {
+std::unique_ptr<LightSource> LightSource::createFromDictionary(
+    const ghoul::Dictionary& dictionary)
+{
     documentation::testSpecificationAndThrow(Documentation(), dictionary, "LightSource");
 
     const std::string timeFrameType = dictionary.value<std::string>(KeyType);


### PR DESCRIPTION
- Remove hard coded sun light source for RenderableModel
- Introduce LightSource interface
- Implement CameraLightSource, to always follow camera
- Implement SceneGraphLightSource to follow scene graph node
- Change model shader to accept up to 8 light sources
- Add properties to RenderableModel for diffuse, ambient and specular intensities
- Fix New Horizons label texture, so that the colors align with the text

All light sources are directional at this point. Keeping it simple. This may need to be redone if we go more into the deferred shading direction, but this should be useful until we get there.