### PR TITLE
Changed webbrowser to use cef touch events

### DIFF
--- a/modules/webbrowser/include/browserinstance.h
+++ b/modules/webbrowser/include/browserinstance.h
@@ -84,7 +84,9 @@ public:
     void draw();
     void close(bool force = false);
 
+#ifdef WIN32
     void sendTouchEvent(const CefTouchEvent& event) const;
+#endif
 
     bool sendKeyEvent(const CefKeyEvent& event);
     bool sendMouseClickEvent(const CefMouseEvent& event,

--- a/modules/webbrowser/include/browserinstance.h
+++ b/modules/webbrowser/include/browserinstance.h
@@ -84,10 +84,7 @@ public:
     void draw();
     void close(bool force = false);
 
-    void sendTouchPressEvent(const CefMouseEvent & event,
-        CefBrowserHost::MouseButtonType button, const int clickCount);
-    void sendResleasePressEvent(const CefMouseEvent & event,
-        CefBrowserHost::MouseButtonType button, const int clickCount);
+    void sendTouchEvent(const CefTouchEvent& event) const;
 
     bool sendKeyEvent(const CefKeyEvent& event);
     bool sendMouseClickEvent(const CefMouseEvent& event,

--- a/modules/webbrowser/include/eventhandler.h
+++ b/modules/webbrowser/include/eventhandler.h
@@ -84,8 +84,19 @@ private:
      */
     CefMouseEvent mouseEvent(KeyModifier mods = KeyModifier::NoModifier);
 
+#ifdef WIN32
+    /**
+     * Build a CEF touch event based on our internal structure
+     * 
+     * Note: as of 02/21/2020 we are using an older version of CEF on OSX
+     * than WIN32.
+     * This version does not handle the CefTouchEvent type and does
+     * not have any internal touch handling.
+     */
     CefTouchEvent touchEvent(const TouchInput& input,
         const cef_touch_event_type_t eventType) const;
+#endif
+
     /**
      * Find the CEF key event to use for a given action.
      *

--- a/modules/webbrowser/include/eventhandler.h
+++ b/modules/webbrowser/include/eventhandler.h
@@ -84,6 +84,8 @@ private:
      */
     CefMouseEvent mouseEvent(KeyModifier mods = KeyModifier::NoModifier);
 
+    CefTouchEvent touchEvent(const TouchInput& input,
+        const cef_touch_event_type_t eventType) const;
     /**
      * Find the CEF key event to use for a given action.
      *

--- a/modules/webbrowser/src/browserinstance.cpp
+++ b/modules/webbrowser/src/browserinstance.cpp
@@ -149,9 +149,11 @@ bool BrowserInstance::sendMouseClickEvent(const CefMouseEvent& event,
     return hasContent(event.x, event.y);
 }
 
+#ifdef WIN32
 void BrowserInstance::sendTouchEvent(const CefTouchEvent& event) const{
     _browser->GetHost()->SendTouchEvent(event);
 }
+#endif
 
 bool BrowserInstance::sendMouseMoveEvent(const CefMouseEvent& event) {
     constexpr const bool DidNotLeaveWindow = false;

--- a/modules/webbrowser/src/browserinstance.cpp
+++ b/modules/webbrowser/src/browserinstance.cpp
@@ -149,18 +149,8 @@ bool BrowserInstance::sendMouseClickEvent(const CefMouseEvent& event,
     return hasContent(event.x, event.y);
 }
 
-void BrowserInstance::sendTouchPressEvent(const CefMouseEvent& event,
-                                          CefBrowserHost::MouseButtonType button,
-                                          const int clickCount)
-{
-    _browser->GetHost()->SendMouseClickEvent(event, button, false, clickCount);
-}
-
-void BrowserInstance::sendResleasePressEvent(const CefMouseEvent& event,
-                                             CefBrowserHost::MouseButtonType button,
-                                             const int clickCount)
-{
-    _browser->GetHost()->SendMouseClickEvent(event, button, true, clickCount);
+void BrowserInstance::sendTouchEvent(const CefTouchEvent& event) const{
+    _browser->GetHost()->SendTouchEvent(event);
 }
 
 bool BrowserInstance::sendMouseMoveEvent(const CefMouseEvent& event) {

--- a/modules/webbrowser/src/eventhandler.cpp
+++ b/modules/webbrowser/src/eventhandler.cpp
@@ -28,6 +28,8 @@
 #include <openspace/engine/globalscallbacks.h>
 #include <openspace/engine/globals.h>
 #include <openspace/engine/windowdelegate.h>
+#include <openspace/interaction/navigationhandler.h>
+#include <openspace/interaction/inputstate.h>
 #include <openspace/interaction/interactionmonitor.h>
 #include <ghoul/logging/logmanager.h>
 #include <fmt/format.h>
@@ -473,8 +475,12 @@ CefTouchEvent EventHandler::touchEvent(const TouchInput& input,
     event.x = windowPos.x;
     event.y = windowPos.y;
     event.type = eventType;
-    //TODO: We should probably use key mods for touch as well:
-    // event.modifiers = mods;
+    const std::vector<std::pair<Key, KeyModifier>> &keyModVec = 
+        global::navigationHandler.inputState().pressedKeys();
+    for (auto keyModPair : keyModVec) {
+        const KeyModifier mods = keyModVec[0].second;
+        event.modifiers |= static_cast<uint32_t>(mapToCefModifiers(mods));
+    }
     event.pointer_type = cef_pointer_type_t::CEF_POINTER_TYPE_TOUCH;
     return event;
 }


### PR DESCRIPTION
This PR changes the internal behaviour of the Cef webbrowser to treat touch events as true touch points (cef-wise) rather than as an injected mouse event.

This means that scrolling in menus, panning and potentially zooming of canvases should be possible through the means of touch.

For this to work, a newer CEF version than the one OSX currently uses is required. However, bumping CEF is not included in this PR, so touch is treated as injected mouse events on mac.