### PR TITLE
Introduce ability to configure ports etc for external applications.

### DIFF
--- a/data/assets/util/webgui.asset
+++ b/data/assets/util/webgui.asset
@@ -33,7 +33,7 @@ asset.onInitialize(function ()
             "Modules.WebGui.ServerProcessEntryPoint", backend .. "/backend.js"
         )
         openspace.setPropertyValueSingle(
-            "Modules.WebGui.ServerProcessWorkingDirectory", frontend .. "/frontend"
+            "Modules.WebGui.WebDirectory", frontend .. "/frontend"
         )
         openspace.setPropertyValueSingle("Modules.WebGui.ServerProcessEnabled", true)
     end

--- a/include/openspace/engine/configuration.h
+++ b/include/openspace/engine/configuration.h
@@ -105,10 +105,6 @@ struct Configuration {
     };
     OpenGLDebugContext openGLDebugContext;
 
-    std::string serverPasskey = "17308";
-    bool doesRequireSocketAuthentication = true;
-    std::vector<std::string> clientAddressWhitelist = {};
-
     struct HTTPProxy {
         bool usingHttpProxy = false;
         std::string address;

--- a/modules/cefwebgui/cefwebguimodule.cpp
+++ b/modules/cefwebgui/cefwebguimodule.cpp
@@ -22,9 +22,10 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#include <modules/webbrowser/webbrowsermodule.h>
-
 #include <modules/cefwebgui/cefwebguimodule.h>
+
+#include <modules/webbrowser/webbrowsermodule.h>
+#include <modules/webgui/webguimodule.h>
 #include <modules/cefwebgui/include/guirenderhandler.h>
 #include <modules/cefwebgui/include/guikeyboardhandler.h>
 #include <modules/webbrowser/include/browserinstance.h>
@@ -131,7 +132,14 @@ void CefWebGuiModule::internalInitialize(const ghoul::Dictionary& configuration)
         }
     });
 
-    _url = configuration.value<std::string>(GuiUrlInfo.identifier);
+
+    if (configuration.hasValue<std::string>(GuiUrlInfo.identifier)) {
+        _url = configuration.value<std::string>(GuiUrlInfo.identifier);
+    } else {
+        WebGuiModule* webGuiModule = global::moduleEngine.module<WebGuiModule>();
+        _url = "http://localhost:" +
+            std::to_string(webGuiModule->port()) + "/#/onscreen";
+    }
 
     _enabled = configuration.hasValue<bool>(EnabledInfo.identifier) &&
                configuration.value<bool>(EnabledInfo.identifier);

