### PR TITLE
Issue/1238

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -24,6 +24,7 @@ local initializeAndAddNodes = function()
   local iss = {
     Identifier = "ISS",
     Parent = transforms.EarthInertial.Identifier,
+    BoundingSphere = 30,
     Transform = {
       Translation = {
         Type = "TLETranslation",

--- a/include/openspace/scene/scenegraphnode.h
+++ b/include/openspace/scene/scenegraphnode.h
@@ -187,11 +187,10 @@ private:
     glm::dmat3 _worldRotationCached = glm::dmat3(1.0);
     glm::dvec3 _worldScaleCached = glm::dvec3(1.0);
 
-    float _fixedBoundingSphere = 0.f;
-
     glm::dmat4 _modelTransformCached = glm::dmat4(1.0);
     glm::dmat4 _inverseModelTransformCached = glm::dmat4(1.0);
 
+    properties::FloatProperty _boundingSphere;
     properties::BoolProperty _computeScreenSpaceValues;
     properties::IVec2Property _screenSpacePosition;
     properties::BoolProperty _screenVisibility;

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -98,7 +98,8 @@ namespace {
         "Bounding Sphere",
         "The bounding sphere of the scene graph node. This can be the "
         "bounding sphere of an attached renderable or directly specified to the node. "
-        "If there is a boundingsphere on both the renderable and the node, the largest number will be picked. ",
+        "If there is a boundingsphere on both the renderable and the node, the largest "
+        "number will be picked.",
         openspace::properties::Property::Visibility::Hidden
     };
 
@@ -164,7 +165,7 @@ std::unique_ptr<SceneGraphNode> SceneGraphNode::createFromDictionary(
 
     if (dictionary.hasKey(BoundingSphereInfo.identifier)) {
         result->_boundingSphere = dictionary.value<float>(BoundingSphereInfo.identifier);
-        result->_boundingSphere.setVisibility(openspace::properties::Property::Visibility::All);
+        result->_boundingSphere.setVisibility(properties::Property::Visibility::All);
     }
 
     if (dictionary.hasKey(KeyTransformTranslation)) {
@@ -259,18 +260,18 @@ std::unique_ptr<SceneGraphNode> SceneGraphNode::createFromDictionary(
             "Successfully created renderable for '{}'", result->identifier()
         ));
 
-        // If the renderable child has a bounding sphere that is larger, we allow it to override
-        if (result->_renderable->boundingSphere() > result->_boundingSphere.value()) {
-            result->_boundingSphere.setValue(result->_renderable->boundingSphere());
+        // If the renderable child has a larger bounding sphere, we allow it tooverride
+        if (result->_renderable->boundingSphere() > result->_boundingSphere) {
+            result->_boundingSphere = result->_renderable->boundingSphere();
 
             if (dictionary.hasKey(BoundingSphereInfo.identifier)) {
                 LWARNING(fmt::format(
-                    "The specified property 'BoundingSphere' for '{}' was overwritten by a child renderable",
+                    "The specified property 'BoundingSphere' for '{}' was overwritten "
+                    "by a child renderable",
                     result->_identifier
                 ));
             }
         }
-
     }
 
     if (dictionary.hasKey(KeyTag)) {
@@ -315,7 +316,7 @@ SceneGraphNode::SceneGraphNode()
         std::make_unique<StaticRotation>(),
         std::make_unique<StaticScale>()
     }
-   , _boundingSphere(properties::FloatProperty(BoundingSphereInfo, 0.0f))
+   , _boundingSphere(properties::FloatProperty(BoundingSphereInfo, 0.f))
     , _computeScreenSpaceValues(ComputeScreenSpaceInfo, false)
     , _screenSpacePosition(
         properties::IVec2Property(ScreenSpacePositionInfo, glm::ivec2(-1, -1))
@@ -927,7 +928,7 @@ std::vector<SceneGraphNode*> SceneGraphNode::children() const {
 }
 
 float SceneGraphNode::boundingSphere() const {
-    return _boundingSphere.value();
+    return _boundingSphere;
 }
 
 // renderable

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -98,7 +98,7 @@ namespace {
         "Bounding Sphere",
         "The bounding sphere of the scene graph node. This can be the "
         "bounding sphere of an attached renderable or directly specified to the node. "
-        "If there is a boundingsphere on both the renderable and the ndoe, the largest number will be picked. ",
+        "If there is a boundingsphere on both the renderable and the node, the largest number will be picked. ",
         openspace::properties::Property::Visibility::Hidden
     };
 

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -260,9 +260,17 @@ std::unique_ptr<SceneGraphNode> SceneGraphNode::createFromDictionary(
         ));
 
         // If the renderable child has a bounding sphere that is larger, we allow it to override
-        result->_boundingSphere.setValue(std::max(result->_renderable->boundingSphere(),
-            result->_boundingSphere.value()
-        ));
+        if (result->_renderable->boundingSphere() > result->_boundingSphere.value()) {
+            result->_boundingSphere.setValue(result->_renderable->boundingSphere());
+
+            if (dictionary.hasKey(BoundingSphereInfo.identifier)) {
+                LWARNING(fmt::format(
+                    "The specified property 'BoundingSphere' for '{}' was overwritten by a child renderable",
+                    result->_identifier
+                ));
+            }
+        }
+
     }
 
     if (dictionary.hasKey(KeyTag)) {

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -56,7 +56,7 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo ComputeScreenSpaceInfo =
     {
         "ComputeScreenSpaceData",
-        "Screen Space Data",
+        "Compute Screen Space Data",
         "If this value is set to 'true', the screenspace-based properties are calculated "
         "at regular intervals. If these values are set to 'false', they are not updated."
     };
@@ -64,27 +64,33 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo ScreenSpacePositionInfo = {
         "ScreenSpacePosition",
         "ScreenSpacePosition",
-        "" // @TODO Missing documentation
+        "The x,y position in screen space. Can be used for placing GUI elements",
+        openspace::properties::Property::Visibility::Hidden
     };
     constexpr openspace::properties::Property::PropertyInfo ScreenVisibilityInfo = {
         "ScreenVisibility",
         "ScreenVisibility",
-        "" // @TODO Missing documentation
+        "Determines if the node is currently visible on screen",
+        openspace::properties::Property::Visibility::Hidden
     };
     constexpr openspace::properties::Property::PropertyInfo DistanceFromCamToNodeInfo = {
         "DistanceFromCamToNode",
         "DistanceFromCamToNode",
-        "" // @TODO Missing documentation
+        "The distance from the camera to the node surface",
+        openspace::properties::Property::Visibility::Hidden
     };
     constexpr openspace::properties::Property::PropertyInfo ScreenSizeRadiusInfo = {
         "ScreenSizeRadius",
         "ScreenSizeRadius",
-        "" // @TODO Missing documentation
+        "The screen size of the radius of the node",
+        openspace::properties::Property::Visibility::Hidden
     };
     constexpr openspace::properties::Property::PropertyInfo VisibilityDistanceInfo = {
         "VisibilityDistance",
         "VisibilityDistance",
-        "" // @TODO Missing documentation
+        "The distace in world coordinates between node and camera "
+        "at which the screenspace object will become visible",
+        openspace::properties::Property::Visibility::Hidden
     };
 
     constexpr openspace::properties::Property::PropertyInfo BoundingSphereInfo = {


### PR DESCRIPTION
To further improve the possibilites of automatic flight there has been a request to be able to have a bounding shape on scene graph nodes, where they previously where limited to renderable types. 

This PR contains:
* A boundingSphere-property being added to scenegraph nodes. It will be 0 by default. If it has a renderable it will compare the bounding sphere of the renderable and pick the largest out of the two bounding spheres as the bounding sphere of the node.  The idea here is that if a renderable child is attached to the parent, it will automatically respect that bounding sphere without additional changes having to be applied. Unless explicitly provided in the dictionary, this boundingsphere property will be hidden in the gui.
* Added a small bounding sphere to ISS node
* Updated documentation and hiding of a number of screen space properties that are currently only used for touch gui markers, Also closes #1257 

Questions: 
* Can it lead to confusion that a scene graph node can have a boundingSphere both on its node and on its renderable child?
* Are there issues with the automatically picking the largest of the two bounding spheres?
* Are there issues having a duplicate property existing on both the renderable and the scenegraph node?