### PR TITLE
Feature/integrated touchserver

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -1043,14 +1043,13 @@ void setSgctDelegateFunctions() {
         w->setHorizFieldOfView(hFovDeg);
     };
     #ifdef WIN32
-    sgctDelegate.getNativeWindowHandle = [](size_t windowIndex) -> void* 
-    {
+    sgctDelegate.getNativeWindowHandle = [](size_t windowIndex) -> void* {
         sgct::SGCTWindow* w = sgct::Engine::instance()->getWindowPtr(windowIndex);
         if(w) {
                 HWND hWnd = glfwGetWin32Window(w->getWindowHandle());
                 return reinterpret_cast<void*>(hWnd);
         }
-        return (void*)nullptr;
+        return nullptr;
     };
     #endif // WIN32
     sgctDelegate.frustumMode = []() {

--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -1042,6 +1042,17 @@ void setSgctDelegateFunctions() {
         sgct::SGCTWindow* w = sgct::Engine::instance()->getWindowPtr(0);
         w->setHorizFieldOfView(hFovDeg);
     };
+    #ifdef WIN32
+    sgctDelegate.getNativeWindowHandle = [](size_t windowIndex) -> void* 
+    {
+        sgct::SGCTWindow* w = sgct::Engine::instance()->getWindowPtr(windowIndex);
+        if(w) {
+                HWND hWnd = glfwGetWin32Window(w->getWindowHandle());
+                return reinterpret_cast<void*>(hWnd);
+        }
+        return (void*)nullptr;
+    };
+    #endif // WIN32
     sgctDelegate.frustumMode = []() {
         using FM = sgct_core::Frustum::FrustumMode;
         switch (sgct::Engine::instance()->getCurrentFrustumMode()) {

--- a/include/openspace/engine/windowdelegate.h
+++ b/include/openspace/engine/windowdelegate.h
@@ -118,6 +118,8 @@ struct WindowDelegate {
     double (*getHorizFieldOfView)() = []() { return 0.0; };
 
     void (*setHorizFieldOfView)(float hFovDeg) = [](float) { };
+    
+    void* (*getNativeWindowHandle)(size_t windowIndex) = [](size_t) { return (void*)nullptr; };
 
     using GLProcAddress = void(*)(void);
 

--- a/include/openspace/engine/windowdelegate.h
+++ b/include/openspace/engine/windowdelegate.h
@@ -119,7 +119,9 @@ struct WindowDelegate {
 
     void (*setHorizFieldOfView)(float hFovDeg) = [](float) { };
     
-    void* (*getNativeWindowHandle)(size_t windowIndex) = [](size_t) { return (void*)nullptr; };
+    void* (*getNativeWindowHandle)(size_t windowIndex) = [](size_t) -> void* { 
+        return nullptr; 
+    };
 
     using GLProcAddress = void(*)(void);
 

--- a/modules/touch/CMakeLists.txt
+++ b/modules/touch/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADER_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/include/tuioear.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/touchinteraction.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/touchmarker.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/win32_touch.h
 )
 source_group("Header Files" FILES ${HEADER_FILES})
 
@@ -37,6 +38,7 @@ set(SOURCE_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tuioear.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/touchinteraction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/touchmarker.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/win32_touch.cpp
 )
 source_group("Source Files" FILES ${SOURCE_FILES})
 

--- a/modules/touch/include/tuioear.h
+++ b/modules/touch/include/tuioear.h
@@ -63,7 +63,6 @@ class TuioEar : public TUIO::TuioListener {
         ~TuioEar() {
             _tuioClient->disconnect();
             delete _tuioClient;
-            delete _oscReceiver;
         }
 
         /**
@@ -109,7 +108,6 @@ class TuioEar : public TUIO::TuioListener {
         std::mutex _mx;
 
         TUIO::TuioClient *_tuioClient;
-        TUIO::OscReceiver *_oscReceiver;
 
         std::vector<TUIO::TuioCursor> _list;
 

--- a/modules/touch/include/tuioear.h
+++ b/modules/touch/include/tuioear.h
@@ -61,8 +61,7 @@ class TuioEar : public TUIO::TuioListener {
     public:
         TuioEar();
         ~TuioEar() {
-            _tuioClient->disconnect();
-            delete _tuioClient;
+            _tuioClient.disconnect();
         }
 
         /**
@@ -107,7 +106,7 @@ class TuioEar : public TUIO::TuioListener {
         TUIO::TuioCursor _tapCo = TUIO::TuioCursor(-1, -1, -1.0f, -1.0f);
         std::mutex _mx;
 
-        TUIO::TuioClient *_tuioClient;
+        TUIO::TuioClient _tuioClient;
 
         std::vector<TUIO::TuioCursor> _list;
 

--- a/modules/touch/include/win32_touch.h
+++ b/modules/touch/include/win32_touch.h
@@ -1,4 +1,30 @@
-#pragma once
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2019                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_MODULE_TOUCH___WIN32_TOUCH___H__
+#define __OPENSPACE_MODULE_TOUCH___WIN32_TOUCH___H__
+
 #ifdef WIN32
 
 class Win32TouchHook {
@@ -11,3 +37,4 @@ private:
 };
 
 #endif //WIN32
+#endif //__OPENSPACE_MODULE_TOUCH___WIN32_TOUCH___H__

--- a/modules/touch/include/win32_touch.h
+++ b/modules/touch/include/win32_touch.h
@@ -1,0 +1,13 @@
+#pragma once
+#ifdef WIN32
+
+class Win32TouchHook {
+public:
+    Win32TouchHook(void* nativeWindowPtr);
+    ~Win32TouchHook();
+
+private:
+    bool _enabled;
+};
+
+#endif //WIN32

--- a/modules/touch/include/win32_touch.h
+++ b/modules/touch/include/win32_touch.h
@@ -27,14 +27,15 @@
 
 #ifdef WIN32
 
+namespace openspace {
+
 class Win32TouchHook {
 public:
-    Win32TouchHook(void* nativeWindowPtr);
+    Win32TouchHook(void* nativeWindow);
     ~Win32TouchHook();
-
-private:
-    bool _enabled;
 };
 
-#endif //WIN32
-#endif //__OPENSPACE_MODULE_TOUCH___WIN32_TOUCH___H__
+} // namespace openspace
+
+#endif // WIN32
+#endif // __OPENSPACE_MODULE_TOUCH___WIN32_TOUCH___H__

--- a/modules/touch/src/tuioear.cpp
+++ b/modules/touch/src/tuioear.cpp
@@ -115,12 +115,12 @@ void TuioEar::removeTuioBlob(TuioBlob*) { }
 void TuioEar::refresh(TuioTime) { } // about every 15ms
 
 std::vector<TuioCursor> TuioEar::getInput() {
-    std::lock_guard<std::mutex> lock(_mx);
+    std::lock_guard lock(_mx);
     return _list;
 }
 
 bool TuioEar::tap() {
-    std::lock_guard<std::mutex> lock(_mx);
+    std::lock_guard lock(_mx);
     if (_tap) {
         _tap = false;
         return !_tap;
@@ -131,7 +131,7 @@ bool TuioEar::tap() {
 }
 
 TuioCursor TuioEar::getTap() {
-    std::lock_guard<std::mutex> lock(_mx);
+    std::lock_guard lock(_mx);
     return _tapCo;
 }
 
@@ -159,8 +159,9 @@ void TuioEar::clearInput() {
 }
 
 // Standard UDP IP connection to port 3333
-TuioEar::TuioEar() {
-    _tuioClient = new TuioClient(3333);
-    _tuioClient->addTuioListener(this);
-    _tuioClient->connect();
+TuioEar::TuioEar()
+    : _tuioClient(3333)
+{
+    _tuioClient.addTuioListener(this);
+    _tuioClient.connect();
 }

--- a/modules/touch/src/tuioear.cpp
+++ b/modules/touch/src/tuioear.cpp
@@ -115,10 +115,12 @@ void TuioEar::removeTuioBlob(TuioBlob*) { }
 void TuioEar::refresh(TuioTime) { } // about every 15ms
 
 std::vector<TuioCursor> TuioEar::getInput() {
+    std::lock_guard<std::mutex> lock(_mx);
     return _list;
 }
 
 bool TuioEar::tap() {
+    std::lock_guard<std::mutex> lock(_mx);
     if (_tap) {
         _tap = false;
         return !_tap;
@@ -158,8 +160,7 @@ void TuioEar::clearInput() {
 
 // Standard UDP IP connection to port 3333
 TuioEar::TuioEar() {
-    _oscReceiver = new UdpReceiver(3333);
-    _tuioClient = new TuioClient(_oscReceiver);
+    _tuioClient = new TuioClient(3333);
     _tuioClient->addTuioListener(this);
     _tuioClient->connect();
 }

--- a/modules/touch/src/win32_touch.cpp
+++ b/modules/touch/src/win32_touch.cpp
@@ -23,95 +23,90 @@
  ****************************************************************************************/
 
 #ifdef WIN32
+
 #include <modules/touch/include/win32_touch.h>
 
 #include <openspace/engine/openspaceengine.h>
 #include <openspace/engine/windowdelegate.h>
-#include <TUIO/TuioServer.h>
 
 #include <ghoul/logging/logmanager.h>
+
+#include <TUIO/TuioServer.h>
 
 #include <tchar.h>
 #include <tpcshrd.h>
 
-//TODO: Make an application namespace?
-constexpr const char* _loggerCat = "win32_touch";
+namespace {
+    constexpr const char* _loggerCat = "win32_touch";
+    HHOOK gTouchHook{ nullptr };
+    bool gStarted{ false };
+    TUIO::TuioServer* gTuioServer{ nullptr };
+    std::unordered_map<UINT, TUIO::TuioCursor*> gCursorMap;
+}
 
-HHOOK g_touchHook{ nullptr };
-bool g_started{ false };
+namespace openspace {
 
-TUIO::TuioServer* g_tuioServer{ nullptr };
-std::unordered_map<UINT, TUIO::TuioCursor*> g_cursorMap;
-
-//This hook will only work for Win7+ Digitizers.
-//  - Once GLFW has native touch support, we can remove this windows-specific code
-LRESULT CALLBACK HookCallback(int nCode, WPARAM wParam, LPARAM lParam)
-{
-    if (nCode < 0) // do not process message 
-    {
+// This hook will only work for Win7+ Digitizers.
+// - Once GLFW has native touch support, we can remove this windows-specific code
+LRESULT CALLBACK HookCallback(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode < 0) {
         return CallNextHookEx(0, nCode, wParam, lParam);
     }
-
-    switch (nCode)
-    {
-    case HC_ACTION:
-        LPMSG pStruct = (LPMSG)lParam;
-        UINT message = pStruct->message;
+    if (nCode == HC_ACTION) {
+        LPMSG pStruct = reinterpret_cast<LPMSG>(lParam);
+        const UINT message = pStruct->message;
         switch (message) {
-        case WM_POINTERDOWN:
-        case WM_POINTERUPDATE:
-        case WM_POINTERUP:
-        {
-            POINTER_INFO pointerInfo = {};
-            if (GetPointerInfo(GET_POINTERID_WPARAM(pStruct->wParam), &pointerInfo)) {
-                RECT rect;
-                GetClientRect(pStruct->hwnd, (LPRECT)&rect);
+            case WM_POINTERDOWN:
+            case WM_POINTERUPDATE:
+            case WM_POINTERUP:
+            {
+                POINTER_INFO pointerInfo = {};
+                if (GetPointerInfo(GET_POINTERID_WPARAM(pStruct->wParam), &pointerInfo)) {
+                    RECT rect;
+                    GetClientRect(pStruct->hwnd, reinterpret_cast<LPRECT>(&rect));
 
-                POINT p = pointerInfo.ptPixelLocation;
-                // native touch to screen conversion
-                ScreenToClient(pStruct->hwnd, (LPPOINT)&p);
+                    POINT p = pointerInfo.ptPixelLocation;
+                    // native touch to screen conversion
+                    ScreenToClient(pStruct->hwnd, reinterpret_cast<LPPOINT>(&p));
 
-                float xPos = (float)p.x / (float)(rect.right - rect.left);
-                float yPos = (float)p.y / (float)(rect.bottom - rect.top);               
-                if (pointerInfo.pointerFlags & POINTER_FLAG_DOWN) {
-                    //Handle new touchpoint
-                    g_tuioServer->initFrame(TUIO::TuioTime::getSessionTime());
-                    g_cursorMap[pointerInfo.pointerId] = g_tuioServer->addTuioCursor(xPos, yPos);
-                    g_tuioServer->commitFrame();
-                }
-                else if (pointerInfo.pointerFlags & POINTER_FLAG_UPDATE) {
-                    //Handle update of touchpoint
-                    TUIO::TuioTime frameTime = TUIO::TuioTime::getSessionTime();
-                    if (g_cursorMap[pointerInfo.pointerId]->getTuioTime() == frameTime)
-                    {
-                        break;
+                    float xPos = (float)p.x / (float)(rect.right - rect.left);
+                    float yPos = (float)p.y / (float)(rect.bottom - rect.top);
+                    if (pointerInfo.pointerFlags & POINTER_FLAG_DOWN) {
+                        // Handle new touchpoint
+                        gTuioServer->initFrame(TUIO::TuioTime::getSessionTime());
+                        gCursorMap[pointerInfo.pointerId] = gTuioServer->addTuioCursor(xPos, yPos);
+                        gTuioServer->commitFrame();
                     }
-                    g_tuioServer->initFrame(frameTime);
-                    g_tuioServer->updateTuioCursor(g_cursorMap[pointerInfo.pointerId], xPos, yPos);
-                    g_tuioServer->commitFrame();
+                    else if (pointerInfo.pointerFlags & POINTER_FLAG_UPDATE) {
+                        // Handle update of touchpoint
+                        TUIO::TuioTime frameTime = TUIO::TuioTime::getSessionTime();
+                        if (gCursorMap[pointerInfo.pointerId]->getTuioTime() == frameTime) {
+                            break;
+                        }
+                        gTuioServer->initFrame(frameTime);
+                        gTuioServer->updateTuioCursor(gCursorMap[pointerInfo.pointerId], xPos, yPos);
+                        gTuioServer->commitFrame();
+                    }
+                    else if (pointerInfo.pointerFlags & POINTER_FLAG_UP) {
+                        // Handle removed touchpoint
+                        gTuioServer->initFrame(TUIO::TuioTime::getSessionTime());
+                        gTuioServer->removeTuioCursor(gCursorMap[pointerInfo.pointerId]);
+                        gTuioServer->commitFrame();
+                        gCursorMap.erase(pointerInfo.pointerId);
+                    }
                 }
-                else if (pointerInfo.pointerFlags & POINTER_FLAG_UP) {
-                    //Handle removed touchpoint
-                    g_tuioServer->initFrame(TUIO::TuioTime::getSessionTime());
-                    g_tuioServer->removeTuioCursor(g_cursorMap[pointerInfo.pointerId]);
-                    g_tuioServer->commitFrame();
-                    g_cursorMap.erase(pointerInfo.pointerId);
-                }
+                break;
             }
-            break;
         }
-        }
-        break;
     }
 
-    //Pass the hook along!
+    // Pass the hook along!
     return CallNextHookEx(0, nCode, wParam, lParam);
 }
 
-Win32TouchHook::Win32TouchHook(void* nativeWindowPtr)
-    : _enabled(false)
+Win32TouchHook::Win32TouchHook(void* nativeWindow)
 {
-    HWND hWnd = reinterpret_cast<HWND>(nativeWindowPtr);
+    HWND hWnd = reinterpret_cast<HWND>(nativeWindow);
     if (hWnd == nullptr) {
         LINFO("No windowhandle available for touch input.");
         return;
@@ -119,24 +114,24 @@ Win32TouchHook::Win32TouchHook(void* nativeWindowPtr)
 
     // Test for touch:
     int value = GetSystemMetrics(SM_DIGITIZER);
-    if (value & NID_READY) { 
-        // stack ready, drivers installed and digitizer is ready for input
-    }
-    else {
-        //Don't bother setting up touch hooks?
+    if ((value & NID_READY) == 0) { 
+        // Don't bother setting up touch hooks?
         return;
     }
+    // stack ready, drivers installed and digitizer is ready for input
     if (value & NID_MULTI_INPUT) {
-        /* digitizer is multitouch */
+        // Digitizer is multitouch
         LINFO("Found Multitouch input digitizer!");
     }
-    if (value & NID_INTEGRATED_TOUCH) { /* Integrated touch */ }
+    if (value & NID_INTEGRATED_TOUCH) { 
+        // Integrated touch
+    }
 
-    //This should be needed, but we seem to receive messages even without it,
-    //probably a Win7+ behaviour
-    //Also - RegisterTouchWindow enables Windows gestures, which we don't want
-    //since they produce visual feedback for "press-and-tap" etc.
-    //RegisterTouchWindow(hWnd, TWF_FINETOUCH | TWF_WANTPALM);
+    // This should be needed, but we seem to receive messages even without it,
+    // probably a Win7+ behaviour
+    // Also - RegisterTouchWindow enables Windows gestures, which we don't want
+    // since they produce visual feedback for "press-and-tap" etc.
+    // RegisterTouchWindow(hWnd, TWF_FINETOUCH | TWF_WANTPALM);
 
     // TODO: Would be nice to find out if the gesture "press-and-tap" can be disabled
     // basically we don't really care for windows gestures for now...
@@ -144,24 +139,28 @@ Win32TouchHook::Win32TouchHook(void* nativeWindowPtr)
     const DWORD dwHwndTabletProperty = TABLET_DISABLE_PRESSANDHOLD; 
 
     ATOM atom = ::GlobalAddAtom(MICROSOFT_TABLETPENSERVICE_PROPERTY);
-    ::SetProp(hWnd, MICROSOFT_TABLETPENSERVICE_PROPERTY, 
-        reinterpret_cast<HANDLE>(dwHwndTabletProperty));
+    ::SetProp(hWnd, MICROSOFT_TABLETPENSERVICE_PROPERTY, reinterpret_cast<HANDLE>(dwHwndTabletProperty));
     ::GlobalDeleteAtom(atom);
 
-    if (!g_started) {
-        g_tuioServer = new TUIO::TuioServer("localhost", 3333);
-        if (!(g_touchHook = SetWindowsHookExW(WH_GETMESSAGE, HookCallback, GetModuleHandleW(NULL), GetCurrentThreadId()))) {
-            LINFO(fmt::format("Failed to setup WindowsHook for touch input redirection"));
-        }
+    if (!gStarted) {
+        gStarted = true;
+        gTuioServer = new TUIO::TuioServer("localhost", 3333);
         TUIO::TuioTime::initSession();
+        gTouchHook = SetWindowsHookExW(WH_GETMESSAGE, HookCallback, GetModuleHandleW(NULL), GetCurrentThreadId());
+        if (!gTouchHook) {
+            LINFO(fmt::format("Failed to setup WindowsHook for touch input redirection"));
+            delete gTuioServer;
+            gStarted = false;
+        }
     }
 }
 
 Win32TouchHook::~Win32TouchHook() {
-    if (_enabled) {
-        UnhookWindowsHookEx(g_touchHook);
-        delete g_tuioServer;
+    if (gStarted) {
+        UnhookWindowsHookEx(gTouchHook);
+        delete gTuioServer;
     }
 }
 
-#endif //WIN32
+} // namespace openspace
+#endif // WIN32

--- a/modules/touch/src/win32_touch.cpp
+++ b/modules/touch/src/win32_touch.cpp
@@ -1,3 +1,27 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2019                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
 #ifdef WIN32
 #include <modules/touch/include/win32_touch.h>
 

--- a/modules/touch/src/win32_touch.cpp
+++ b/modules/touch/src/win32_touch.cpp
@@ -1,0 +1,143 @@
+#ifdef WIN32
+#include <modules/touch/include/win32_touch.h>
+
+#include <openspace/engine/openspaceengine.h>
+#include <openspace/engine/windowdelegate.h>
+#include <TUIO/TuioServer.h>
+
+#include <ghoul/logging/logmanager.h>
+
+#include <tchar.h>
+#include <tpcshrd.h>
+
+//TODO: Make an application namespace?
+constexpr const char* _loggerCat = "win32_touch";
+
+HHOOK g_touchHook{ nullptr };
+bool g_started{ false };
+
+TUIO::TuioServer* g_tuioServer{ nullptr };
+std::unordered_map<UINT, TUIO::TuioCursor*> g_cursorMap;
+
+//This hook will only work for Win7+ Digitizers.
+//  - Once GLFW has native touch support, we can remove this windows-specific code
+LRESULT CALLBACK HookCallback(int nCode, WPARAM wParam, LPARAM lParam)
+{
+    if (nCode < 0) // do not process message 
+    {
+        return CallNextHookEx(0, nCode, wParam, lParam);
+    }
+
+    switch (nCode)
+    {
+    case HC_ACTION:
+        LPMSG pStruct = (LPMSG)lParam;
+        UINT message = pStruct->message;
+        switch (message) {
+        case WM_POINTERDOWN:
+        case WM_POINTERUPDATE:
+        case WM_POINTERUP:
+        {
+            POINTER_INFO pointerInfo = {};
+            if (GetPointerInfo(GET_POINTERID_WPARAM(pStruct->wParam), &pointerInfo)) {
+                RECT rect;
+                GetClientRect(pStruct->hwnd, (LPRECT)&rect);
+
+                POINT p = pointerInfo.ptPixelLocation;
+                // native touch to screen conversion
+                ScreenToClient(pStruct->hwnd, (LPPOINT)&p);
+
+                float xPos = (float)p.x / (float)(rect.right - rect.left);
+                float yPos = (float)p.y / (float)(rect.bottom - rect.top);               
+                if (pointerInfo.pointerFlags & POINTER_FLAG_DOWN) {
+                    //Handle new touchpoint
+                    g_tuioServer->initFrame(TUIO::TuioTime::getSessionTime());
+                    g_cursorMap[pointerInfo.pointerId] = g_tuioServer->addTuioCursor(xPos, yPos);
+                    g_tuioServer->commitFrame();
+                }
+                else if (pointerInfo.pointerFlags & POINTER_FLAG_UPDATE) {
+                    //Handle update of touchpoint
+                    TUIO::TuioTime frameTime = TUIO::TuioTime::getSessionTime();
+                    if (g_cursorMap[pointerInfo.pointerId]->getTuioTime() == frameTime)
+                    {
+                        break;
+                    }
+                    g_tuioServer->initFrame(frameTime);
+                    g_tuioServer->updateTuioCursor(g_cursorMap[pointerInfo.pointerId], xPos, yPos);
+                    g_tuioServer->commitFrame();
+                }
+                else if (pointerInfo.pointerFlags & POINTER_FLAG_UP) {
+                    //Handle removed touchpoint
+                    g_tuioServer->initFrame(TUIO::TuioTime::getSessionTime());
+                    g_tuioServer->removeTuioCursor(g_cursorMap[pointerInfo.pointerId]);
+                    g_tuioServer->commitFrame();
+                    g_cursorMap.erase(pointerInfo.pointerId);
+                }
+            }
+            break;
+        }
+        }
+        break;
+    }
+
+    //Pass the hook along!
+    return CallNextHookEx(0, nCode, wParam, lParam);
+}
+
+Win32TouchHook::Win32TouchHook(void* nativeWindowPtr)
+    : _enabled(false)
+{
+    HWND hWnd = reinterpret_cast<HWND>(nativeWindowPtr);
+    if (hWnd == nullptr) {
+        LINFO("No windowhandle available for touch input.");
+        return;
+    }
+
+    // Test for touch:
+    int value = GetSystemMetrics(SM_DIGITIZER);
+    if (value & NID_READY) { 
+        // stack ready, drivers installed and digitizer is ready for input
+    }
+    else {
+        //Don't bother setting up touch hooks?
+        return;
+    }
+    if (value & NID_MULTI_INPUT) {
+        /* digitizer is multitouch */
+        LINFO("Found Multitouch input digitizer!");
+    }
+    if (value & NID_INTEGRATED_TOUCH) { /* Integrated touch */ }
+
+    //This should be needed, but we seem to receive messages even without it,
+    //probably a Win7+ behaviour
+    //Also - RegisterTouchWindow enables Windows gestures, which we don't want
+    //since they produce visual feedback for "press-and-tap" etc.
+    //RegisterTouchWindow(hWnd, TWF_FINETOUCH | TWF_WANTPALM);
+
+    // TODO: Would be nice to find out if the gesture "press-and-tap" can be disabled
+    // basically we don't really care for windows gestures for now...
+    // this disables press and hold (right-click) gesture
+    const DWORD dwHwndTabletProperty = TABLET_DISABLE_PRESSANDHOLD; 
+
+    ATOM atom = ::GlobalAddAtom(MICROSOFT_TABLETPENSERVICE_PROPERTY);
+    ::SetProp(hWnd, MICROSOFT_TABLETPENSERVICE_PROPERTY, 
+        reinterpret_cast<HANDLE>(dwHwndTabletProperty));
+    ::GlobalDeleteAtom(atom);
+
+    if (!g_started) {
+        g_tuioServer = new TUIO::TuioServer("localhost", 3333);
+        if (!(g_touchHook = SetWindowsHookExW(WH_GETMESSAGE, HookCallback, GetModuleHandleW(NULL), GetCurrentThreadId()))) {
+            LINFO(fmt::format("Failed to setup WindowsHook for touch input redirection"));
+        }
+        TUIO::TuioTime::initSession();
+    }
+}
+
+Win32TouchHook::~Win32TouchHook() {
+    if (_enabled) {
+        UnhookWindowsHookEx(g_touchHook);
+        delete g_tuioServer;
+    }
+}
+
+#endif //WIN32

--- a/modules/touch/touchmodule.cpp
+++ b/modules/touch/touchmodule.cpp
@@ -158,6 +158,8 @@ TouchModule::TouchModule()
         LDEBUGC("TouchModule", "Initializing TouchMarker OpenGL");
         _markers.initialize();
 #ifdef WIN32
+    //We currently only support one window of touch input internally
+    //so here we grab the first window-handle and use it.
     void* nativeWindowHandle = global::windowDelegate.getNativeWindowHandle(0);
     if (nativeWindowHandle) {
         _win32TouchHook.reset(new Win32TouchHook(nativeWindowHandle));

--- a/modules/touch/touchmodule.cpp
+++ b/modules/touch/touchmodule.cpp
@@ -23,6 +23,7 @@
  ****************************************************************************************/
 
 #include <modules/touch/touchmodule.h>
+#include <modules/touch/include/win32_touch.h>
 
 #include <modules/webgui/webguimodule.h>
 #include <openspace/engine/globals.h>
@@ -156,6 +157,12 @@ TouchModule::TouchModule()
     global::callback::initializeGL.push_back([&]() {
         LDEBUGC("TouchModule", "Initializing TouchMarker OpenGL");
         _markers.initialize();
+#ifdef WIN32
+    void* nativeWindowHandle = global::windowDelegate.getNativeWindowHandle(0);
+    if (nativeWindowHandle) {
+        _win32TouchHook.reset(new Win32TouchHook(nativeWindowHandle));
+    }
+#endif //WIN32
     });
 
     global::callback::deinitializeGL.push_back([&]() {

--- a/modules/touch/touchmodule.cpp
+++ b/modules/touch/touchmodule.cpp
@@ -158,8 +158,8 @@ TouchModule::TouchModule()
         LDEBUGC("TouchModule", "Initializing TouchMarker OpenGL");
         _markers.initialize();
 #ifdef WIN32
-    //We currently only support one window of touch input internally
-    //so here we grab the first window-handle and use it.
+    // We currently only support one window of touch input internally
+    // so here we grab the first window-handle and use it.
     void* nativeWindowHandle = global::windowDelegate.getNativeWindowHandle(0);
     if (nativeWindowHandle) {
         _win32TouchHook.reset(new Win32TouchHook(nativeWindowHandle));
@@ -197,6 +197,10 @@ TouchModule::TouchModule()
 
     global::callback::render.push_back([&]() { _markers.render(_listOfContactPoints); });
 
+}
+
+TouchModule::~TouchModule() {
+    //intentionally left empty
 }
 
 } // namespace openspace

--- a/modules/touch/touchmodule.h
+++ b/modules/touch/touchmodule.h
@@ -29,16 +29,17 @@
 #include <modules/touch/include/touchmarker.h>
 #include <modules/touch/include/touchinteraction.h>
 
-#ifdef WIN32
-class Win32TouchHook;
-#endif //WIN32
 
 namespace openspace {
+    #ifdef WIN32
+    class Win32TouchHook;
+    #endif //WIN32
 
     class TouchModule : public OpenSpaceModule {
         using Point = std::pair<int, TUIO::TuioPoint>;
     public:
         TouchModule();
+        ~TouchModule();
 
     private:
         /**

--- a/modules/touch/touchmodule.h
+++ b/modules/touch/touchmodule.h
@@ -29,6 +29,9 @@
 #include <modules/touch/include/touchmarker.h>
 #include <modules/touch/include/touchinteraction.h>
 
+#ifdef WIN32
+class Win32TouchHook;
+#endif //WIN32
 
 namespace openspace {
 
@@ -54,6 +57,9 @@ namespace openspace {
         // contains an id and the TuioPoint that was processed last frame
         std::vector<Point> _lastProcessed;
         glm::ivec2 _webPositionCallback = glm::ivec2(0,0);
+#ifdef WIN32
+        std::unique_ptr<Win32TouchHook> _win32TouchHook;
+#endif //WIN32
     };
 
 } // namespace openspace


### PR DESCRIPTION
Integrated a kind of touch-server into the touch module.
This only changes the behaviour of the touch module on windows, whereas on mac/linux one would still have to handle touch-to-tuio separately.

Current implementation creates a windows message-hook which listens to touch events and forwards them as TUIO-messages to the touch client(tuioear.cpp). 
In tuioear.cpp - two locks have been added since a smaller race condition seemed to be in place.