--- a/modules/server/CMakeLists.txt
+++ b/modules/server/CMakeLists.txt
@@ -30,6 +30,7 @@ set(HEADER_FILES
     include/connection.h
     include/connectionpool.h
     include/jsonconverters.h
+    include/serverinterface.h
     include/topics/authorizationtopic.h
     include/topics/bouncetopic.h
     include/topics/getpropertytopic.h
@@ -49,6 +50,7 @@ set(SOURCE_FILES
     src/connection.cpp
     src/connectionpool.cpp
     src/jsonconverters.cpp
+    src/serverinterface.cpp
     src/topics/authorizationtopic.cpp
     src/topics/bouncetopic.cpp
     src/topics/getpropertytopic.cpp

--- a/modules/server/include/connection.h
+++ b/modules/server/include/connection.h
@@ -41,7 +41,12 @@ class Topic;
 
 class Connection {
 public:
-    Connection(std::unique_ptr<ghoul::io::Socket> s, std::string address);
+    Connection(
+        std::unique_ptr<ghoul::io::Socket> s,
+        std::string address,
+        bool authorized = false,
+        const std::string& password = ""
+    );
 
     void handleMessage(const std::string& message);
     void sendMessage(const std::string& message);
@@ -62,12 +67,9 @@ private:
     std::thread _thread;
 
     std::string _address;
-    bool _requireAuthorization;
     bool _isAuthorized = false;
     std::map<TopicId, std::string> _messageQueue;
     std::map<TopicId, std::chrono::system_clock::time_point> _sentMessages;
-
-    bool isWhitelisted() const;
 };
 
 } // namespace openspace

--- a/modules/server/include/topics/authorizationtopic.h
+++ b/modules/server/include/topics/authorizationtopic.h
@@ -31,7 +31,7 @@ namespace openspace {
 
 class AuthorizationTopic : public Topic {
 public:
-    AuthorizationTopic() = default;
+    AuthorizationTopic(std::string password);
 
     void handleJson(const nlohmann::json& json) override;
     bool isDone() const override;
@@ -39,6 +39,7 @@ public:
 private:
     bool authorize(const std::string& key);
 
+    std::string _password;
     bool _isAuthenticated = false;
 };
 

--- a/modules/server/servermodule.cpp
+++ b/modules/server/servermodule.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/server/servermodule.h>
 
+#include <modules/server/include/serverinterface.h>
 #include <modules/server/include/connection.h>
 #include <modules/server/include/topics/topic.h>
 #include <openspace/engine/globalscallbacks.h>
@@ -37,53 +38,102 @@
 
 namespace {
     constexpr const char* _loggerCat = "ServerModule";
+    constexpr const char* KeyInterfaces = "Interfaces";
 } // namespace
 
 namespace openspace {
 
-ServerModule::ServerModule() : OpenSpaceModule(ServerModule::Name) {}
+ServerModule::ServerModule()
+    : OpenSpaceModule(ServerModule::Name)
+    , _interfaceOwner({"Interfaces", "Interfaces", "Server Interfaces"})
+{
+    addPropertySubOwner(_interfaceOwner);
+}
 
 ServerModule::~ServerModule() {
     disconnectAll();
     cleanUpFinishedThreads();
 }
 
-void ServerModule::internalInitialize(const ghoul::Dictionary&) {
+ServerInterface* ServerModule::serverInterfaceByIdentifier(const std::string& identifier)
+{
+    const auto si = std::find_if(
+        _interfaces.begin(),
+        _interfaces.end(),
+        [identifier](std::unique_ptr<ServerInterface>& i) {
+            return i->identifier() == identifier;
+        }
+    );
+    if (si == _interfaces.end()) {
+        return nullptr;
+    }
+    return si->get();
+}
+
+void ServerModule::internalInitialize(const ghoul::Dictionary& configuration) {
     using namespace ghoul::io;
 
-    std::unique_ptr<TcpSocketServer> tcpServer = std::make_unique<TcpSocketServer>();
-    std::unique_ptr<WebSocketServer> wsServer = std::make_unique<WebSocketServer>();
+    if (configuration.hasValue<ghoul::Dictionary>(KeyInterfaces)) {
+        ghoul::Dictionary interfaces =
+            configuration.value<ghoul::Dictionary>(KeyInterfaces);
 
-    // Temporary hard coded addresses and ports.
-    tcpServer->listen("localhost", 8000);
-    wsServer->listen("localhost", 8001);
-    LDEBUG(fmt::format(
-        "TCP Server listening on {}:{}",tcpServer->address(), tcpServer->port()
-    ));
+        for (std::string& key : interfaces.keys()) {
+            if (!interfaces.hasValue<ghoul::Dictionary>(key)) {
+                continue;
+            }
+            ghoul::Dictionary interfaceDictionary =
+                interfaces.value<ghoul::Dictionary>(key);
 
-    LDEBUG(fmt::format(
-        "WS Server listening on {}:{}", wsServer->address(), wsServer->port()
-    ));
+            std::unique_ptr<ServerInterface> serverInterface =
+                ServerInterface::createFromDictionary(interfaceDictionary);
 
-    _servers.push_back(std::move(tcpServer));
-    _servers.push_back(std::move(wsServer));
+            serverInterface->initialize();
+
+            _interfaceOwner.addPropertySubOwner(serverInterface.get());
+            
+            if (serverInterface) {
+                _interfaces.push_back(std::move(serverInterface));
+            }
+        }
+
+    }
 
     global::callback::preSync.emplace_back([this]() { preSync(); });
 }
 
 void ServerModule::preSync() {
     // Set up new connections.
-    for (std::unique_ptr<ghoul::io::SocketServer>& server : _servers) {
+    for (std::unique_ptr<ServerInterface>& serverInterface : _interfaces) {
+        if (!serverInterface->isEnabled()) {
+            continue;
+        }
+
+        ghoul::io::SocketServer* socketServer = serverInterface->server();
+
+        if (!socketServer) {
+            continue;
+        }
+
         std::unique_ptr<ghoul::io::Socket> socket;
-        while ((socket = server->nextPendingSocket())) {
+        while ((socket = socketServer->nextPendingSocket())) {
+            std::string address = socket->address();
+            if (serverInterface->clientIsBlocked(address)) {
+                // Drop connection if the address is blocked.
+                continue;
+            }
             socket->startStreams();
             std::shared_ptr<Connection> connection = std::make_shared<Connection>(
                 std::move(socket),
-                server->address()
+                address,
+                false,
+                serverInterface->password()
             );
             connection->setThread(std::thread(
                 [this, connection] () { handleConnection(connection); }
             ));
+            if (serverInterface->clientHasAccessWithoutPassword(address)) {
+                connection->setAuthorized(true);
+            }
             _connections.push_back({ std::move(connection), false });
         }
     }
@@ -115,6 +165,10 @@ void ServerModule::cleanUpFinishedThreads() {
 }
 
 void ServerModule::disconnectAll() {
+    for (std::unique_ptr<ServerInterface>& serverInterface : _interfaces) {
+        serverInterface->deinitialize();
+    }
+
     for (ConnectionData& connectionData : _connections) {
         Connection& connection = *connectionData.connection;
         if (connection.socket() && connection.socket()->isConnected()) {

--- a/modules/server/servermodule.h
+++ b/modules/server/servermodule.h
@@ -27,11 +27,11 @@
 
 #include <openspace/util/openspacemodule.h>
 
+#include <modules/server/include/serverinterface.h>
+
 #include <deque>
 #include <memory>
 #include <mutex>
-
-namespace ghoul::io { class SocketServer; }
 
 namespace openspace {
 
@@ -53,6 +53,8 @@ public:
     ServerModule();
     virtual ~ServerModule();
 
+    ServerInterface* serverInterfaceByIdentifier(const std::string& identifier);
+
 protected:
     void internalInitialize(const ghoul::Dictionary& configuration) override;
 
@@ -72,7 +74,8 @@ private:
     std::deque<Message> _messageQueue;
 
     std::vector<ConnectionData> _connections;
-    std::vector<std::unique_ptr<ghoul::io::SocketServer>> _servers;
+    std::vector<std::unique_ptr<ServerInterface>> _interfaces;
+    properties::PropertyOwner _interfaceOwner;
 };
 
 } // namespace openspace

--- a/modules/server/src/serverinterface.cpp
+++ b/modules/server/src/serverinterface.cpp
@@ -1,0 +1,262 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2018                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <modules/server/include/serverinterface.h>
+#include <ghoul/io/socket/socketserver.h>
+
+#include <ghoul/io/socket/tcpsocketserver.h>
+#include <ghoul/io/socket/websocketserver.h>
+
+namespace {
+
+    constexpr const char* KeyIdentifier = "Identifier";
+    constexpr const char* TcpSocketType = "TcpSocket";
+    constexpr const char* WebSocketType = "WebSocket";
+    constexpr const char* DenyAccess = "Deny";
+    constexpr const char* RequirePassword = "RequirePassword";
+    constexpr const char* AllowAccess = "Allow";
+
+    constexpr openspace::properties::Property::PropertyInfo EnabledInfo = {
+        "Enabled",
+        "Is Enabled",
+        "This setting determines whether this server interface is enabled or not."
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo TypeInfo = {
+        "Type",
+        "Type",
+        "Whether the interface is using a Socket or a WebSocket"
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo PortInfo = {
+        "Port",
+        "Port",
+        "The network port to use for this sevrer interface"
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo DefaultAccessInfo = {
+        "DefaultAccess",
+        "Default Access",
+        "Sets the default access policy: Allow, RequirePassword or Deny"
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo AllowInfo = {
+        "Allow",
+        "Allow",
+        "Ip addresses or domains that should always be allowed access to this interface"
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo RequirePasswordInfo = {
+        "RequirePassword",
+        "Require Password",
+        "Ip addresses or domains that should be allowed access if they provide a password"
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo DenyInfo = {
+        "Deny",
+        "Deny",
+        "Ip addresses or domains that should never be allowed access to this interface"
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo PasswordInfo = {
+        "Password",
+        "Password",
+        "Password for connecting to this interface"
+    };
+}
+
+namespace openspace {
+
+std::unique_ptr<ServerInterface> ServerInterface::createFromDictionary(
+    const ghoul::Dictionary& config)
+{
+    // TODO: Use documentation to verify dictionary
+    std::unique_ptr<ServerInterface> si = std::make_unique<ServerInterface>(config);
+    return std::move(si);
+}
+
+ServerInterface::ServerInterface(const ghoul::Dictionary& config) 
+    : properties::PropertyOwner({ "", "", "" })
+    , _type(TypeInfo)
+    , _port(PortInfo, 0)
+    , _defaultAccess(DefaultAccessInfo)
+    , _allowAddresses(AllowInfo)
+    , _requirePasswordAddresses(RequirePasswordInfo)
+    , _denyAddresses(DenyInfo)
+    , _enabled(EnabledInfo)
+    , _password(PasswordInfo)
+{
+
+    _type.addOption(static_cast<int>(InterfaceType::TcpSocket), TcpSocketType);
+    _type.addOption(static_cast<int>(InterfaceType::WebSocket), WebSocketType);
+
+    _defaultAccess.addOption(static_cast<int>(Access::Deny), DenyAccess);
+    _defaultAccess.addOption(static_cast<int>(Access::RequirePassword), RequirePassword);
+    _defaultAccess.addOption(static_cast<int>(Access::Allow), AllowAccess);
+
+    const std::string identifier = config.value<std::string>(KeyIdentifier);
+
+    std::function readList =
+        [config](const std::string& key, properties::StringListProperty& list) {
+            if (config.hasValue<ghoul::Dictionary>(key)) {
+                const ghoul::Dictionary& dict = config.value<ghoul::Dictionary>(key);
+                std::vector<std::string> v;
+                for (const std::string& k : dict.keys()) {
+                    v.push_back(dict.value<std::string>(k));
+                }
+                list.set(v);
+            }
+        };
+    
+    readList(AllowInfo.identifier, _allowAddresses);
+    readList(DenyInfo.identifier, _denyAddresses);
+    readList(RequirePasswordInfo.identifier, _requirePasswordAddresses);
+
+    this->setIdentifier(identifier);
+    this->setGuiName(identifier);
+    this->setDescription("Settings for server interface " + identifier);
+
+    const std::string type = config.value<std::string>(TypeInfo.identifier);
+    if (type == TcpSocketType) {
+        _type = static_cast<int>(InterfaceType::TcpSocket);
+    } else if (type == WebSocketType) {
+        _type = static_cast<int>(InterfaceType::WebSocket);
+    }
+
+    if (config.hasValue<std::string>(PasswordInfo.identifier)) {
+        _password = config.value<std::string>(PasswordInfo.identifier);
+    }
+
+    _port = static_cast<int>(config.value<double>(PortInfo.identifier));
+    _enabled = config.value<bool>(EnabledInfo.identifier);
+
+    std::function<void()> reinitialize = [this]() {
+        deinitialize();
+        initialize();
+    };
+
+    _type.onChange(reinitialize);
+    _port.onChange(reinitialize);
+    _enabled.onChange(reinitialize);
+    _defaultAccess.onChange(reinitialize);
+    _allowAddresses.onChange(reinitialize);
+    _requirePasswordAddresses.onChange(reinitialize);
+    _denyAddresses.onChange(reinitialize);
+
+    addProperty(_type);
+    addProperty(_port);
+    addProperty(_enabled);
+    addProperty(_defaultAccess);
+    addProperty(_allowAddresses);
+    addProperty(_requirePasswordAddresses);
+    addProperty(_denyAddresses);
+    addProperty(_password);
+}
+
+ServerInterface::~ServerInterface() {}
+
+void ServerInterface::initialize() {
+    if (!_enabled) {
+        return;
+    }
+    switch (static_cast<InterfaceType>(_type.value())) {
+    case InterfaceType::TcpSocket:
+        _socketServer = std::make_unique<ghoul::io::TcpSocketServer>();
+        break;
+    case InterfaceType::WebSocket:
+        _socketServer = std::make_unique<ghoul::io::WebSocketServer>();
+        break;
+    }
+    _socketServer->listen(_port);
+}
+
+void ServerInterface::deinitialize() {
+    _socketServer->close();
+}
+
+bool ServerInterface::isEnabled() const {
+    return _enabled.value();
+}
+
+bool ServerInterface::isActive() const {
+    return _socketServer->isListening();
+}
+
+int ServerInterface::port() const {
+    return _port;
+}
+
+std::string ServerInterface::password() const {
+    return _password;
+}
+
+bool ServerInterface::clientHasAccessWithoutPassword(
+    const std::string& clientAddress) const
+{
+    for (const std::string& address : _allowAddresses.value()) {
+        if (clientAddress == address) {
+            return true;
+        }
+    }
+    Access access = static_cast<Access>(_defaultAccess.value());
+    if (access == Access::Allow) {
+        for (const std::string& address : _denyAddresses.value()) {
+            if (clientAddress == address) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+bool ServerInterface::clientIsBlocked(const std::string& clientAddress) const {
+    for (const std::string& address : _denyAddresses.value()) {
+        if (clientAddress == address) {
+            return true;
+        }
+    }
+    Access access = static_cast<Access>(_defaultAccess.value());
+    if (access == Access::Deny) {
+        for (const std::string& address : _allowAddresses.value()) {
+            if (clientAddress == address) {
+                return false;
+            }
+        }
+        for (const std::string& address : _requirePasswordAddresses.value()) {
+            if (clientAddress == address) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+ghoul::io::SocketServer* ServerInterface::server() {
+    return _socketServer.get();
+}
+
+
+}

--- a/modules/webgui/webguimodule.cpp
+++ b/modules/webgui/webguimodule.cpp
@@ -24,6 +24,9 @@
 
 #include <modules/webgui/webguimodule.h>
 
+#include <modules/server/servermodule.h>
+#include <openspace/engine/globals.h>
+#include <openspace/engine/moduleengine.h>
 #include <ghoul/fmt.h>
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/logging/logmanager.h>
@@ -38,20 +41,41 @@ namespace {
         "Enable the node js based process used to serve the Web GUI."
     };
 
+    constexpr openspace::properties::Property::PropertyInfo AddressInfo = {
+        "Address",
+        "Address",
+        "The network address to use when connecting to OpenSpace from the Web GUI."
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo PortInfo = {
+        "Port",
+        "Port",
+        "The network port to use when serving the Web GUI over HTTP."
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo WebSocketInterfaceInfo = {
+        "WebSocketInterface",
+        "WebSocket Interface",
+        "The identifier of the websocket interface to use when communicating."
+    };
+
     constexpr openspace::properties::Property::PropertyInfo ServerProcessEntryPointInfo =
     {
         "ServerProcessEntryPoint",
         "Server Process Entry Point",
-        "The node js command to invoke"
+        "The node js command to invoke."
     };
 
     constexpr openspace::properties::Property::PropertyInfo
-        ServerProcessWorkingDirectoryInfo =
+        WebDirectoryInfo =
     {
-        "ServerProcessWorkingDirectory",
-        "Server Process Working Directory",
-        "The working directory of the process"
+        "WebDirectory",
+        "Web Directory",
+        "Directory from which to to serve static content",
     };
+
+    constexpr const char* DefaultAddress = "localhost";
+    constexpr const int DefaultPort = 4680;
 }
 
 namespace openspace {
@@ -60,14 +84,40 @@ WebGuiModule::WebGuiModule()
     : OpenSpaceModule(WebGuiModule::Name)
     , _enabled(ServerProcessEnabledInfo, false)
     , _entryPoint(ServerProcessEntryPointInfo)
-    , _workingDirectory(ServerProcessWorkingDirectoryInfo)
+    , _webDirectory(WebDirectoryInfo)
+    , _address(AddressInfo, DefaultAddress)
+    , _port(PortInfo, DefaultPort)
+    , _webSocketInterface(WebSocketInterfaceInfo, "")
 {
     addProperty(_enabled);
     addProperty(_entryPoint);
-    addProperty(_workingDirectory);
+    addProperty(_webDirectory);
+    addProperty(_address);
+    addProperty(_port);
 }
 
-void WebGuiModule::internalInitialize(const ghoul::Dictionary&) {
+int WebGuiModule::port() const {
+    return _port;
+}
+
+std::string  WebGuiModule::address() const {
+    return _address;
+}
+
+void WebGuiModule::internalInitialize(const ghoul::Dictionary& configuration) {
+    if (configuration.hasValue<int>(PortInfo.identifier)) {
+        _port = configuration.value<int>(PortInfo.identifier);
+    }
+
+    if (configuration.hasValue<std::string>(AddressInfo.identifier)) {
+        _address = configuration.value<std::string>(AddressInfo.identifier);
+    }
+
+    if (configuration.hasValue<std::string>(WebSocketInterfaceInfo.identifier)) {
+        _webSocketInterface =
+            configuration.value<std::string>(WebSocketInterfaceInfo.identifier);
+    }
+
     auto startOrStop = [this]() {
         if (_enabled) {
             startProcess();
@@ -85,20 +135,39 @@ void WebGuiModule::internalInitialize(const ghoul::Dictionary&) {
 
     _enabled.onChange(startOrStop);
     _entryPoint.onChange(restartIfEnabled);
-    _workingDirectory.onChange(restartIfEnabled);
+    _webDirectory.onChange(restartIfEnabled);
+    _port.onChange(restartIfEnabled);
     startOrStop();
 }
 
 void WebGuiModule::startProcess() {
+    ServerModule* serverModule = global::moduleEngine.module<ServerModule>();
+    const ServerInterface* serverInterface =
+        serverModule->serverInterfaceByIdentifier(_webSocketInterface);
+    if (!serverInterface) {
+        LERROR("Missing server interface. Server process could not start.");
+        return;
+    }
+    const int webSocketPort = serverInterface->port();
+
+
 #ifdef _MSC_VER
     const std::string nodePath = absPath("${MODULE_WEBGUI}/ext/nodejs/node.exe");
 #else
     const std::string nodePath = absPath("${MODULE_WEBGUI}/ext/nodejs/node");
 #endif
 
+    const std::string command = "\"" + nodePath + "\" "
+        + "\"" + _entryPoint.value() + "\"" +
+        " --directory \"" + _webDirectory.value() + "\"" +
+        " --http-port \"" + std::to_string(_port.value()) + "\" " +
+        " --ws-address \"" + _address.value() + "\"" +
+        " --ws-port \"" + std::to_string(webSocketPort) + "\"" +
+        " --auto-close --local";
+
     _process = std::make_unique<ghoul::Process>(
-        "\"" + nodePath + "\" \"" + _entryPoint.value() + "\"",
-        _workingDirectory.value(),
+        command,
+        _webDirectory.value(),
         [](const char* data, size_t n) {
             const std::string str(data, n);
             LDEBUG(fmt::format("Web GUI server output: {}", str));

--- a/modules/webgui/webguimodule.h
+++ b/modules/webgui/webguimodule.h
@@ -28,6 +28,7 @@
 #include <openspace/util/openspacemodule.h>
 
 #include <openspace/properties/stringproperty.h>
+#include <openspace/properties/scalar/intproperty.h>
 #include <openspace/properties/scalar/boolproperty.h>
 #include <ghoul/misc/process.h>
 #include <memory>
@@ -38,6 +39,8 @@ class WebGuiModule : public OpenSpaceModule {
 public:
     static constexpr const char* Name = "WebGui";
     WebGuiModule();
+    int port() const;
+    std::string address() const;
 
 protected:
     void internalInitialize(const ghoul::Dictionary&) override;
@@ -49,7 +52,11 @@ private:
     std::unique_ptr<ghoul::Process> _process;
     properties::BoolProperty _enabled;
     properties::StringProperty _entryPoint;
-    properties::StringProperty _workingDirectory;
+    properties::StringProperty _webDirectory;
+
+    properties::IntProperty _port;
+    properties::StringProperty _address;
+    properties::StringProperty _webSocketInterface;
 };
 
 } // namespace openspace

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -86,12 +86,41 @@ ModuleConfigurations = {
             "data.openspaceproject.com/request"
         }
     },
+    Server = {
+        Interfaces = {
+            {
+                Type = "TcpSocket",
+                Identifier = "DefaultTcpSocketInterface",
+                Port = 4681,
+                Enabled = true,
+                DefaultAccess = "Deny",
+                Allow = {"127.0.0.1", "localhost"},
+                RequirePassword = {},
+                Password = ""
+            },
+            {
+                Type = "WebSocket",
+                Identifier = "DefaultWebSocketInterface",
+                Port = 4682,
+                Enabled = true,
+                DefaultAccess = "Deny",
+                Allow = {"127.0.0.1", "localhost"},
+                RequirePassword = {},
+                Password = ""
+            }
+        }
+    },
     WebBrowser = {
         Enabled = true,
         WebHelperLocation = "${BIN}/openspace_web_helper"
     },
+    WebGui = {
+        Address = "130.236.243.249",
+        HttpPort = 4680,
+        WebSocketInterface = "DefaultWebSocketInterface"
+    },
     CefWebGui = {
-        GuiUrl = "http://localhost:8080/#/onscreen/",
+        -- GuiUrl = "http://localhost:4680/#/onscreen/",
         Enabled = true,
         Visible = true
     }
@@ -154,9 +183,3 @@ OpenGLDebugContext = {
 --      FilterSeverity = { }
 }
 --RenderingMethod = "ABuffer" -- alternative: "Framebuffer"
-
-ServerPasskey = "secret!"
-ClientAddressWhitelist = {
-    "127.0.0.1",
-    "localhost"
-}

--- a/src/engine/configuration.cpp
+++ b/src/engine/configuration.cpp
@@ -24,6 +24,7 @@
 
 #include <openspace/engine/configuration.h>
 
+#include <ghoul/logging/logmanager.h>
 #include <openspace/documentation/documentation.h>
 #include <ghoul/filesystem/file.h>
 #include <ghoul/filesystem/filesystem.h>
@@ -57,9 +58,6 @@ namespace {
     constexpr const char* KeyKeyboardShortcuts = "KeyboardShortcuts";
     constexpr const char* KeyDocumentation = "Documentation";
     constexpr const char* KeyFactoryDocumentation = "FactoryDocumentation";
-    constexpr const char* KeyRequireSocketAuthentication = "RequireSocketAuthentication";
-    constexpr const char* KeyServerPasskey = "ServerPasskey";
-    constexpr const char* KeyClientAddressWhitelist = "ClientAddressWhitelist";
     constexpr const char* KeyLicenseDocumentation = "LicenseDocumentation";
     constexpr const char* KeyShutdownCountdown = "ShutdownCountdown";
     constexpr const char* KeyPerSceneCache = "PerSceneCache";
@@ -92,6 +90,8 @@ namespace {
     constexpr const char* KeyShowNodeNames = "ShowNodeNames";
     constexpr const char* KeyShowProgressbar = "ShowProgressbar";
     constexpr const char* KeyModuleConfigurations = "ModuleConfigurations";
+
+    constexpr const char* _loggerCat = "Configration";
 
     template <typename T>
     void getValue(ghoul::lua::LuaState& L, const char* name, T& value) {
@@ -294,9 +294,6 @@ void parseLuaState(Configuration& configuration) {
     getValue(s, KeyDisableSceneOnMaster, c.isSceneTranslationOnMasterDisabled);
     getValue(s, KeyDisableInGameConsole, c.isConsoleDisabled);
     getValue(s, KeyRenderingMethod, c.renderingMethod);
-    getValue(s, KeyServerPasskey, c.serverPasskey);
-    getValue(s, KeyRequireSocketAuthentication, c.doesRequireSocketAuthentication);
-    getValue(s, KeyClientAddressWhitelist, c.clientAddressWhitelist);
 
     getValue(s, KeyLogging, c.logging);
     getValue(s, KeyDocumentation, c.documentation);

--- a/src/engine/configuration_doc.inl
+++ b/src/engine/configuration_doc.inl
@@ -210,26 +210,6 @@ documentation::Documentation Configuration::Documentation = {
             "All documentations that are generated at application startup."
         },
         {
-            KeyRequireSocketAuthentication,
-            new BoolVerifier,
-            Optional::Yes,
-            "If socket connections should be authenticated or not before they are "
-            "allowed to get or set information. Defaults to 'true'."
-        },
-        {
-            KeyServerPasskey,
-            new StringVerifier,
-            Optional::Yes,
-            "Passkey to limit server access. Used to authorize incoming connections."
-        },
-        {
-            KeyClientAddressWhitelist,
-            new StringListVerifier,
-            Optional::Yes,
-            "String containing white listed client IP addresses that won't need to be"
-            "authorized with the server. Space separated"
-        },
-        {
             KeyShutdownCountdown,
             new DoubleGreaterEqualVerifier(0.0),
             Optional::Yes,

--- a/src/network/parallelserver.cpp
+++ b/src/network/parallelserver.cpp
@@ -41,7 +41,7 @@ namespace openspace {
 void ParallelServer::start(int port, const std::string& password,
                            const std::string& changeHostPassword)
 {
-    _socketServer.listen("localhost", port);
+    _socketServer.listen(port);
     _passwordHash = std::hash<std::string>{}(password);
     _changeHostPasswordHash = std::hash<std::string>{}(changeHostPassword);
 


### PR DESCRIPTION
I'm in the process of making the webgui more configurable, in terms of ports, addresses, white/blacklisting, and requiring password to access the api.

Note: For this to work, we need to reference new versions of the backend and frontend of the webgui, which have not been merged yet. 

Before I go ahead and merge this, it would be great to get a second pair of eyes on these changes including 
this: https://github.com/OpenSpace/OpenSpace-WebGuiBackend/pull/1/files
and this: https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/1/files

Thanks!