### PR TITLE
Changed glm include path

### DIFF
--- a/include/openspace/util/touch.h
+++ b/include/openspace/util/touch.h
@@ -25,7 +25,7 @@
 #ifndef __OPENSPACE_CORE___TOUCH___H__
 #define __OPENSPACE_CORE___TOUCH___H__
 
-#include <glm/detail/type_vec2.hpp>
+#include <glm/vec2.hpp>
 
 #include <cstdint>
 #include <deque>


### PR DESCRIPTION
This should fix builds since another version of glm handles these include paths somewhat differently.