### PR TITLE
Exoplanets - fixes to avoid errors when adding/removing systems

### DIFF
--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -177,7 +177,15 @@ glm::dmat3 computeSystemRotation(glm::dvec3 starPosition) {
 
 std::string createIdentifier(std::string name) {
     std::replace(name.begin(), name.end(), ' ', '_');
+    sanitizeNameString(name);
     return name;
+}
+
+void sanitizeNameString(std::string& s) {
+    // We want to avoid quotes and apostrophes in names, since they cause problems
+    // when a string is translated to a script call
+    s.erase(remove(s.begin(), s.end(), '\"'), s.end());
+    s.erase(remove(s.begin(), s.end(), '\''), s.end());
 }
 
 } // namespace openspace::exoplanets

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/exoplanets/exoplanetshelper.h>
 
+#include <openspace/util/spicemanager.h>
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/fmt.h>
 #include <ghoul/logging/logmanager.h>
@@ -137,44 +138,41 @@ glm::dmat4 computeOrbitPlaneRotationMatrix(float i, float bigom, float omega) {
     return orbitPlaneRotation;
 }
 
-// Rotate the original coordinate system (where x is pointing to First Point of Aries)
-// so that x is pointing from star to the sun.
-// Modified from "http://www.opengl-tutorial.org/intermediate-tutorials/
-// tutorial-17-quaternions/ #how-do-i-find-the-rotation-between-2-vectors"
-glm::dmat3 exoplanetSystemRotation(glm::dvec3 start, glm::dvec3 end) {
-    glm::quat rotationQuat;
-    glm::dvec3 rotationAxis;
-    const float cosTheta = static_cast<float>(glm::dot(start, end));
-    constexpr float Epsilon = 1E-3f;
+glm::dmat3 computeSystemRotation(glm::dvec3 starPosition) {
+    const glm::dvec3 sunPosition = glm::dvec3(0.0, 0.0, 0.0);
+    const glm::dvec3 starToSunVec = glm::normalize(sunPosition - starPosition);
+    const glm::dvec3 galacticNorth = glm::dvec3(0.0, 0.0, 1.0);
 
-    if (cosTheta < -1.f + Epsilon) {
-        // special case when vectors in opposite directions:
-        // there is no "ideal" rotation axis
-        // So guess one; any will do as long as it's perpendicular to start vector
-        rotationAxis = glm::cross(glm::dvec3(0.0, 0.0, 1.0), start);
-        if (glm::length2(rotationAxis) < 0.01f) {
-            // bad luck, they were parallel, try again!
-            rotationAxis = glm::cross(glm::dvec3(1.0, 0.0, 0.0), start);
-        }
+    const glm::dmat3 galacticToCelestialMatrix =
+        SpiceManager::ref().positionTransformMatrix("GALACTIC", "J2000", 0.0);
 
-        rotationAxis = glm::normalize(rotationAxis);
-        rotationQuat = glm::quat(glm::radians(180.f), rotationAxis);
-        return glm::dmat3(glm::toMat4(rotationQuat));
-    }
-
-    rotationAxis = glm::cross(start, end);
-
-    const float s = sqrt((1.f + cosTheta) * 2.f);
-    const float invs = 1.f / s;
-
-    rotationQuat = glm::quat(
-        s * 0.5f,
-        static_cast<float>(rotationAxis.x * invs),
-        static_cast<float>(rotationAxis.y * invs),
-        static_cast<float>(rotationAxis.z * invs)
+    const glm::dvec3 celestialNorth = glm::normalize(
+        galacticToCelestialMatrix * galacticNorth
     );
 
-    return glm::dmat3(glm::toMat4(rotationQuat));
+    // Earth's north vector projected onto the skyplane, the plane perpendicular to the
+    // viewing vector (starToSunVec)
+    const float celestialAngle = static_cast<float>(glm::dot(
+        celestialNorth,
+        starToSunVec
+    ));
+    glm::dvec3 northProjected = glm::normalize(
+        celestialNorth - (celestialAngle / glm::length(starToSunVec)) * starToSunVec
+    );
+
+    const glm::dvec3 beta = glm::normalize(glm::cross(starToSunVec, northProjected));
+
+    return glm::dmat3(
+        northProjected.x,
+        northProjected.y,
+        northProjected.z,
+        beta.x,
+        beta.y,
+        beta.z,
+        starToSunVec.x,
+        starToSunVec.y,
+        starToSunVec.z
+    );
 }
 
 std::string createIdentifier(std::string name) {

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -81,6 +81,17 @@ std::string_view csvStarName(std::string_view name) {
     return name;
 }
 
+bool hasSufficientData(const Exoplanet& p) {
+    bool invalidPos = std::isnan(p.positionX)
+        || std::isnan(p.positionY)
+        || std::isnan(p.positionZ);
+
+    bool hasSemiMajorAxis = !std::isnan(p.a);
+    bool hasOrbitalPeriod = !std::isnan(p.per);
+
+    return !invalidPos && hasSemiMajorAxis && hasOrbitalPeriod;
+}
+
 std::string starColor(float bv) {
     std::ifstream colorMap(absPath(BvColormapPath), std::ios::in);
 

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -82,7 +82,7 @@ glm::dmat4 computeOrbitPlaneRotationMatrix(float i, float bigom, float omega);
 
 // Rotate the original coordinate system (where x is pointing to First Point of Aries)
 // so that x is pointing from star to the sun.
-glm::dmat3 exoplanetSystemRotation(glm::dvec3 start, glm::dvec3 end);
+glm::dmat3 computeSystemRotation(glm::dvec3 starPosition);
 
 // Create an identifier without whitespaces
 std::string createIdentifier(std::string name);

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -87,6 +87,8 @@ glm::dmat3 computeSystemRotation(glm::dvec3 starPosition);
 // Create an identifier without whitespaces
 std::string createIdentifier(std::string name);
 
+void sanitizeNameString(std::string& s);
+
 } // namespace openspace::exoplanets
 
 #endif // __OPENSPACE_MODULE_EXOPLANETS___EXOPLANETSMODULE___H__

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -72,6 +72,9 @@ std::string_view speckStarName(std::string_view name);
 // Convert speck-file specific names to the corresponding name in the csv data file
 std::string_view csvStarName(std::string_view name);
 
+// Check if the exoplanet p has sufficient data for visualization
+bool hasSufficientData(const Exoplanet& p);
+
 // Compute star color in RGB from b-v color index
 std::string starColor(float bv);
 

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -59,7 +59,11 @@ void createExoplanetSystem(std::string_view starName) {
     const std::string starNameSpeck = std::string(speckStarName(starName));
 
     const std::string starIdentifier = createIdentifier(starNameSpeck);
-    const std::string guiPath = ExoplanetsGuiPath + starNameSpeck;
+
+    std::string sanitizedStarName = starNameSpeck;
+    sanitizeNameString(sanitizedStarName);
+
+    const std::string guiPath = ExoplanetsGuiPath + sanitizedStarName;
 
     SceneGraphNode* existingStarNode = sceneGraphNode(starIdentifier);
     if (existingStarNode) {
@@ -110,6 +114,7 @@ void createExoplanetSystem(std::string_view starName) {
             data.seekg(location);
             data.read(reinterpret_cast<char*>(&p), sizeof(Exoplanet));
 
+            sanitizeNameString(name);
             planetNames.push_back(name);
             planetSystem.push_back(p);
             found = true;
@@ -200,7 +205,7 @@ void createExoplanetSystem(std::string_view starName) {
         "},"
         "Tag = {'exoplanet_system'},"
         "GUI = {"
-            "Name = '" + starNameSpeck + " (Star)',"
+            "Name = '" + sanitizedStarName + " (Star)',"
             "Path = '" + guiPath + "'"
         "}"
     "}";

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -29,7 +29,6 @@
 #include <openspace/scene/scenegraphnode.h>
 #include <openspace/scripting/scriptengine.h>
 #include <openspace/util/distanceconstants.h>
-#include <openspace/util/spicemanager.h>
 #include <openspace/util/timeconversion.h>
 #include <openspace/util/timemanager.h>
 #include <ghoul/filesystem/filesystem.h>
@@ -146,40 +145,7 @@ void createExoplanetSystem(std::string_view starName) {
         p.positionZ * distanceconstants::Parsec
     );
 
-    const glm::dvec3 sunPosition = glm::dvec3(0.0, 0.0, 0.0);
-    const glm::dvec3 starToSunVec = glm::normalize(sunPosition - starPosition);
-    const glm::dvec3 galacticNorth = glm::dvec3(0.0, 0.0, 1.0);
-
-    const glm::dmat3 galaxticToCelestialMatrix =
-        SpiceManager::ref().positionTransformMatrix("GALACTIC", "J2000", 0.0);
-
-    const glm::dvec3 celestialNorth = glm::normalize(
-        galaxticToCelestialMatrix * galacticNorth
-    );
-
-    // Earth's north vector projected onto the skyplane, the plane perpendicular to the
-    // viewing vector (starToSunVec)
-    const float celestialAngle = static_cast<float>(glm::dot(
-        celestialNorth,
-        starToSunVec
-    ));
-    glm::dvec3 northProjected = glm::normalize(
-        celestialNorth - (celestialAngle / glm::length(starToSunVec)) * starToSunVec
-    );
-
-    const glm::dvec3 beta = glm::normalize(glm::cross(starToSunVec, northProjected));
-
-    const glm::dmat3 exoplanetSystemRotation = glm::dmat3(
-        northProjected.x,
-        northProjected.y,
-        northProjected.z,
-        beta.x,
-        beta.y,
-        beta.z,
-        starToSunVec.x,
-        starToSunVec.y,
-        starToSunVec.z
-    );
+    const glm::dmat3 exoplanetSystemRotation = computeSystemRotation(starPosition);
 
     // Star renderable globe, if we have a radius and bv color index
     std::string starGlobeRenderableString;

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -259,15 +259,18 @@ void createExoplanetSystem(std::string_view starName) {
         if (std::isnan(planet.ecc)) {
             planet.ecc = 0.f;
         }
-        if (std::isnan(planet.i)) {
-            planet.i = 90.f;
-        }
-        if (std::isnan(planet.bigOmega)) {
-            planet.bigOmega = 180.f;
-        }
-        if (std::isnan(planet.omega)) {
-            planet.omega = 90.f;
-        }
+
+        // KeplerTranslation requires angles in range [0, 360]
+        auto validAngle = [](float angle, float defaultValue) {
+            if (std::isnan(angle)) { return defaultValue; }
+            if (angle < 0.f) { return angle + 360.f; }
+            if (angle > 360.f) { return angle - 360.f; }
+        };
+
+        planet.i = validAngle(planet.i, 90.f);
+        planet.bigOmega = validAngle(planet.bigOmega, 180.f);
+        planet.omega = validAngle(planet.omega, 90.f);
+
         Time epoch;
         std::string sEpoch;
         if (!std::isnan(planet.tt)) {

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -24,7 +24,6 @@
 
 #include <modules/exoplanets/exoplanetshelper.h>
 #include <openspace/engine/globals.h>
-#include <openspace/engine/moduleengine.h>
 #include <openspace/query/query.h>
 #include <openspace/scene/scenegraphnode.h>
 #include <openspace/scripting/scriptengine.h>
@@ -36,13 +35,7 @@
 #include <ghoul/glm.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/assert.h>
-#include <glm/gtc/quaternion.hpp>
-#include <glm/gtx/quaternion.hpp>
-#include <glm/gtx/transform.hpp>
-#include <cfloat>
-#include <cmath>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 
 namespace {

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -121,6 +121,14 @@ void createExoplanetSystem(std::string_view starName) {
             planetNames.push_back(name);
             planetSystem.push_back(p);
             found = true;
+
+            if (!hasSufficientData(p)) {
+                LERROR(fmt::format(
+                    "Insufficient data available for visualizion of exoplanet system: '{}'",
+                    starName
+                ));
+                return;
+            }
         }
     }
 
@@ -129,16 +137,6 @@ void createExoplanetSystem(std::string_view starName) {
 
     if (!found) {
         LERROR(fmt::format("No star with the provided name was found: '{}'", starName));
-        return;
-    }
-
-    bool notEnoughData = std::isnan(p.positionX) || std::isnan(p.a) || std::isnan(p.per);
-
-    if (notEnoughData) {
-        LERROR(fmt::format(
-            "Insufficient data available for representing the exoplanet system: '{}'",
-            starName
-        ));
         return;
     }
 

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -676,6 +676,14 @@ scripting::LuaLibrary Scene::luaLibrary() {
                 "Removes the SceneGraphNode identified by name"
             },
             {
+                "removeSceneGraphNodesFromRegex",
+                &luascriptfunctions::removeSceneGraphNodesFromRegex,
+                {},
+                "string",
+                "Removes all SceneGraphNodes with identifiers matching the input regular "
+                "expression"
+            },
+            {
                 "hasSceneGraphNode",
                 &luascriptfunctions::hasSceneGraphNode,
                 {},


### PR DESCRIPTION
Fixes to handle problems with problematic data, e.g. angles outside [0, 360] or with problematic names. Also, don't include exoplanet systems without sufficient data in the GUI list. 

Also, `removeSceneGraphNode` had problems with identifiers with e.g. plus signs in them since it was based on a regex match. Implemented so that the regular removal just finds the node with the specified identifier and made the regex removal its own function

There are still about 30 systems in the GUI list that cannot be added, due to missing data in a subset of the exoplanets in the system. I was thinking of hacking together something quick to solve this, but want to make a neater solution for handling systems with insufficient data... So that will be left until after the release