### PR TITLE
Feature/continuous pinch

### DIFF
--- a/include/openspace/util/touch.h
+++ b/include/openspace/util/touch.h
@@ -80,6 +80,7 @@ public:
 private:
     //A deque of recorded inputs. Adding newer points to the front of the queue
     std::deque<TouchInput> _inputs;
+    TouchInput _firstInput;
 
     size_t _touchDeviceId;
     size_t _fingerId;

--- a/include/openspace/util/touch.h
+++ b/include/openspace/util/touch.h
@@ -46,7 +46,7 @@ struct TouchInput {
     float y;
     float dx = 0.f;         // movement in x direction since last touch input
     float dy = 0.f;         // movement in y direction since last touch input
-    double timestamp; // timestamp in seconds from global touch initialization
+    double timestamp;       // timestamp in seconds from global touch initialization
 };
 
 class TouchInputHolder {
@@ -56,6 +56,7 @@ public:
     // tryAddInput:
     // Succeeds upon a different input than last.
     // Fails upon a too similar input as last.
+    // Updates time for the last input if same position.
     bool tryAddInput(TouchInput input);
     void clearInputs();
 
@@ -72,6 +73,7 @@ public:
     double gestureTime() const;
 
     size_t numInputs() const;
+    const TouchInput& firstInput() const;
     const TouchInput& latestInput() const;
     const std::deque<TouchInput>& peekInputs() const;
 

--- a/include/openspace/util/touch.h
+++ b/include/openspace/util/touch.h
@@ -32,6 +32,9 @@
 
 namespace openspace {
 
+// The TouchInput represents a single finger/device-input at a specific point in time.
+// the fingerId and touchDeviceId coupled with the timestamp allows this to be compared
+// with other TouchInputs in order to calculate gesture-like behaviour.
 struct TouchInput {
     TouchInput(size_t touchDeviceId, size_t fingerId, float x, float y, double timestamp);
     glm::vec2 screenCoordinates(glm::vec2 resolution) const;
@@ -49,17 +52,22 @@ struct TouchInput {
     double timestamp;       // timestamp in seconds from global touch initialization
 };
 
+// The TouchInputHolder holds one or many TouchInputs, in order to track the history of 
+// the finger/input device
 class TouchInputHolder {
 public:
     TouchInputHolder(TouchInput input);
 
-    // tryAddInput:
     // Succeeds upon a different input than last.
     // Fails upon a too similar input as last.
     // Updates time for the last input if same position.
     bool tryAddInput(TouchInput input);
+    
     void clearInputs();
 
+    // Checks whether or not this Holder actually holds a specific input (based on IDs)
+    // Succeeds when `input` is held by this Holder
+    // Fails if `input` is not held by this Holder
     bool holdsInput(const TouchInput &input) const;
 
     size_t touchDeviceId() const;

--- a/modules/touch/include/touchinteraction.h
+++ b/modules/touch/include/touchinteraction.h
@@ -167,6 +167,7 @@ private:
     properties::IntProperty _deceleratesPerSecond;
     properties::FloatProperty _touchScreenSize;
     properties::FloatProperty _tapZoomFactor;
+    properties::FloatProperty _pinchZoomFactor;
     properties::FloatProperty _nodeRadiusThreshold;
     properties::FloatProperty _rollAngleThreshold;
     properties::FloatProperty _orbitSpeedThreshold;

--- a/modules/touch/include/touchinteraction.h
+++ b/modules/touch/include/touchinteraction.h
@@ -35,6 +35,7 @@
 #include <openspace/properties/stringproperty.h>
 #include <openspace/properties/vector/ivec2property.h>
 #include <openspace/properties/vector/vec4property.h>
+#include <array>
 #include <chrono>
 #include <memory>
 
@@ -96,7 +97,7 @@ public:
         std::vector<TouchInput>& lastProcessed);
 
     // Calculates the new camera state with velocities and time since last frame
-    void step(double dt);
+    void step(double dt, bool directTouch = false);
 
     // Called each frame we have no new input, used to reset data
     void resetAfterInput();
@@ -202,7 +203,7 @@ private:
     double pinchConsecZoomFactor = 0;
     //int stepVelUpdate = 0;
 #endif
-
+    std::array<TouchInputHolder, 2> _pinchInputs;
     // Class variables
     VelocityStates _vel;
     VelocityStates _lastVel;
@@ -242,4 +243,3 @@ private:
 } // openspace namespace
 
 #endif // __OPENSPACE_MODULE_TOUCH___TOUCH_INTERACTION___H__
-

--- a/modules/touch/src/touchinteraction.cpp
+++ b/modules/touch/src/touchinteraction.cpp
@@ -118,10 +118,10 @@ namespace {
     };
 
     constexpr openspace::properties::Property::PropertyInfo PinchZoomFactorInfo = {
-            "PinchZoomFactor",
-            "Scaling distance travelled on pinch",
-            "This value is used to reduce the amount of pinching needed. A linear"
-            "kind of sensitivity that will alter the pinch-zoom speed."
+        "PinchZoomFactor",
+        "Scaling distance travelled on pinch",
+        "This value is used to reduce the amount of pinching needed. A linear kind of "
+        "sensitivity that will alter the pinch-zoom speed."
     };
 
     constexpr openspace::properties::Property::PropertyInfo DirectManipulationInfo = {
@@ -285,7 +285,12 @@ TouchInteraction::TouchInteraction()
         0.25f
     )
     , _zoomBoundarySphereMultiplier(ZoomBoundarySphereMultiplierInfo, 1.001f, 1.f, 1.01f)
-    , _zoomOutLimit(ZoomOutLimitInfo, std::numeric_limits<double>::max(), 1000.0, std::numeric_limits<double>::max())
+    , _zoomOutLimit(
+        ZoomOutLimitInfo,
+        std::numeric_limits<double>::max(),
+        1000.0,
+        std::numeric_limits<double>::max()
+    )
     , _zoomInLimit(ZoomInLimitInfo, -1.0, 0.0, std::numeric_limits<double>::max())
     , _inputStillThreshold(InputSensitivityInfo, 0.0005f, 0.f, 0.001f)
     // used to void wrongly interpreted roll interactions
@@ -315,10 +320,9 @@ TouchInteraction::TouchInteraction()
         { "Ignore GUI", "Disable GUI touch interaction", "" },
         false
     )
-    , _pinchInputs({ TouchInput(0x0, 0x0, 0.0, 0.0, 0.0), 
-                     TouchInput(0x0, 0x0, 0.0, 0.0, 0.0) })
+    , _pinchInputs({ TouchInput(0, 0, 0.0, 0.0, 0.0), TouchInput(0, 0, 0.0, 0.0, 0.0) })
     , _vel{ glm::dvec2(0.0), 0.0, 0.0, glm::dvec2(0.0) }
-    , _sensitivity{ glm::dvec2(0.08, 0.045), 12.0 /*4.0*/, 2.75, glm::dvec2(0.08, 0.045) }
+    , _sensitivity{ glm::dvec2(0.08, 0.045), 12.0, 2.75, glm::dvec2(0.08, 0.045) }
     , _constTimeDecay_secs(ConstantTimeDecaySecsInfo, 1.75f, 0.1f, 4.0f)
     // calculated with two vectors with known diff in length, then
     // projDiffLength/diffLength.
@@ -790,11 +794,10 @@ int TouchInteraction::interpretInteraction(const std::vector<TouchInputHolder>& 
         else {
             const bool sameInput0 = _pinchInputs[0].holdsInput(list[0].latestInput());
             const bool sameInput1 = _pinchInputs[1].holdsInput(list[1].latestInput());
-            if(sameInput0 && sameInput1)
-            {
+            if (sameInput0 && sameInput1) {
                 _pinchInputs[0].tryAddInput(list[0].latestInput());
                 _pinchInputs[1].tryAddInput(list[1].latestInput());
-            }else{
+            } else {
                 _pinchInputs[0] = TouchInputHolder(list[0].latestInput());
                 _pinchInputs[1] = TouchInputHolder(list[1].latestInput());
             }
@@ -1131,17 +1134,18 @@ void TouchInteraction::step(double dt, bool directTouch) {
 
             // Possible with other navigations performed outside touch interaction
             const bool currentPosViolatingZoomOutLimit =
-                (currentPosDistance >= _zoomOutLimit.value());
+                (currentPosDistance >= _zoomOutLimit);
             const bool willNewPositionViolateZoomOutLimit =
-                (newPosDistance >= _zoomOutLimit.value());
+                (newPosDistance >= _zoomOutLimit);
             bool willNewPositionViolateZoomInLimit =
                 (newPosDistance < zoomInBounds);
             bool willNewPositionViolateDirection =
                 (currentPosDistance <= length(zoomDistanceIncrement));
 
-            if (!willNewPositionViolateZoomInLimit
-                && !willNewPositionViolateDirection
-                && !willNewPositionViolateZoomOutLimit) {
+            if (!willNewPositionViolateZoomInLimit &&
+                !willNewPositionViolateDirection &&
+                !willNewPositionViolateZoomOutLimit)
+            {
                 camPos += zoomDistanceIncrement;
             }
             else if (currentPosViolatingZoomOutLimit) {

--- a/modules/touch/src/touchinteraction.cpp
+++ b/modules/touch/src/touchinteraction.cpp
@@ -118,8 +118,10 @@ namespace {
     };
 
     constexpr openspace::properties::Property::PropertyInfo PinchZoomFactorInfo = {
-            "PinchZoomFactor", "Scaling distance travelled on pinch",
-            ""  // @TODO Missing documentation
+            "PinchZoomFactor",
+            "Scaling distance travelled on pinch",
+            "This value is used to reduce the amount of pinching needed. A linear"
+            "kind of sensitivity that will alter the pinch-zoom speed."
     };
 
     constexpr openspace::properties::Property::PropertyInfo DirectManipulationInfo = {
@@ -1106,7 +1108,7 @@ void TouchInteraction::step(double dt, bool directTouch) {
 
             //Apply the velocity to update camera position
             double zoomVelocity = _vel.zoom;
-            if(!directTouch) {
+            if (!directTouch) {
                 const double distanceFromSurface =
                     length(currentPosDistance) - anchor->boundingSphere();
                 if (distanceFromSurface > 0.1) {

--- a/modules/touch/src/touchinteraction.cpp
+++ b/modules/touch/src/touchinteraction.cpp
@@ -307,6 +307,8 @@ TouchInteraction::TouchInteraction()
         { "Ignore GUI", "Disable GUI touch interaction", "" },
         false
     )
+    , _pinchInputs({ TouchInput(0x0, 0x0, 0.0, 0.0, 0.0), 
+                     TouchInput(0x0, 0x0, 0.0, 0.0, 0.0) })
     , _vel{ glm::dvec2(0.0), 0.0, 0.0, glm::dvec2(0.0) }
     , _sensitivity{ glm::dvec2(0.08, 0.045), 12.0 /*4.0*/, 2.75, glm::dvec2(0.08, 0.045) }
     , _constTimeDecay_secs(ConstantTimeDecaySecsInfo, 1.75f, 0.1f, 4.0f)
@@ -494,7 +496,7 @@ void TouchInteraction::directControl(const std::vector<TouchInputHolder>& list) 
                 _vel.pan = glm::dvec2(par.at(4), par.at(5));
             }
         }
-        step(1.0);
+        step(1.0, true);
 
         // Reset velocities after setting new camera state
         _lastVel = _vel;
@@ -777,6 +779,16 @@ int TouchInteraction::interpretInteraction(const std::vector<TouchInputHolder>& 
             return ROLL;
         }
         else {
+            const bool sameInput0 = _pinchInputs[0].holdsInput(list[0].latestInput());
+            const bool sameInput1 = _pinchInputs[1].holdsInput(list[1].latestInput());
+            if(sameInput0 && sameInput1)
+            {
+                _pinchInputs[0].tryAddInput(list[0].latestInput());
+                _pinchInputs[1].tryAddInput(list[1].latestInput());
+            }else{
+                _pinchInputs[0] = TouchInputHolder(list[0].latestInput());
+                _pinchInputs[1] = TouchInputHolder(list[1].latestInput());
+            }
             return PINCH;
         }
     }
@@ -818,6 +830,10 @@ void TouchInteraction::computeVelocities(const std::vector<TouchInputHolder>& li
     const TouchInputHolder& inputHolder = list.at(0);
     switch (action) {
         case ROT: { // add rotation velocity
+            const auto inputs = inputHolder.peekInputs();
+            if(inputs.size() > 1 ){
+                const float dt = inputs[0].timestamp - inputs[1].timestamp;
+            }
             _vel.orbit += glm::dvec2(inputHolder.speedX() *
                           _sensitivity.orbit.x, inputHolder.speedY() *
                           _sensitivity.orbit.y);
@@ -830,51 +846,25 @@ void TouchInteraction::computeVelocities(const std::vector<TouchInputHolder>& li
         case PINCH: {
              // add zooming velocity - dependant on distance difference between contact
              // points this/last frame
-            double distance = std::accumulate(
-                list.begin(),
-                list.end(),
-                0.0,
-                [&](double d, const TouchInputHolder& c) {
-                    const glm::vec2 currPos = { c.latestInput().x, c.latestInput().y };
-                    return d + glm::distance(currPos, _centroid);
-                }
-            ) / list.size();
-            double lastDistance = std::accumulate(
-                lastProcessed.begin(),
-                lastProcessed.end(),
-                0.f,
-                [&](float d, const TouchInput& p) {
-                    const glm::vec2 lastPos = { p.x, p.y };
-                    return d + glm::distance(lastPos, _centroid);
-                }
-            ) / lastProcessed.size();
+            const TouchInput& startFinger0 = _pinchInputs[0].firstInput();
+            const TouchInput& startFinger1 = _pinchInputs[1].firstInput();
+            double distToCentroidStart = 
+                glm::length(glm::dvec2(startFinger0.x, startFinger0.y) - 
+                            glm::dvec2(startFinger1.x, startFinger1.y)) / 2.0;
 
-            glm::dvec3 camPos = _camera->positionVec3();
-            glm::dvec3 centerPos = anchor->worldPosition();
-            glm::dvec3 currDistanceToFocusNode = camPos - centerPos;
+            const TouchInput& endFinger0 = _pinchInputs[0].latestInput();
+            const TouchInput& endFinger1 = _pinchInputs[1].latestInput();
+            double distToCentroidEnd = 
+                glm::length(glm::dvec2(endFinger0.x, endFinger0.y) - 
+                            glm::dvec2(endFinger1.x, endFinger1.y)) / 2.0;
 
-            const double distanceFromFocusSurface =
-                length(currDistanceToFocusNode) - anchor->boundingSphere();
-            double zoomFactor = (distance - lastDistance);
+            double zoomFactor = 0.01*(distToCentroidEnd - distToCentroidStart);
 #ifdef TOUCH_DEBUG_PROPERTIES
             pinchConsecCt++;
             pinchConsecZoomFactor += zoomFactor;
 #endif
 
-            _constTimeDecayCoeff.zoom = computeConstTimeDecayCoefficient(_vel.zoom);
-            if (distanceFromFocusSurface > 0.1) {
-                const double ratioOfDistanceToNodeVsSurface =
-                    length(currDistanceToFocusNode) / distanceFromFocusSurface;
-                if (ratioOfDistanceToNodeVsSurface > _zoomSensitivityDistanceThreshold) {
-                    zoomFactor *= pow(
-                        std::abs(distanceFromFocusSurface),
-                        static_cast<float>(_zoomSensitivityExponential)
-                    );
-                }
-            }
-            else {
-                zoomFactor = 1.0;
-            }
+            _constTimeDecayCoeff.zoom = 1.0;
             _vel.zoom = zoomFactor * _zoomSensitivityProportionalDist *
                          std::max(_touchScreenSize.value() * 0.1, 1.0);
             break;
@@ -917,7 +907,7 @@ void TouchInteraction::computeVelocities(const std::vector<TouchInputHolder>& li
             break;
         }
         case PAN: {
-             // add local rotation velocity
+            // add local rotation velocity
             _vel.pan += glm::dvec2(inputHolder.speedX() *
                         _sensitivity.pan.x, inputHolder.speedY() * _sensitivity.pan.y);
             double panVelocityAvg = glm::distance(_vel.pan.x, _vel.pan.y);
@@ -925,7 +915,7 @@ void TouchInteraction::computeVelocities(const std::vector<TouchInputHolder>& li
             break;
         }
         case PICK: {
-             // pick something in the scene as focus node
+            // pick something in the scene as focus node
             if (_pickingSelected) {
                 setFocusNode(_pickingSelected);
 
@@ -992,7 +982,7 @@ double TouchInteraction::computeTapZoomDistance(double zoomGain) {
 
 // Main update call, calculates the new orientation and position for the camera depending
 // on _vel and dt. Called every frame
-void TouchInteraction::step(double dt) {
+void TouchInteraction::step(double dt, bool directTouch) {
     using namespace glm;
 
     const SceneGraphNode* anchor =
@@ -1103,11 +1093,30 @@ void TouchInteraction::step(double dt) {
                     _loggerCat, _zoomOutLimit.value()
                ));
             }
+            const double currentPosDistance = length(centerToCamera);
 
             //Apply the velocity to update camera position
-            glm::dvec3 zoomDistanceIncrement = directionToCenter * _vel.zoom * dt;
+            double zoomVelocity = _vel.zoom;
+            if(!directTouch) {
+                const double distanceFromSurface =
+                    length(currentPosDistance) - anchor->boundingSphere();
+                if (distanceFromSurface > 0.1) {
+                    const double ratioOfDistanceToNodeVsSurface =
+                        length(currentPosDistance) / distanceFromSurface;
+                    if (ratioOfDistanceToNodeVsSurface > _zoomSensitivityDistanceThreshold) {
+                        zoomVelocity *= pow(
+                            std::abs(distanceFromSurface),
+                            static_cast<float>(_zoomSensitivityExponential)
+                        );
+                    }
+                }
+                else {
+                    zoomVelocity = 1.0;
+                }
+            }
+
+            const glm::dvec3 zoomDistanceIncrement = directionToCenter * zoomVelocity * dt;
             const double newPosDistance = length(centerToCamera + zoomDistanceIncrement);
-            const double currentPosDistance = length(centerToCamera);
 
             // Possible with other navigations performed outside touch interaction
             const bool currentPosViolatingZoomOutLimit =
@@ -1116,8 +1125,11 @@ void TouchInteraction::step(double dt) {
                 (newPosDistance >= _zoomOutLimit.value());
             bool willNewPositionViolateZoomInLimit =
                 (newPosDistance < zoomInBounds);
+            bool willNewPositionViolateDirection =
+                (currentPosDistance <= length(zoomDistanceIncrement));
 
             if (!willNewPositionViolateZoomInLimit
+                && !willNewPositionViolateDirection
                 && !willNewPositionViolateZoomOutLimit) {
                 camPos += zoomDistanceIncrement;
             }
@@ -1218,7 +1230,6 @@ void TouchInteraction::resetAfterInput() {
         module.touchInput.active = false;
         module.touchInput.action = 0;
     }
-
     _lmSuccess = true;
     // Ensure that _guiON is consistent with properties in OnScreenGUI and
     _guiON = module.gui.isEnabled();
@@ -1228,6 +1239,11 @@ void TouchInteraction::resetAfterInput() {
     _lastVel.zoom = 0.0;
     _lastVel.roll = 0.0;
     _lastVel.pan = glm::dvec2(0.0);
+    
+    _constTimeDecayCoeff.zoom = computeConstTimeDecayCoefficient(_vel.zoom);
+    _pinchInputs[0].clearInputs();
+    _pinchInputs[1].clearInputs();
+
     _selected.clear();
     _pickingSelected = nullptr;
 }

--- a/modules/touch/src/touchinteraction.cpp
+++ b/modules/touch/src/touchinteraction.cpp
@@ -852,17 +852,18 @@ void TouchInteraction::computeVelocities(const std::vector<TouchInputHolder>& li
         case PINCH: {
              // add zooming velocity - dependant on distance difference between contact
              // points this/first frame
+            using namespace glm;
             const TouchInput& startFinger0 = _pinchInputs[0].firstInput();
             const TouchInput& startFinger1 = _pinchInputs[1].firstInput();
-            double distToCentroidStart = 
-                glm::length(glm::dvec2(startFinger0.x * aspectRatio, startFinger0.y) - 
-                        glm::dvec2(startFinger1.x * aspectRatio, startFinger1.y)) / 2.0;
+            const dvec2 startVec0 = dvec2(startFinger0.x * aspectRatio, startFinger0.y);
+            const dvec2 startVec1 = dvec2(startFinger1.x * aspectRatio, startFinger1.y);
+            double distToCentroidStart = length(startVec0 - startVec1) / 2.0;
 
             const TouchInput& endFinger0 = _pinchInputs[0].latestInput();
             const TouchInput& endFinger1 = _pinchInputs[1].latestInput();
-            double distToCentroidEnd = 
-                glm::length(glm::dvec2(endFinger0.x * aspectRatio, endFinger0.y) - 
-                        glm::dvec2(endFinger1.x * aspectRatio, endFinger1.y)) / 2.0;
+            const dvec2 endVec0 = dvec2(endFinger0.x * aspectRatio, endFinger0.y);
+            const dvec2 endVec1 = dvec2(endFinger1.x * aspectRatio, endFinger1.y);
+            double distToCentroidEnd = length(endVec0 - endVec1) / 2.0;
 
             double zoomFactor = distToCentroidEnd - distToCentroidStart;
 #ifdef TOUCH_DEBUG_PROPERTIES

--- a/modules/touch/touchmodule.cpp
+++ b/modules/touch/touchmodule.cpp
@@ -221,7 +221,7 @@ void TouchModule::internalInitialize(const ghoul::Dictionary& /*dictionary*/){
     global::callback::touchUpdated.push_back(
         [this](TouchInput i) {
             updateOrAddTouchInput(i);
-        return true;
+            return true;
         }
     );
 

--- a/src/util/touch.cpp
+++ b/src/util/touch.cpp
@@ -78,27 +78,35 @@ TouchInputHolder::TouchInputHolder(TouchInput input)
 {}
 
 bool TouchInputHolder::tryAddInput(TouchInput input) {
+    if(_inputs.empty()) {
+        _inputs.emplace_front(input);
+        return true;
+    }
     constexpr const double ONE_MS = 0.001;
     const TouchInput& lastInput = latestInput();
     input.dx = input.x - lastInput.x;
     input.dy = input.y - lastInput.y;
 
-    const bool sameTimeAsLastInput = (input.timestamp - lastInput.timestamp) > ONE_MS;
-    bool wasInserted = false;
-    if (isMoving()) {
+    const bool sameTimeAsLastInput = (input.timestamp - lastInput.timestamp) < ONE_MS;
+    bool successful = false;
+    if (!sameTimeAsLastInput && isMoving()) {
         _inputs.emplace_front(input);
-        wasInserted = true;
+        successful = true;
     }
-    else if (sameTimeAsLastInput && input.isMoving()) {
+    else if (!sameTimeAsLastInput && input.isMoving()) {
         _inputs.emplace_front(input);
-        wasInserted = true;
+        successful = true;
+    }
+    else if (!sameTimeAsLastInput){
+        _inputs.front().timestamp = input.timestamp;
+        successful = true;
     }
 
     constexpr const int MaxInputs = 128;
     if (_inputs.size() > MaxInputs) {
         _inputs.pop_back();
     }
-    return wasInserted;
+    return successful;
 }
 
 void TouchInputHolder::clearInputs() {
@@ -142,8 +150,7 @@ bool TouchInputHolder::isMoving() const {
     if (_inputs.size() <= 1) {
         return false;
     }
-    const TouchInput& currentInput = _inputs[0];
-    return currentInput.dx != 0.f || currentInput.dy != 0.f;
+    return latestInput().isMoving();
 }
 
 float TouchInputHolder::gestureDistance() const {
@@ -172,6 +179,10 @@ double TouchInputHolder::gestureTime() const {
 
 size_t TouchInputHolder::numInputs() const {
     return _inputs.size();
+}
+
+const TouchInput& TouchInputHolder::firstInput() const {
+    return _inputs.back();
 }
 
 const TouchInput& TouchInputHolder::latestInput() const {

--- a/src/util/touch.cpp
+++ b/src/util/touch.cpp
@@ -73,6 +73,7 @@ float TouchInput::angleToPos(float otherX, float otherY) const {
 
 TouchInputHolder::TouchInputHolder(TouchInput input)
     : _inputs{ input }
+    , _firstInput(input)
     , _touchDeviceId(input.touchDeviceId)
     , _fingerId(input.fingerId)
 {}
@@ -182,7 +183,7 @@ size_t TouchInputHolder::numInputs() const {
 }
 
 const TouchInput& TouchInputHolder::firstInput() const {
-    return _inputs.back();
+    return _firstInput;
 }
 
 const TouchInput& TouchInputHolder::latestInput() const {


### PR DESCRIPTION
This PR fixes some issues in the win32_touch hook (timestamps are now based on touchscreen driver rather than OpenSpace message pumping frequency).

We also now default the pinch gesture to use continuous zooming, meaning that if we pinch and stop our fingers, we will keep on zooming in. Letting go of one finger will let the pinch motion continue, and completely letting go will stop the zoom.

No values are tweaked to perfection as of this PR, but in general this improves the touch experience.