### PR TITLE
Fix for crash if screenspace image load fails

### DIFF
--- a/modules/base/rendering/renderableplaneimageonline.cpp
+++ b/modules/base/rendering/renderableplaneimageonline.cpp
@@ -120,24 +120,30 @@ void RenderablePlaneImageOnline::update(const UpdateData&) {
                 return;
             }
 
-            std::unique_ptr<ghoul::opengl::Texture> texture =
-                ghoul::io::TextureReader::ref().loadTexture(
-                    reinterpret_cast<void*>(imageFile.buffer),
-                    imageFile.size,
-                    imageFile.format
-                );
+            try {
+                std::unique_ptr<ghoul::opengl::Texture> texture =
+                    ghoul::io::TextureReader::ref().loadTexture(
+                        reinterpret_cast<void*>(imageFile.buffer),
+                        imageFile.size,
+                        imageFile.format
+                    );
 
-            if (texture) {
-                // Images don't need to start on 4-byte boundaries, for example if the
-                // image is only RGB
-                glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+                if (texture) {
+                    // Images don't need to start on 4-byte boundaries, for example if the
+                    // image is only RGB
+                    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-                texture->uploadTexture();
-                texture->setFilter(ghoul::opengl::Texture::FilterMode::LinearMipMap);
-                texture->purgeFromRAM();
+                    texture->uploadTexture();
+                    texture->setFilter(ghoul::opengl::Texture::FilterMode::LinearMipMap);
+                    texture->purgeFromRAM();
 
-                _texture = std::move(texture);
+                    _texture = std::move(texture);
+                    _textureIsDirty = false;
+                }
+            }
+            catch (const ghoul::io::TextureReader::InvalidLoadException& e) {
                 _textureIsDirty = false;
+                LERRORC(e.component, e.message);
             }
         }
     }

--- a/modules/base/rendering/screenspaceimageonline.cpp
+++ b/modules/base/rendering/screenspaceimageonline.cpp
@@ -129,25 +129,31 @@ void ScreenSpaceImageOnline::update() {
                 return;
             }
 
-            std::unique_ptr<ghoul::opengl::Texture> texture =
-                ghoul::io::TextureReader::ref().loadTexture(
-                    reinterpret_cast<void*>(imageFile.buffer),
-                    imageFile.size,
-                    imageFile.format
-                );
+            try {
+                std::unique_ptr<ghoul::opengl::Texture> texture =
+                    ghoul::io::TextureReader::ref().loadTexture(
+                        reinterpret_cast<void*>(imageFile.buffer),
+                        imageFile.size,
+                        imageFile.format
+                    );
 
-            if (texture) {
-                // Images don't need to start on 4-byte boundaries, for example if the
-                // image is only RGB
-                glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+                if (texture) {
+                    // Images don't need to start on 4-byte boundaries, for example if the
+                    // image is only RGB
+                    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-                texture->uploadTexture();
-                texture->setFilter(ghoul::opengl::Texture::FilterMode::LinearMipMap);
-                texture->purgeFromRAM();
+                    texture->uploadTexture();
+                    texture->setFilter(ghoul::opengl::Texture::FilterMode::LinearMipMap);
+                    texture->purgeFromRAM();
 
-                _texture = std::move(texture);
-                _objectSize = _texture->dimensions();
+                    _texture = std::move(texture);
+                    _objectSize = _texture->dimensions();
+                    _textureIsDirty = false;
+                }
+            }
+            catch (const ghoul::io::TextureReader::InvalidLoadException& e) {
                 _textureIsDirty = false;
+                LERRORC(e.component, e.message);
             }
         }
     }


### PR DESCRIPTION
Added to Ghoul TextureReader an exception throw if `loadTexture` fails. This covers uses of the `loadTexture(memory, size, format)` overload that didn't throw an exception.