### PR TITLE
Issue/1065

### DIFF
--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -249,6 +249,18 @@ RenderableTrail::RenderableTrail(const ghoul::Dictionary& dictionary)
 }
 
 void RenderableTrail::initializeGL() {
+#ifdef __APPLE__
+    _programObject = BaseModule::ProgramObjectManager.request(
+        ProgramName,
+        []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
+            return global::renderEngine.buildRenderProgram(
+                ProgramName,
+                absPath("${MODULE_BASE}/shaders/renderabletrail_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/renderabletrail_apple_fs.glsl")
+            );
+        }
+    );
+#else
     _programObject = BaseModule::ProgramObjectManager.request(
         ProgramName,
         []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
@@ -259,6 +271,7 @@ void RenderableTrail::initializeGL() {
             );
         }
     );
+#endif
 
     ghoul::opengl::updateUniformLocations(*_programObject, _uniformCache, UniformNames);
 }
@@ -320,7 +333,11 @@ void RenderableTrail::render(const RenderData& data, RendererTasks&) {
                               (_appearance.renderingModes == RenderingModeLinesPoints);
 
     if (renderLines) {
+#ifdef __APPLE__
+        glLineWidth(1.f);
+#else
         glLineWidth(ceil((2.f * 1.f + _appearance.lineWidth) * std::sqrt(2.f)));
+#endif
     }
     if (renderPoints) {
         glEnable(GL_PROGRAM_POINT_SIZE);

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -255,7 +255,7 @@ void RenderableTrail::initializeGL() {
         []() -> std::unique_ptr<ghoul::opengl::ProgramObject> {
             return global::renderEngine.buildRenderProgram(
                 ProgramName,
-                absPath("${MODULE_BASE}/shaders/renderabletrail_vs.glsl"),
+                absPath("${MODULE_BASE}/shaders/renderabletrail_apple_vs.glsl"),
                 absPath("${MODULE_BASE}/shaders/renderabletrail_apple_fs.glsl")
             );
         }

--- a/modules/base/shaders/renderabletrail_apple_fs.glsl
+++ b/modules/base/shaders/renderabletrail_apple_fs.glsl
@@ -1,0 +1,68 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2019                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include "fragment.glsl"
+
+in float vs_positionDepth;
+in vec4 vs_gPosition;
+in float fade;
+
+uniform vec3 color;
+uniform int renderPhase;
+uniform float opacity = 1.0;
+
+// Fragile! Keep in sync with RenderableTrail::render::RenderPhase 
+#define RenderPhaseLines 0
+#define RenderPhasePoints 1
+
+#define Delta 0.25
+
+
+Fragment getFragment() {
+    Fragment frag;
+    frag.color = vec4(color * fade, fade * opacity);
+    frag.depth = vs_positionDepth;
+    frag.blend = BLEND_MODE_ADDITIVE;
+
+    if (renderPhase == RenderPhasePoints) {
+        // Use the length of the vector (dot(circCoord, circCoord)) as factor in the
+        // smoothstep to gradually decrease the alpha on the edges of the point
+        vec2 circCoord = 2.0 * gl_PointCoord - 1.0;
+        //float circleClipping = 1.0 - smoothstep(1.0 - Delta, 1.0, dot(circCoord, circCoord));        
+        float circleClipping = smoothstep(1.0, 1.0 - Delta, dot(circCoord, circCoord));
+        float transparencyCorrection = frag.color.a * circleClipping;
+        if (transparencyCorrection < 0.9) {
+            discard;
+        }
+
+        frag.color.a = transparencyCorrection;
+    }
+
+    frag.gPosition = vs_gPosition;
+
+    // There is no normal here
+    frag.gNormal = vec4(0.0, 0.0, -1.0, 1.0);
+
+    return frag;
+}

--- a/modules/base/shaders/renderabletrail_apple_vs.glsl
+++ b/modules/base/shaders/renderabletrail_apple_vs.glsl
@@ -1,0 +1,83 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2019                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#version __CONTEXT__
+
+#include "PowerScaling/powerScaling_vs.hglsl"
+
+layout(location = 0) in vec3 in_point_position;
+
+out float vs_positionDepth;
+out vec4 vs_gPosition;
+out float fade;
+
+uniform dmat4 modelViewTransform;
+uniform mat4 projectionTransform;
+uniform int idOffset;
+uniform int nVertices;
+uniform bool useLineFade;
+uniform float lineFade;
+uniform int vertexSortingMethod;
+uniform int pointSize;
+uniform int stride;
+
+uniform ivec2 resolution;
+
+// Fragile! Keep in sync with RenderableTrail::render
+#define VERTEX_SORTING_NEWESTFIRST 0
+#define VERTEX_SORTING_OLDESTFIRST 1
+#define VERTEX_SORTING_NOSORTING 2
+
+
+void main() {
+    int modId = gl_VertexID;
+
+    if ((vertexSortingMethod != VERTEX_SORTING_NOSORTING) && useLineFade) {
+        // Account for a potential rolling buffer
+        modId = gl_VertexID - idOffset;
+        if (modId < 0) {
+            modId += nVertices;
+        }
+
+        // Convert the index to a [0,1] ranger
+        float id = float(modId) / float(nVertices);
+
+        if (vertexSortingMethod == VERTEX_SORTING_NEWESTFIRST) {
+            id = 1.0 - id;
+        }
+
+        fade = clamp(id * lineFade, 0.0, 1.0); 
+    }
+    else {
+        fade = 1.0;
+    }
+
+    vs_gPosition = vec4(modelViewTransform * dvec4(in_point_position, 1));
+    vec4 vs_positionClipSpace = projectionTransform * vs_gPosition;
+    vs_positionDepth = vs_positionClipSpace.w;
+    
+    gl_PointSize = (stride == 1 || int(modId) % stride == 0) ? 
+                    float(pointSize) : float(pointSize) / 2;
+    gl_Position  = z_normalization(vs_positionClipSpace);
+}


### PR DESCRIPTION
The new AA lines won't work on Mac. That's because glLineWidth is deprecated in OpenGL core and removed support for it on macOS.
A new AA solution for Mac must be developed.