### PR TITLE
support curl version < 7.32.0, i.e. rhel/centos 7

### DIFF
--- a/src/engine/downloadmanager.cpp
+++ b/src/engine/downloadmanager.cpp
@@ -187,8 +187,12 @@ std::shared_ptr<DownloadManager::FileFuture> DownloadManager::downloadFile(
                 std::chrono::system_clock::now(),
                 &progressCb
             };
+            #if LIBCURL_VERSION_NUM >= 0x072000
+            // xferinfo was introduced in 7.32.0, if a lower curl version is used the progress
+            // will not be shown for downloads on the splash screen
             curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xferinfo); // NOLINT
             curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &p); // NOLINT
+            #endif
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L); // NOLINT
 
             CURLcode res = curl_easy_perform(curl);

--- a/src/util/httprequest.cpp
+++ b/src/util/httprequest.cpp
@@ -124,9 +124,13 @@ void HttpRequest::perform(RequestOptions opt) {
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlfunctions::writeCallback);
 
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L); // NOLINT
+    #if LIBCURL_VERSION_NUM >= 0x072000
+    // xferinfo was introduced in 7.32.0, if a lower curl version is used the progress
+    // will not be shown for downloads on the splash screen
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA, this); // NOLINT
     // NOLINTNEXTLINE
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, curlfunctions::progressCallback);
+    #endif
 
     if (opt.requestTimeoutSeconds > 0) {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, opt.requestTimeoutSeconds); // NOLINT


### PR DESCRIPTION
This will make it possible to build OpenSpace on a Linux OS with an older curl version. The curl progress will not be shown on the splash screen but will instead be outputted in the console. I have verified that the download works on both cases on Linux.