### PR TITLE
Pass on modifier keys to CEF for mouse events

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -548,11 +548,12 @@ void mainKeyboardCallback(int key, int, int action, int mods) {
 
 
 
-void mainMouseButtonCallback(int key, int action) {
+void mainMouseButtonCallback(int key, int action, int modifiers) {
     LTRACE("main::mainMouseButtonCallback(begin)");
     openspace::global::openSpaceEngine.mouseButtonCallback(
         openspace::MouseButton(key),
-        openspace::MouseAction(action)
+        openspace::MouseAction(action),
+        openspace::KeyModifier(modifiers)
     );
     LTRACE("main::mainMouseButtonCallback(end)");
 }

--- a/include/openspace/engine/globalscallbacks.h
+++ b/include/openspace/engine/globalscallbacks.h
@@ -49,7 +49,7 @@ std::vector<std::function<void()>>& gPostDraw();
 std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>& gKeyboard();
 std::vector<std::function<bool(unsigned int, KeyModifier)>>& gCharacter();
 
-std::vector<std::function<bool(MouseButton, MouseAction)>>& gMouseButton();
+std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>& gMouseButton();
 std::vector<std::function<void(double, double)>>& gMousePosition();
 std::vector<std::function<bool(double, double)>>& gMouseScrollWheel();
 
@@ -70,8 +70,8 @@ static std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>& keyboard =
     detail::gKeyboard();
 static std::vector<std::function<bool(unsigned int, KeyModifier)>>& character =
     detail::gCharacter();
-static std::vector<std::function<bool(MouseButton, MouseAction)>>& mouseButton =
-    detail::gMouseButton();
+static std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>&
+    mouseButton = detail::gMouseButton();
 static std::vector<std::function<void(double, double)>>& mousePosition =
     detail::gMousePosition();
 static std::vector<std::function<bool(double, double)>>& mouseScrollWheel =

--- a/include/openspace/engine/openspaceengine.h
+++ b/include/openspace/engine/openspaceengine.h
@@ -76,7 +76,7 @@ public:
     void postDraw();
     void keyboardCallback(Key key, KeyModifier mod, KeyAction action);
     void charCallback(unsigned int codepoint, KeyModifier modifier);
-    void mouseButtonCallback(MouseButton button, MouseAction action);
+    void mouseButtonCallback(MouseButton button, MouseAction action, KeyModifier mods);
     void mousePositionCallback(double x, double y);
     void mouseScrollWheelCallback(double posX, double posY);
     void externalControlCallback(const char* receivedChars, int size, int clientId);

--- a/modules/imgui/imguimodule.cpp
+++ b/modules/imgui/imguimodule.cpp
@@ -205,7 +205,7 @@ ImGUIModule::ImGUIModule() : OpenSpaceModule(Name) {
     );
 
     global::callback::mouseButton.emplace_back(
-        [&](MouseButton button, MouseAction action) -> bool {
+        [&](MouseButton button, MouseAction action, KeyModifier) -> bool {
             // A list of all the windows that can show up by themselves
             if (gui.isEnabled() || gui._performance.isEnabled() ||
                 gui._sceneProperty.isEnabled())

--- a/modules/webbrowser/include/eventhandler.h
+++ b/modules/webbrowser/include/eventhandler.h
@@ -62,7 +62,7 @@ public:
     void detachBrowser();
 
 private:
-    bool mouseButtonCallback(MouseButton button, MouseAction action);
+    bool mouseButtonCallback(MouseButton button, MouseAction action, KeyModifier mods);
     bool mousePositionCallback(double x, double y);
     bool mouseWheelCallback(glm::ivec2 delta);
     bool charCallback(unsigned int charCode, KeyModifier modifier);
@@ -82,7 +82,7 @@ private:
      *
      * \return
      */
-    CefMouseEvent mouseEvent();
+    CefMouseEvent mouseEvent(KeyModifier mods = KeyModifier::NoModifier);
 
     /**
      * Find the CEF key event to use for a given action.

--- a/modules/webbrowser/src/eventhandler.cpp
+++ b/modules/webbrowser/src/eventhandler.cpp
@@ -125,9 +125,9 @@ void EventHandler::initialize() {
         }
     );
     global::callback::mouseButton.emplace_back(
-        [this](MouseButton button, MouseAction action) -> bool {
+        [this](MouseButton button, MouseAction action, KeyModifier mods) -> bool {
             if (_browserInstance) {
-                return mouseButtonCallback(button, action);
+                return mouseButtonCallback(button, action, mods);
             }
             return false;
         }
@@ -143,7 +143,10 @@ void EventHandler::initialize() {
     );
 }
 
-bool EventHandler::mouseButtonCallback(MouseButton button, MouseAction action) {
+bool EventHandler::mouseButtonCallback(MouseButton button,
+                                       MouseAction action,
+                                       KeyModifier mods)
+{
     if (button != MouseButton::Left && button != MouseButton::Right) {
         return false;
     }
@@ -167,7 +170,7 @@ bool EventHandler::mouseButtonCallback(MouseButton button, MouseAction action) {
     }
 
     return _browserInstance->sendMouseClickEvent(
-        mouseEvent(),
+        mouseEvent(mods),
         (button == MouseButton::Left) ? MBT_LEFT : MBT_RIGHT,
         !state.down,
         clickCount
@@ -250,7 +253,7 @@ cef_key_event_type_t EventHandler::keyEventType(KeyAction action) {
     }
 }
 
-CefMouseEvent EventHandler::mouseEvent() {
+CefMouseEvent EventHandler::mouseEvent(KeyModifier mods) {
     CefMouseEvent event;
     event.x = static_cast<int>(_mousePosition.x);
     event.y = static_cast<int>(_mousePosition.y);
@@ -263,6 +266,7 @@ CefMouseEvent EventHandler::mouseEvent() {
         event.modifiers = EVENTFLAG_RIGHT_MOUSE_BUTTON;
     }
 
+    event.modifiers |= static_cast<uint32_t>(mapToCefModifiers(mods));
     return event;
 }
 

--- a/src/engine/globalscallbacks.cpp
+++ b/src/engine/globalscallbacks.cpp
@@ -81,8 +81,8 @@ std::vector<std::function<bool(unsigned int, KeyModifier)>>& gCharacter() {
     return g;
 }
 
-std::vector<std::function<bool(MouseButton, MouseAction)>>& gMouseButton() {
-    static std::vector<std::function<bool(MouseButton, MouseAction)>> g;
+std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>& gMouseButton() {
+    static std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>> g;
     return g;
 }
 

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1180,10 +1180,13 @@ void OpenSpaceEngine::charCallback(unsigned int codepoint, KeyModifier modifier)
     global::luaConsole.charCallback(codepoint, modifier);
 }
 
-void OpenSpaceEngine::mouseButtonCallback(MouseButton button, MouseAction action) {
-    using F = std::function<bool (MouseButton, MouseAction)>;
+void OpenSpaceEngine::mouseButtonCallback(MouseButton button,
+                                          MouseAction action,
+                                          KeyModifier mods)
+{
+    using F = std::function<bool (MouseButton, MouseAction, KeyModifier)>;
     for (const F& func : global::callback::mouseButton) {
-        bool isConsumed = func(button, action);
+        bool isConsumed = func(button, action, mods);
         if (isConsumed) {
             // If the mouse was released, we still want to forward it to the navigation
             // handler in order to reliably terminate a rotation or zoom. Accidentally


### PR DESCRIPTION
Depends on https://github.com/opensgct/sgct/pull/26
Enables correct keyboard modifier information to be passed to CEF on mouse clicks events.