### PR TITLE
Feature/statistics

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -639,6 +639,15 @@ void setSgctDelegateFunctions() {
         return sgct::Engine::instance()->getCurrentWindowPtr()->isWindowResized();
     };
     sgctDelegate.averageDeltaTime = []() { return sgct::Engine::instance()->getAvgDt(); };
+    sgctDelegate.deltaTimeStandardDeviation = []() {
+        return sgct::Engine::instance()->getDtStandardDeviation();
+    };
+    sgctDelegate.minDeltaTime = []() {
+        return sgct::Engine::instance()->getMinDt();
+    };
+    sgctDelegate.maxDeltaTime = []() {
+        return sgct::Engine::instance()->getMaxDt();
+    };
     sgctDelegate.deltaTime = []() { return sgct::Engine::instance()->getDt(); };
     sgctDelegate.applicationTime = []() { return sgct::Engine::getTime(); };
     sgctDelegate.mousePosition = []() {

--- a/include/openspace/engine/windowdelegate.h
+++ b/include/openspace/engine/windowdelegate.h
@@ -44,6 +44,12 @@ struct WindowDelegate {
 
     double (*averageDeltaTime)() = []() { return 0.0; };
 
+    double (*minDeltaTime)() = []() { return 0.0; };
+
+    double (*maxDeltaTime)() = []() { return 0.0; };
+
+    double (*deltaTimeStandardDeviation)() = []() { return 0.0; };
+
     double (*deltaTime)() = []() { return 0.0; };
 
     double (*applicationTime)() = []() { return 0.0; };

--- a/modules/base/dashboard/dashboarditemframerate.cpp
+++ b/modules/base/dashboard/dashboarditemframerate.cpp
@@ -85,8 +85,9 @@ documentation::Documentation DashboardItemFramerate::Documentation() {
             {
                 FrametimeInfo.identifier,
                 new StringInListVerifier({
-                    "Average Deltatime", "Frames per second", "Average frames per second",
-                    "None"
+                    "Average Deltatime", "Deltatime Extremes", "Deltatime standard deviation",
+                    "Deltatime coefficient of variation", "Frames per second",
+                    "Average frames per second", "None"
                 }),
                 Optional::Yes,
                 FrametimeInfo.description
@@ -127,6 +128,17 @@ DashboardItemFramerate::DashboardItemFramerate(const ghoul::Dictionary& dictiona
 
     _frametimeType.addOptions({
         { static_cast<int>(FrametimeType::DtTimeAvg), "Average Deltatime" },
+        { static_cast<int>(FrametimeType::DtTimeExtremes), "Deltatime Extremes" },
+        {
+            static_cast<int>(FrametimeType::DtStandardDeviation),
+            "Deltatime standard deviation"
+
+        },
+        {
+            static_cast<int>(FrametimeType::DtCoefficientOfVariation),
+            "Deltatime coefficient of variation"
+
+        },
         { static_cast<int>(FrametimeType::FPS), "Frames per second" },
         { static_cast<int>(FrametimeType::FPSAvg), "Average frames per second" },
         { static_cast<int>(FrametimeType::None), "None" }
@@ -136,6 +148,17 @@ DashboardItemFramerate::DashboardItemFramerate(const ghoul::Dictionary& dictiona
         const std::string& v = dictionary.value<std::string>(FrametimeInfo.identifier);
         if (v == "Average Deltatime") {
             _frametimeType = static_cast<int>(FrametimeType::DtTimeAvg);
+        }
+        else if (v == "Deltatime Extremes") {
+            _frametimeType = static_cast<int>(FrametimeType::DtTimeExtremes);
+        }
+        else if (v == "Deltatime standard deviation") {
+            _frametimeType =
+            static_cast<int>(FrametimeType::DtStandardDeviation);
+        }
+        else if (v == "Deltatime coefficient of variation") {
+            _frametimeType =
+            static_cast<int>(FrametimeType::DtCoefficientOfVariation);
         }
         else if (v == "Frames per second") {
             _frametimeType = static_cast<int>(FrametimeType::FPS);
@@ -164,7 +187,43 @@ void DashboardItemFramerate::render(glm::vec2& penPosition) {
                 *_font,
                 penPosition,
                 fmt::format(
-                    "Avg. Frametime: {:.5f}", global::windowDelegate.averageDeltaTime()
+                    "Avg. Frametime: {:.2f} ms",
+                    global::windowDelegate.averageDeltaTime() * 1000.0
+                )
+            );
+            break;
+        case FrametimeType::DtTimeExtremes:
+            penPosition.y -= _font->height();
+            RenderFont(
+                *_font,
+                penPosition,
+                fmt::format(
+                    "Frametimes between: {:.2f} and {:.2f} ms",
+                    global::windowDelegate.minDeltaTime() * 1000.0,
+                    global::windowDelegate.maxDeltaTime() * 1000.0
+                )
+            );
+            break;
+        case FrametimeType::DtStandardDeviation:
+            penPosition.y -= _font->height();
+            RenderFont(
+                *_font,
+                penPosition,
+                fmt::format(
+                   "Frametime standard deviation : {:.2f} ms",
+                   global::windowDelegate.deltaTimeStandardDeviation() * 1000.0
+                )
+            );
+            break;
+        case FrametimeType::DtCoefficientOfVariation:
+            penPosition.y -= _font->height();
+            RenderFont(
+                *_font,
+                penPosition,
+                fmt::format(
+                    "Frametime coefficient of variation : {:.2f} %",
+                    global::windowDelegate.deltaTimeStandardDeviation() /
+                    global::windowDelegate.averageDeltaTime() * 100.0
                 )
             );
             break;

--- a/modules/base/dashboard/dashboarditemframerate.cpp
+++ b/modules/base/dashboard/dashboarditemframerate.cpp
@@ -110,23 +110,22 @@ namespace {
     std::string format(openspace::DashboardItemFramerate::FrametimeType frametimeType) {
         using namespace openspace;
         switch (frametimeType) {
-        case DashboardItemFramerate::FrametimeType::DtTimeAvg:
-            return formatDt();
-        case DashboardItemFramerate::FrametimeType::DtTimeExtremes:
-            return formatDtExtremes();
-        case DashboardItemFramerate::FrametimeType::DtStandardDeviation:
-            return formatDtStandardDeviation();
-        case DashboardItemFramerate::FrametimeType::DtCoefficientOfVariation:
-            return formatDtCoefficientOfVariation();
-        case DashboardItemFramerate::FrametimeType::FPS:
-            return formatFps();
-        case DashboardItemFramerate::FrametimeType::FPSAvg:
-            return formatAverageFps();
-        default:
-            return "";
+            case DashboardItemFramerate::FrametimeType::DtTimeAvg:
+                return formatDt();
+            case DashboardItemFramerate::FrametimeType::DtTimeExtremes:
+                return formatDtExtremes();
+            case DashboardItemFramerate::FrametimeType::DtStandardDeviation:
+                return formatDtStandardDeviation();
+            case DashboardItemFramerate::FrametimeType::DtCoefficientOfVariation:
+                return formatDtCoefficientOfVariation();
+            case DashboardItemFramerate::FrametimeType::FPS:
+                return formatFps();
+            case DashboardItemFramerate::FrametimeType::FPSAvg:
+                return formatAverageFps();
+            default:
+                return "";
         }
     }
-
 } // namespace
 
 namespace openspace {
@@ -157,14 +156,8 @@ documentation::Documentation DashboardItemFramerate::Documentation() {
             },
             {
                 FrametimeInfo.identifier,
-                new StringInListVerifier({
-                    ValueDtAvg,
-                    ValueDtExtremes,
-                    ValueDtStandardDeviation,
-                    ValueDtCov,
-                    ValueFps,
-                    ValueFpsAvg,
-                    ValueNone
+                new StringInListVerifier({ ValueDtAvg, ValueDtExtremes,
+                    ValueDtStandardDeviation, ValueDtCov, ValueFps, ValueFpsAvg, ValueNone
                 }),
                 Optional::Yes,
                 FrametimeInfo.description

--- a/modules/base/dashboard/dashboarditemframerate.cpp
+++ b/modules/base/dashboard/dashboarditemframerate.cpp
@@ -55,6 +55,14 @@ namespace {
         "This value determines the units in which the frame time is displayed."
     };
 
+    constexpr const char* ValueDtAvg = "Average Deltatime";
+    constexpr const char* ValueDtExtremes = "Deltatime extremes";
+    constexpr const char* ValueDtStandardDeviation = "Deltatime standard deviation";
+    constexpr const char* ValueDtCov = "Deltatime coefficient of variation";
+    constexpr const char* ValueFps = "Frames per second";
+    constexpr const char* ValueFpsAvg = "Average frames per second";
+    constexpr const char* ValueNone = "None";
+
     std::string formatDt() {
         return fmt::format(
             "Avg. Frametime: {:.2f} ms",
@@ -150,9 +158,13 @@ documentation::Documentation DashboardItemFramerate::Documentation() {
             {
                 FrametimeInfo.identifier,
                 new StringInListVerifier({
-                    "Average Deltatime", "Deltatime Extremes", "Deltatime standard deviation",
-                    "Deltatime coefficient of variation", "Frames per second",
-                    "Average frames per second", "None"
+                    ValueDtAvg,
+                    ValueDtExtremes,
+                    ValueDtStandardDeviation,
+                    ValueDtCov,
+                    ValueFps,
+                    ValueFpsAvg,
+                    ValueNone
                 }),
                 Optional::Yes,
                 FrametimeInfo.description
@@ -192,41 +204,41 @@ DashboardItemFramerate::DashboardItemFramerate(const ghoul::Dictionary& dictiona
     addProperty(_fontSize);
 
     _frametimeType.addOptions({
-        { static_cast<int>(FrametimeType::DtTimeAvg), "Average Deltatime" },
-        { static_cast<int>(FrametimeType::DtTimeExtremes), "Deltatime Extremes" },
+        { static_cast<int>(FrametimeType::DtTimeAvg), ValueDtAvg },
+        { static_cast<int>(FrametimeType::DtTimeExtremes), ValueDtExtremes },
         {
             static_cast<int>(FrametimeType::DtStandardDeviation),
-            "Deltatime standard deviation"
+            ValueDtStandardDeviation
         },
         {
             static_cast<int>(FrametimeType::DtCoefficientOfVariation),
-            "Deltatime coefficient of variation"
+            ValueDtCov
         },
-        { static_cast<int>(FrametimeType::FPS), "Frames per second" },
-        { static_cast<int>(FrametimeType::FPSAvg), "Average frames per second" },
-        { static_cast<int>(FrametimeType::None), "None" }
+        { static_cast<int>(FrametimeType::FPS), ValueFps },
+        { static_cast<int>(FrametimeType::FPSAvg), ValueFpsAvg },
+        { static_cast<int>(FrametimeType::None), ValueNone }
     });
 
     if (dictionary.hasKey(FrametimeInfo.identifier)) {
         const std::string& v = dictionary.value<std::string>(FrametimeInfo.identifier);
-        if (v == "Average Deltatime") {
+        if (v == ValueDtAvg) {
             _frametimeType = static_cast<int>(FrametimeType::DtTimeAvg);
         }
-        else if (v == "Deltatime Extremes") {
+        else if (v == ValueDtExtremes) {
             _frametimeType = static_cast<int>(FrametimeType::DtTimeExtremes);
         }
-        else if (v == "Deltatime standard deviation") {
+        else if (v == ValueDtStandardDeviation) {
             _frametimeType =
-            static_cast<int>(FrametimeType::DtStandardDeviation);
+                static_cast<int>(FrametimeType::DtStandardDeviation);
         }
-        else if (v == "Deltatime coefficient of variation") {
+        else if (v == ValueDtCov) {
             _frametimeType =
-            static_cast<int>(FrametimeType::DtCoefficientOfVariation);
+                static_cast<int>(FrametimeType::DtCoefficientOfVariation);
         }
-        else if (v == "Frames per second") {
+        else if (v == ValueFps) {
             _frametimeType = static_cast<int>(FrametimeType::FPS);
         }
-        else if (v == "Average frames per second") {
+        else if (v == ValueFpsAvg) {
             _frametimeType = static_cast<int>(FrametimeType::FPSAvg);
         }
         else {

--- a/modules/base/dashboard/dashboarditemframerate.h
+++ b/modules/base/dashboard/dashboarditemframerate.h
@@ -42,6 +42,9 @@ class DashboardItemFramerate : public DashboardItem {
 public:
     enum class FrametimeType {
         DtTimeAvg = 0,
+        DtTimeExtremes,
+        DtStandardDeviation,
+        DtCoefficientOfVariation,
         FPS,
         FPSAvg,
         None


### PR DESCRIPTION
Add options to DashboardItemFramerate: 
Extreme frametimes, Standard Deviation, Coefficient of variation
The display options all use the same averaging window as the average fps, which is currently hard-coded in sgct. This should be useful when monitoring frame stuttering.