### PR TITLE
Use bin folder instead of cwd to find configuration file

### DIFF
--- a/src/engine/configuration.cpp
+++ b/src/engine/configuration.cpp
@@ -309,7 +309,7 @@ void parseLuaState(Configuration& configuration) {
 std::string findConfiguration(const std::string& filename) {
     using ghoul::filesystem::Directory;
 
-    Directory directory = FileSys.currentDirectory();
+    Directory directory = FileSys.absolutePath("${BIN}");
 
     while (true) {
         std::string fullPath = FileSys.pathByAppendingComponent(


### PR DESCRIPTION
@micahnyc pointed out that when double clicking an application on mac, the current working directory is set to "/". One way to get around this problem would be to set cwd to the application path, using NSGetExecutablePath. However, instead, I suggest that we don't change the current working directory, and use the newly introduced ${BIN} to find the configuration file.

Let me know what your thoughts are. I have only tested this on mac yet.