### PR TITLE
added viewport tracking to configs

### DIFF
--- a/config/single.xml
+++ b/config/single.xml
@@ -8,11 +8,11 @@
             <Stereo type="none" />
             <Size x="1280" y="720" />
             <Pos x="50" y="50" />
-            <Viewport>
+            <Viewport tracked="true">
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
                 <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                    <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                     <Orientation heading="0.0" pitch="0.0" roll="0.0" />
                 </PlanarProjection>
             </Viewport>

--- a/config/single_gui.xml
+++ b/config/single_gui.xml
@@ -8,11 +8,11 @@
             <Stereo type="none" />
             <Size x="1280" y="720" />
             <Pos x="50" y="50" />
-            <Viewport>
+            <Viewport tracked="true">
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
                 <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                    <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                     <Orientation heading="0.0" pitch="0.0" roll="0.0" />
                 </PlanarProjection>
             </Viewport>
@@ -24,10 +24,6 @@
             <Viewport>
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
-                <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
-                    <Orientation heading="0.0" pitch="0.0" roll="0.0" />
-                </PlanarProjection>
             </Viewport>
         </Window>       
     </Node>

--- a/config/single_two_win.xml
+++ b/config/single_two_win.xml
@@ -4,11 +4,11 @@
         <Window fullScreen="false" numberOfSamples="8" border="true">
             <Pos x="10" y="100" />
             <Size x="1280" y="720" />
-            <Viewport>
+            <Viewport tracked="true">
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
                 <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                    <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                     <Orientation heading="0.0" pitch="0.0" roll="0.0" />
                 </PlanarProjection>
             </Viewport>
@@ -20,7 +20,7 @@
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
                 <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                    <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                     <Orientation heading="0.0" pitch="0.0" roll="0.0" />
                 </PlanarProjection>
             </Viewport>

--- a/config/spherical_mirror_gui.xml
+++ b/config/spherical_mirror_gui.xml
@@ -34,7 +34,7 @@
             <Pos x="0.0" y="0.0" />
             <Size x="1.0" y="1.0" />
             <PlanarProjection>
-                <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                 <Orientation heading="0.0" pitch="0.0" roll="0.0" />
             </PlanarProjection>
         </Viewport>

--- a/config/two_nodes.xml
+++ b/config/two_nodes.xml
@@ -5,11 +5,11 @@
             <Pos x="0" y="300" />
             <!-- 16:9 aspect ratio -->
             <Size x="1280" y="720" />
-            <Viewport>
+            <Viewport tracked="true">
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
                 <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                    <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                     <Orientation heading="0.0" pitch="0.0" roll="0.0" />
                 </PlanarProjection>
             </Viewport>
@@ -20,11 +20,11 @@
             <Pos x="640" y="300" />
             <!-- 16:9 aspect ratio -->
             <Size x="1280" y="720" />
-            <Viewport>
+            <Viewport tracked="true">
                 <Pos x="0.0" y="0.0" />
                 <Size x="1.0" y="1.0" />
                 <PlanarProjection>
-                    <FOV down="16.875" left="30.0" right="30.0" up="16.875" />
+                    <FOV down="25.267007923362" left="40.0" right="40.0" up="25.267007923362" />
                     <Orientation heading="0.0" pitch="0.0" roll="0.0" />
                 </PlanarProjection>
             </Viewport>

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -12,7 +12,13 @@ SGCTConfig = sgct.config.single{}
 -- SGCTConfig = sgct.config.single{1920, 1080}
 
 -- A windowed 1920x1080 fullscreen
--- SGCTConfig = sgct.config.single{1920, 1080, border=false, windowPos={0,0}, shared=true, name="WV_OBS_SPOUT1"}
+-- SGCTConfig = sgct.config.single{1920, 1080, border=false, windowPos={0,0}}
+
+-- One window for the GUI and one window for Rendering. Good for presenting on a projector.
+-- SGCTConfig = "${CONFIG}/single_gui.xml"
+
+-- One window for the GUI and one window for Rendering fisheye
+-- SGCTConfig = "${CONFIG}/single_fisheye_gui.xml"
 
 -- A 1k fisheye rendering
 -- SGCTConfig = sgct.config.fisheye{1024, 1024}
@@ -23,12 +29,10 @@ SGCTConfig = sgct.config.single{}
 -- Streaming OpenSpace via Spout to OBS
 -- SGCTConfig = sgct.config.single{2560, 1440, shared=true, name="WV_OBS_SPOUT1"}
 
--- Stereo
--- SGCTConfig = "${CONFIG}/stereo.xml"
-
 -- Spout exit
 -- SGCTConfig = "${CONFIG}/spout_output.xml"
 
+-- VR support only if compiled from source with OpenVR
 -- SGCTConfig = "${CONFIG}/openvr_oculusRiftCv1.xml"
 -- SGCTConfig = "${CONFIG}/openvr_htcVive.xml"
 


### PR DESCRIPTION
Fix for : https://github.com/OpenSpace/OpenSpace/issues/893

Figured that it made sense for the FOVs of these files to match what the default window has.

Also removed the spout stuff from the default full screen since we have a spout example below it for obs.