### PR TITLE
Add support for zoom sensitivity adjustment with Ctrl/Shift

### DIFF
--- a/src/interaction/mousecamerastates.cpp
+++ b/src/interaction/mousecamerastates.cpp
@@ -26,6 +26,11 @@
 
 #include <openspace/interaction/inputstate.h>
 
+namespace {
+    const double SENSITIVITY_ADJUSTMENT_INCREASE = 8.0;
+    const double SENSITIVITY_ADJUSTMENT_DECREASE = 0.5;
+}
+
 namespace openspace::interaction {
 
 MouseCameraStates::MouseCameraStates(double sensitivity, double velocityScaleFactor)
@@ -82,8 +87,17 @@ void MouseCameraStates::updateStateFromInput(const InputState& inputState,
     if (button2Pressed || (keyAltPressed && button1Pressed)) {
         glm::dvec2 mousePositionDelta = _truckMovementState.previousPosition -
                                         mousePosition;
+
+        double sensitivity = _sensitivity;
+        if (keyCtrlPressed) {
+            sensitivity *= SENSITIVITY_ADJUSTMENT_INCREASE;
+        }
+        else if (keyShiftPressed) {
+            sensitivity *= SENSITIVITY_ADJUSTMENT_DECREASE;
+        }
+
         _truckMovementState.velocity.set(
-            mousePositionDelta * _sensitivity,
+            mousePositionDelta * sensitivity,
             deltaTime
         );
     }

--- a/src/interaction/mousecamerastates.cpp
+++ b/src/interaction/mousecamerastates.cpp
@@ -89,10 +89,10 @@ void MouseCameraStates::updateStateFromInput(const InputState& inputState,
                                         mousePosition;
 
         double sensitivity = _sensitivity;
-        if (keyCtrlPressed) {
+        if (inputState.isKeyPressed(Key::Z)) {
             sensitivity *= SENSITIVITY_ADJUSTMENT_INCREASE;
         }
-        else if (keyShiftPressed) {
+        else if (inputState.isKeyPressed(Key::X)) {
             sensitivity *= SENSITIVITY_ADJUSTMENT_DECREASE;
         }
 


### PR DESCRIPTION
* Holding Ctrl while zooming with the Right mouse button or Alt-Left mouse will now increase the sensitivity, causing the zoom speed (in or out) to increase by 8x
* Likewise, holding Shift while zooming will decrease the sensitivity by 2x (1/2 of the speed)
* These values are different as zooming is already relatively insensitive, and it seems likely (?) that the user won't want to make it much less insensitive when holding down Shift
* These are hardcoded values but ideally should later be made configurable, e.g. via the Orbital Navigator sliders
* This is related to issue #709, although it allows for both speeding up and down rather than just slowing down
* Thanks to Micah for his support during the hackathon!