### PR TITLE
Added a way to customize renderable distance labels unit

### DIFF
--- a/modules/base/rendering/renderablelabels.cpp
+++ b/modules/base/rendering/renderablelabels.cpp
@@ -784,4 +784,22 @@ float RenderableLabels::unit(int unit) const {
     }
 }
 
+std::string RenderableLabels::toString(int unit) const {
+    switch (static_cast<Unit>(unit)) {
+        case Meter: return MeterUnit;
+        case Kilometer: return KilometerUnit;
+        case Megameter: return  MegameterUnit;
+        case Gigameter: return GigameterUnit;
+        case AU: return AstronomicalUnit;
+        case Terameter: return TerameterUnit;
+        case Petameter: return PetameterUnit;
+        case Parsec: return ParsecUnit;
+        case Kiloparsec: return KiloparsecUnit;
+        case Megaparsec: return MegaparsecUnit;
+        case Gigaparsec: return GigaparsecUnit;
+        case GigalightYears: return GigalightyearUnit;
+        default: throw std::logic_error("Missing case label");
+    }
+}
+
 } // namespace openspace

--- a/modules/base/rendering/renderablelabels.h
+++ b/modules/base/rendering/renderablelabels.h
@@ -74,6 +74,8 @@ protected:
 
     float unit(int unit) const;
 
+    std::string toString(int unit) const;
+
     // Data may require some type of transformation prior the spice transformation being
     // applied.
     glm::dmat4 _transformationMatrix = glm::dmat4(1.0);

--- a/modules/vislab/rendering/renderabledistancelabel.cpp
+++ b/modules/vislab/rendering/renderabledistancelabel.cpp
@@ -42,6 +42,20 @@ namespace {
         "Property to track a nodeline. When tracking the label text will be updating the "
         "distance from the nodeline start and end."
     };
+
+    constexpr openspace::properties::Property::PropertyInfo DistanceUnitInfo = {
+        "DistanceUnit",
+        "Distance Unit",
+        "Property to define the unit in which the distance should be displayed."
+        "Defaults to 'km' if not specified."
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo CustomUnitDescriptorInfo = {
+        "CustomUnitDescriptor",
+        "Custom Unit Descriptor",
+        "Property to define a custom unit descriptor to use to describe the distance value."
+        "Defaults to the units SI descriptor if not specified."
+    };
 }
 
 namespace openspace {
@@ -58,6 +72,18 @@ documentation::Documentation RenderableDistanceLabel::Documentation() {
                 Optional::No,
                 NodeLineInfo.description
             },
+            {
+                DistanceUnitInfo.identifier,
+                new IntVerifier,
+                Optional::Yes,
+                DistanceUnitInfo.description
+            },
+            {
+                CustomUnitDescriptorInfo.identifier,
+                new StringVerifier,
+                Optional::Yes,
+                CustomUnitDescriptorInfo.description
+            }
         }
     };
 }
@@ -65,6 +91,8 @@ documentation::Documentation RenderableDistanceLabel::Documentation() {
 RenderableDistanceLabel::RenderableDistanceLabel(const ghoul::Dictionary& dictionary)
     : RenderableLabels(dictionary)
     , _nodelineId(NodeLineInfo)
+    , _distanceUnit(DistanceUnitInfo, 1, 0, 11)
+    , _customUnitDescriptor(CustomUnitDescriptorInfo)
 {
     documentation::testSpecificationAndThrow(
         Documentation(),
@@ -75,6 +103,16 @@ RenderableDistanceLabel::RenderableDistanceLabel(const ghoul::Dictionary& dictio
     if (dictionary.hasKey(NodeLineInfo.identifier)) {
         _nodelineId = dictionary.value<std::string>(NodeLineInfo.identifier);
         addProperty(_nodelineId);
+    }
+    if (dictionary.hasKey(DistanceUnitInfo.identifier)) {
+        _distanceUnit = static_cast<int>(
+            dictionary.value<double>(DistanceUnitInfo.identifier)
+            );
+        addProperty(_distanceUnit);
+    }
+    if (dictionary.hasKey(CustomUnitDescriptorInfo.identifier)) {
+        _customUnitDescriptor = dictionary.value<std::string>(CustomUnitDescriptorInfo.identifier);
+        addProperty(_customUnitDescriptor);
     }
 }
 
@@ -87,7 +125,6 @@ void RenderableDistanceLabel::update(const UpdateData&) {
 
     SceneGraphNode* nodelineNode = RE.scene()->sceneGraphNode(_nodelineId);
     if (nodelineNode) {
-        // Calculate distance
         RenderableNodeLine* nodeline = dynamic_cast<RenderableNodeLine*>(
             nodelineNode->renderable()
         );
@@ -97,15 +134,23 @@ void RenderableDistanceLabel::update(const UpdateData&) {
             return;
         }
 
-        double myDistance = nodeline->distance();
+        // Get used unit scale
+        const float scale = unit(_distanceUnit);
 
-        // Format string
-        float scale = unit(Kilometer);
-        std::string distanceText = std::to_string(std::round(myDistance / scale));
+        // Get unit descriptor text
+        std::string unitDescriptor = toString(_distanceUnit);
+        if (!_customUnitDescriptor.value().empty()) {
+            unitDescriptor = _customUnitDescriptor.value();
+        }
+
+        // Get distance as string and remove fractional part
+        std::string distanceText = std::to_string(std::round(nodeline->distance() / scale));
         int pos = static_cast<int>(distanceText.find("."));
         std::string subStr = distanceText.substr(pos);
         distanceText.erase(pos, subStr.size());
-        std::string finalText = distanceText + " Km";
+
+        // Create final label text and set it
+        const std::string finalText = distanceText + " " + unitDescriptor;
         setLabelText(finalText);
 
         // Update placement of label with transformation matrix

--- a/modules/vislab/rendering/renderabledistancelabel.cpp
+++ b/modules/vislab/rendering/renderabledistancelabel.cpp
@@ -107,7 +107,7 @@ RenderableDistanceLabel::RenderableDistanceLabel(const ghoul::Dictionary& dictio
     if (dictionary.hasKey(DistanceUnitInfo.identifier)) {
         _distanceUnit = static_cast<int>(
             dictionary.value<double>(DistanceUnitInfo.identifier)
-            );
+        );
         addProperty(_distanceUnit);
     }
     if (dictionary.hasKey(CustomUnitDescriptorInfo.identifier)) {

--- a/modules/vislab/rendering/renderabledistancelabel.h
+++ b/modules/vislab/rendering/renderabledistancelabel.h
@@ -40,6 +40,8 @@ public:
 private:
 
      properties::StringProperty _nodelineId;
+     properties::IntProperty _distanceUnit;
+     properties::StringProperty _customUnitDescriptor;
      bool _errorThrown = false;
 };
 


### PR DESCRIPTION
This adds a way to customize the way how distances are shown on distance labels. It is possible to config the used unit (out of the existent openspace units, for example "gigameter"), and it is possible to set a custom descriptor. For SPVL for example we are using gigameter and the descriptor "million km" since we see that the average museum visitor has limited understanding to grasp "gigameter" and kilometer values are getting too big.

![Capture](https://user-images.githubusercontent.com/2681917/75972698-24b2d980-5ed4-11ea-9d91-1f0dd9103e9f.JPG)

