### PR TITLE
Feature/touch improvements

### DIFF
--- a/modules/touch/touchmodule.cpp
+++ b/modules/touch/touchmodule.cpp
@@ -177,6 +177,7 @@ TouchModule::TouchModule()
 {
     addPropertySubOwner(_touch);
     addPropertySubOwner(_markers);
+    addProperty(_touchActive);
     _touchActive.onChange([&] {
         _touch.resetAfterInput();
         _lastTouchInputs.clear();

--- a/modules/touch/touchmodule.h
+++ b/modules/touch/touchmodule.h
@@ -64,6 +64,7 @@ private:
     std::vector<TouchInput> _deferredRemovals;
     std::vector<TouchInput> _lastTouchInputs;
 
+    properties::BoolProperty _touchActive;
     // contains an id and the Point that was processed last frame
     glm::ivec2 _webPositionCallback = glm::ivec2(0,0);
 #ifdef WIN32


### PR DESCRIPTION
This PR adds a Property (TouchActive) to the TouchModule which can be used to inactivate/reactivate the touch 3D navigation, without changing the GUI behavior.

It also fixes a bug which caused erratic zooming behaviour when touch navigation was active.  If the user focused a larger body, and switched back to a smaller one, the boundingbox of the large body would keep deciding the closest distance to the smaller object. This has been fixed.