### PR TITLE
Fix scaling issue with screenspace renderables

### DIFF
--- a/include/openspace/rendering/screenspacerenderable.h
+++ b/include/openspace/rendering/screenspacerenderable.h
@@ -106,10 +106,8 @@ protected:
     properties::TriggerProperty _delete;
 
     glm::ivec2 _objectSize;
-    UniformCache(occlusionDepth, alpha, modelTransform, viewProj, texture) _uniformCache;
+    UniformCache(alpha, modelTransform, viewProj, texture) _uniformCache;
     std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
-
-    glm::vec2 _originalViewportSize;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/screenspacedashboard.cpp
+++ b/modules/base/rendering/screenspacedashboard.cpp
@@ -212,7 +212,6 @@ void ScreenSpaceDashboard::update() {
     if (global::windowDelegate.windowHasResized()) {
         const glm::ivec2 size = global::windowDelegate.currentWindowResolution();
         _size = { 0.f, 0.f, size.x, size.y };
-        _originalViewportSize = size;
         createFramebuffer();
     }
 }

--- a/modules/base/rendering/screenspaceframebuffer.cpp
+++ b/modules/base/rendering/screenspaceframebuffer.cpp
@@ -106,15 +106,15 @@ void ScreenSpaceFramebuffer::render() {
     const glm::vec2& resolution = global::windowDelegate.currentWindowResolution();
     const glm::vec4& size = _size.value();
 
-    const float xratio = _originalViewportSize.x / (size.z - size.x);
-    const float yratio = _originalViewportSize.y / (size.w - size.y);;
+    const float xratio = resolution.x / (size.z - size.x);
+    const float yratio = resolution.y / (size.w - size.y);;
 
     if (!_renderFunctions.empty()) {
         glViewport(
             static_cast<GLint>(-size.x * xratio),
             static_cast<GLint>(-size.y * yratio),
-            static_cast<GLsizei>(_originalViewportSize.x * xratio),
-            static_cast<GLsizei>(_originalViewportSize.y * yratio)
+            static_cast<GLsizei>(resolution.x * xratio),
+            static_cast<GLsizei>(resolution.y * yratio)
         );
         GLint defaultFBO = _framebuffer->getActiveObject();
         _framebuffer->activate();
@@ -170,14 +170,16 @@ void ScreenSpaceFramebuffer::removeAllRenderFunctions() {
 }
 
 void ScreenSpaceFramebuffer::createFramebuffer() {
+    glm::vec2 resolution = global::windowDelegate.currentWindowResolution();
+
     _framebuffer = std::make_unique<ghoul::opengl::FramebufferObject>();
     _framebuffer->activate();
     _texture = std::make_unique<ghoul::opengl::Texture>(glm::uvec3(
-        _originalViewportSize.x,
-        _originalViewportSize.y,
+        resolution.x,
+        resolution.y,
         1
     ));
-    _objectSize = glm::ivec2(_originalViewportSize);
+    _objectSize = glm::ivec2(resolution);
 
     _texture->uploadTexture();
     _texture->setFilter(ghoul::opengl::Texture::FilterMode::LinearMipMap);

--- a/modules/base/shaders/screenspace_fs.glsl
+++ b/modules/base/shaders/screenspace_fs.glsl
@@ -29,9 +29,7 @@ in vec2 vs_st;
 in vec4 vs_position;
 
 uniform sampler2D texture1;
-uniform float OcclusionDepth;
 uniform float Alpha;
-
 
 Fragment getFragment() {
     Fragment frag;

--- a/modules/webbrowser/src/screenspacebrowser.cpp
+++ b/modules/webbrowser/src/screenspacebrowser.cpp
@@ -113,7 +113,6 @@ ScreenSpaceBrowser::ScreenSpaceBrowser(const ghoul::Dictionary &dictionary)
 }
 
 bool ScreenSpaceBrowser::initialize() {
-    _originalViewportSize = global::windowDelegate.currentWindowSize();
     _renderHandler->setTexture(*_texture);
 
     createShaders();
@@ -164,7 +163,6 @@ void ScreenSpaceBrowser::update() {
 
     if (_isDimensionsDirty) {
         _browserInstance->reshape(_dimensions.value());
-        _originalViewportSize = _dimensions.value();
         _isDimensionsDirty = false;
     }
 }

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -42,8 +42,8 @@ namespace {
     constexpr const char* KeyType = "Type";
     constexpr const char* KeyTag = "Tag";
 
-    constexpr const std::array<const char*, 5> UniformNames = {
-        "OcclusionDepth", "Alpha", "ModelTransform", "ViewProjectionMatrix", "texture1"
+    constexpr const std::array<const char*, 4> UniformNames = {
+        "Alpha", "ModelTransform", "ViewProjectionMatrix", "texture1"
     };
 
     constexpr openspace::properties::Property::PropertyInfo EnabledInfo = {
@@ -451,7 +451,6 @@ bool ScreenSpaceRenderable::initialize() {
 }
 
 bool ScreenSpaceRenderable::initializeGL() {
-    _originalViewportSize = global::windowDelegate.currentWindowResolution();
     createShaders();
     return isReady();
 }
@@ -523,15 +522,9 @@ glm::mat4 ScreenSpaceRenderable::scaleMatrix() {
     float textureRatio =
         static_cast<float>(_objectSize.y) / static_cast<float>(_objectSize.x);
 
-    float scalingRatioX = _originalViewportSize.x / resolution.x;
-    float scalingRatioY = _originalViewportSize.y / resolution.y;
     glm::mat4 scale = glm::scale(
         glm::mat4(1.f),
-        glm::vec3(
-            _scale * scalingRatioX,
-            _scale * scalingRatioY * textureRatio,
-            1.f
-        )
+        glm::vec3(_scale, _scale * textureRatio, 1.f)
     );
 
     // Simulate orthographic projection by distance to plane.


### PR DESCRIPTION
Screenspace renderables used to overcompensate for screen aspect ratio. This is fixed in this commit.
Also removed unused uniform OcclusionDepth.