### PR TITLE
Change AssetLoader unloadAsset to clear init/deinitialization functions for only one asset

### DIFF
--- a/src/scene/assetloader.cpp
+++ b/src/scene/assetloader.cpp
@@ -286,12 +286,12 @@ void AssetLoader::unloadAsset(Asset* asset) {
     for (int ref : _onInitializationFunctionRefs[asset]) {
        luaL_unref(*_luaState, LUA_REGISTRYINDEX, ref);
     }
-    _onInitializationFunctionRefs.clear();
+    _onInitializationFunctionRefs[asset].clear();
 
     for (int ref : _onDeinitializationFunctionRefs[asset]) {
         luaL_unref(*_luaState, LUA_REGISTRYINDEX, ref);
     }
-    _onDeinitializationFunctionRefs.clear();
+    _onDeinitializationFunctionRefs[asset].clear();
 
     for (const auto& it : _onDependencyInitializationFunctionRefs[asset]) {
         for (int ref : it.second) {


### PR DESCRIPTION

This worked for allowing me to remove more than one asset in the console.