### PR TITLE
Fix for Pluto ephemeris expiring on 2019-03-01

### DIFF
--- a/data/assets/scene/solarsystem/dwarf_planets/pluto/kernels.asset
+++ b/data/assets/scene/solarsystem/dwarf_planets/pluto/kernels.asset
@@ -7,7 +7,8 @@ local Kernels = asset.syncedResource({
 
 local PlutoKernels = {
     Kernels .. "/NavPE_de433_od122.bsp",
-    Kernels .. "/NavSE_plu047_od122.bsp"
+    Kernels .. "/NavSE_plu047_od122.bsp",
+    Kernels .. "/ssd_jpl_nasa_gov_plu043.bsp"
 }
 
 asset.export("PlutoKernels", PlutoKernels)


### PR DESCRIPTION
Added plu043.bsp to Pluto asset SPICE kernels. This file is apparently synced already anyway, and handles orbits of Pluto and its moons until year 2100.