### PR TITLE
Feature/serve screenshots

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -383,7 +383,10 @@ void mainInitFunc() {
 
     for (size_t i = 0; i < nWindows; ++i) {
         sgct::SGCTWindow* w = SgctEngine->getWindowPtr(i);
-        constexpr const char* screenshotNames = "OpenSpace";
+        const std::string screenshotNames = nWindows > 1 ?
+            fmt::format("OpenSpace_{}", i) :
+            "OpenSpace";
+
         sgct_core::ScreenCapture* cpt0 = w->getScreenCapturePointer(0);
         sgct_core::ScreenCapture* cpt1 = w->getScreenCapturePointer(1);
 

--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -1014,6 +1014,7 @@ void setSgctDelegateFunctions() {
     sgctDelegate.takeScreenshot = [](bool applyWarping) {
         sgct::SGCTSettings::instance()->setCaptureFromBackBuffer(applyWarping);
         sgct::Engine::instance()->takeScreenshot();
+        return sgct::Engine::instance()->getScreenShotNumber();
     };
     sgctDelegate.swapBuffer = []() {
         GLFWwindow* w = glfwGetCurrentContext();

--- a/data/assets/util/default_keybindings.asset
+++ b/data/assets/util/default_keybindings.asset
@@ -20,7 +20,7 @@ local Keybindings = {
     {
         Key = "PRINT_SCREEN",
         Name = "Take Screenshot",
-        Command = "openspace.takeScreenShot()",
+        Command = "openspace.takeScreenshot()",
         Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true
@@ -28,7 +28,7 @@ local Keybindings = {
     {
         Key = "F12",
         Name = "Take Screenshot",
-        Command = "openspace.takeScreenShot()",
+        Command = "openspace.takeScreenshot()",
         Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true

--- a/data/assets/util/default_keybindings.asset
+++ b/data/assets/util/default_keybindings.asset
@@ -20,16 +20,16 @@ local Keybindings = {
     {
         Key = "PRINT_SCREEN",
         Name = "Take Screenshot",
-        Command = "openspace.setPropertyValueSingle('RenderEngine.TakeScreenshot', nil)",
-        Documentation = "Saves the contents of the screen to a file in the working directory.",
+        Command = "openspace.takeScreenshot()",
+        Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true
     },
     {
         Key = "F12",
         Name = "Take Screenshot",
-        Command = "openspace.setPropertyValueSingle('RenderEngine.TakeScreenshot', nil)",
-        Documentation = "Saves the contents of the screen to a file in the working directory.",
+        Command = "openspace.takeScreenshot()",
+        Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true
     },

--- a/data/assets/util/default_keybindings.asset
+++ b/data/assets/util/default_keybindings.asset
@@ -20,7 +20,7 @@ local Keybindings = {
     {
         Key = "PRINT_SCREEN",
         Name = "Take Screenshot",
-        Command = "openspace.takeScreenshot()",
+        Command = "openspace.takeScreenShot()",
         Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true
@@ -28,7 +28,7 @@ local Keybindings = {
     {
         Key = "F12",
         Name = "Take Screenshot",
-        Command = "openspace.takeScreenshot()",
+        Command = "openspace.takeScreenShot()",
         Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true

--- a/data/assets/util/screenshots_endpoint.asset
+++ b/data/assets/util/screenshots_endpoint.asset
@@ -1,0 +1,21 @@
+asset.onInitialize(function ()
+    -- Disable the server, add production gui endpoint, and restart server.
+    -- The temporary disabling avoids restarting the server on each property change.
+    -- TODO: Add a trigger property to the module to restart the server "manually"
+    -- and remove automatic restart on each property change,
+    -- since frequent restarting seems to be unstable on mac.
+
+    local enabled = openspace.getPropertyValue("Modules.WebGui.ServerProcessEnabled")
+    openspace.setPropertyValueSingle("Modules.WebGui.ServerProcessEnabled", false)
+
+    local directories = openspace.getPropertyValue("Modules.WebGui.Directories")
+    directories[#directories + 1] = "screenshots"
+    directories[#directories + 1] = "${SCREENSHOTS}"
+    openspace.setPropertyValueSingle("Modules.WebGui.Directories", directories)
+    openspace.setPropertyValueSingle("Modules.WebGui.ServerProcessEnabled", enabled)
+end)
+
+asset.onDeinitialize(function ()
+    -- TODO: Remove endpoints. As of 2019-10-29, OpenSpace sometimes
+    -- crashes when endpoints are removed while the application is closing.
+end)

--- a/data/assets/util/testing_keybindings.asset
+++ b/data/assets/util/testing_keybindings.asset
@@ -7,8 +7,8 @@ local Keybindings = {
     {
         Key = "F7",
         Name = "Take Screenshot",
-        Command = "openspace.setPropertyValueSingle('RenderEngine.TakeScreenshot', nil)",
-        Documentation = "Saves the contents of the screen to a file in the working directory.",
+        Command = "openspace.takeScreenshot()",
+        Documentation = "Saves the contents of the screen to a file in the ${SCREENSHOTS} directory.",
         GuiPath = "/Rendering",
         Local = true
     }

--- a/include/openspace/engine/windowdelegate.h
+++ b/include/openspace/engine/windowdelegate.h
@@ -107,7 +107,7 @@ struct WindowDelegate {
 
     bool (*isFisheyeRendering)() = []() { return false; };
 
-    void (*takeScreenshot)(bool applyWarping) = [](bool) { };
+    unsigned int(*takeScreenshot)(bool applyWarping) = [](bool) { return 0u; };
 
     void (*swapBuffer)() = []() {};
 

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -149,7 +149,7 @@ public:
     /**
      * Get the filename of the latest screenshot
      */
-    std::string latestScreenShotFilename() const;
+    unsigned int latestScreenshotNumber() const;
 
     /**
      * Returns the Lua library that contains all Lua functions available to affect the
@@ -229,7 +229,7 @@ private:
     properties::Vec3Property _masterRotation;
     
     uint64_t _frameNumber = 0;
-    unsigned int _latestScreenShotNumber = 0;
+    unsigned int _latestScreenshotNumber = 0;
 
     std::vector<ghoul::opengl::ProgramObject*> _programs;
 

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -142,9 +142,14 @@ public:
     void setResolveData(ghoul::Dictionary resolveData);
 
     /**
-     * Mark that one screenshot should be taken
+     * Take a screenshot and store in the ${SCREENSHOTS} directory
      */
     void takeScreenShot();
+
+    /**
+     * Get the filename of the latest screenshot
+     */
+    std::string latestScreenShotFilename() const;
 
     /**
      * Returns the Lua library that contains all Lua functions available to affect the
@@ -187,8 +192,6 @@ private:
     properties::BoolProperty _showVersionInfo;
     properties::BoolProperty _showCameraInfo;
 
-    properties::TriggerProperty _takeScreenshot;
-    bool _shouldTakeScreenshot = false;
     properties::BoolProperty _applyWarping;
     properties::BoolProperty _showFrameInformation;
 #ifdef OPENSPACE_WITH_INSTRUMENTATION
@@ -226,6 +229,7 @@ private:
     properties::Vec3Property _masterRotation;
     
     uint64_t _frameNumber = 0;
+    unsigned int _latestScreenShotNumber = 0;
 
     std::vector<ghoul::opengl::ProgramObject*> _programs;
 

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -144,7 +144,7 @@ public:
     /**
      * Take a screenshot and store in the ${SCREENSHOTS} directory
      */
-    void takeScreenShot();
+    void takeScreenshot();
 
     /**
      * Get the filename of the latest screenshot

--- a/modules/webgui/webguimodule.cpp
+++ b/modules/webgui/webguimodule.cpp
@@ -246,16 +246,15 @@ void WebGuiModule::startProcess() {
     std::string formattedDirectories = "[";
 
     std::vector<std::string> directories = _directories.value();
-    bool first = true;
-
-    for (const std::string& str : directories) {
-        if (!first) {
+    for (size_t i = 0; i < directories.size(); ++i) {
+        std::string arg = directories[i];
+        if (i & 1) {
+            arg = absPath(arg);
+        }
+        formattedDirectories += "\\\"" + escapedJson(escapedJson(arg)) + "\\\"";
+        if (i != directories.size() - 1) {
             formattedDirectories += ",";
         }
-        first = false;
-
-        // Escape twice: First json, and then bash (which needs same escape sequences)
-        formattedDirectories += "\\\"" + escapedJson(escapedJson(str)) + "\\\"";
     }
     formattedDirectories += "]";
 

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -1033,7 +1033,7 @@ void SessionRecording::moveAheadInTime() {
         const Renderable* focusRenderable = focusNode->renderable();
         if (!focusRenderable || focusRenderable->renderedWithDesiredData()) {
             _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
-            global::renderEngine.takeScreenShot();
+            global::renderEngine.takeScreenshot();
         }
     }
 }

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -1034,7 +1034,7 @@ void RenderEngine::setResolveData(ghoul::Dictionary resolveData) {
 /**
  * Take a screenshot and store it in the ${SCREENSHOTS} directory
  */
-void RenderEngine::takeScreenShot() {
+void RenderEngine::takeScreenshot() {
     // We only create the directory here, as we don't want to spam the users
     // screenshot folder everytime we start OpenSpace even when we are not taking any
     // screenshots. So the first time we actually take one, we create the folder:
@@ -1116,8 +1116,8 @@ scripting::LuaLibrary RenderEngine::luaLibrary() {
                 "renderengine"
             },
             {
-                "takeScreenShot",
-                &luascriptfunctions::takeScreenShot,
+                "takeScreenshot",
+                &luascriptfunctions::takeScreenshot,
                 {},
                 "",
                 "Take a screenshot and return the path of the generated file. "

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -1046,17 +1046,14 @@ void RenderEngine::takeScreenshot() {
         );
     }
 
-    _latestScreenShotNumber = global::windowDelegate.takeScreenshot(_applyWarping);
+    _latestScreenshotNumber = global::windowDelegate.takeScreenshot(_applyWarping);
 }
 
 /**
  * Get the latest screenshot filename
  */
-std::string RenderEngine::latestScreenShotFilename() const {
-    return fmt::format(
-        "OpenSpace_{:0>6}.png",
-        _latestScreenShotNumber
-    );
+unsigned int RenderEngine::latestScreenshotNumber() const {
+    return _latestScreenshotNumber;
 }
 
 /**
@@ -1120,8 +1117,8 @@ scripting::LuaLibrary RenderEngine::luaLibrary() {
                 &luascriptfunctions::takeScreenshot,
                 {},
                 "",
-                "Take a screenshot and return the path of the generated file. "
-                "The Screenshot will be stored in the ${SCREENSHOTS} folder."
+                "Take a screenshot and return the screenshot number. The screenshot will "
+                "be stored in the ${SCREENSHOTS} folder. "
             }
         },
     };

--- a/src/rendering/renderengine_lua.inl
+++ b/src/rendering/renderengine_lua.inl
@@ -89,4 +89,14 @@ int removeScreenSpaceRenderable(lua_State* L) {
     return 0;
 }
 
+int takeScreenShot(lua_State* L) {
+    ghoul::lua::checkArgumentsAndThrow(L, 0, "lua::takeScreenshot");
+
+    global::renderEngine.takeScreenShot();
+    const std::string filename = global::renderEngine.latestScreenShotFilename();
+
+    lua_pushstring(L, filename.c_str());
+    return 1;
+}
+
 }// namespace openspace::luascriptfunctions

--- a/src/rendering/renderengine_lua.inl
+++ b/src/rendering/renderengine_lua.inl
@@ -93,9 +93,9 @@ int takeScreenshot(lua_State* L) {
     ghoul::lua::checkArgumentsAndThrow(L, 0, "lua::takeScreenshot");
 
     global::renderEngine.takeScreenshot();
-    const std::string filename = global::renderEngine.latestScreenShotFilename();
+    const unsigned int screenshotNumber = global::renderEngine.latestScreenshotNumber();
 
-    lua_pushstring(L, filename.c_str());
+    lua_pushinteger(L, screenshotNumber);
     return 1;
 }
 

--- a/src/rendering/renderengine_lua.inl
+++ b/src/rendering/renderengine_lua.inl
@@ -89,10 +89,10 @@ int removeScreenSpaceRenderable(lua_State* L) {
     return 0;
 }
 
-int takeScreenShot(lua_State* L) {
+int takeScreenshot(lua_State* L) {
     ghoul::lua::checkArgumentsAndThrow(L, 0, "lua::takeScreenshot");
 
-    global::renderEngine.takeScreenShot();
+    global::renderEngine.takeScreenshot();
     const std::string filename = global::renderEngine.latestScreenShotFilename();
 
     lua_pushstring(L, filename.c_str());


### PR DESCRIPTION
Remove trigger property `takeScreenShot`, and instead introduce lua function `takeScreenshot` returning the generated filename. 

Add an asset that adds the current `${SCREENSHOTS}` folder as an HTTP endpoint.