### PR TITLE
Rename ScreenSpaceRenderable alpha to opacity (closes #1416)

### DIFF
--- a/include/openspace/rendering/screenspacerenderable.h
+++ b/include/openspace/rendering/screenspacerenderable.h
@@ -104,7 +104,7 @@ protected:
     properties::Vec3Property _localRotation;
 
     properties::FloatProperty _scale;
-    properties::FloatProperty _alpha;
+    properties::FloatProperty _opacity;
     properties::TriggerProperty _delete;
 
     glm::ivec2 _objectSize = glm::ivec2(0);

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -102,10 +102,10 @@ namespace {
     };
 
 
-    constexpr openspace::properties::Property::PropertyInfo AlphaInfo = {
-        "Alpha",
-        "Transparency",
-        "This value determines the transparency of the screen space plane. If this value "
+    constexpr openspace::properties::Property::PropertyInfo OpacityInfo = {
+        "Opacity",
+        "Opacity",
+        "This value determines the opacity of the screen space plane. If this value "
         "is 1, the plane is completely opaque, if this value is 0, the plane is "
         "completely transparent."
     };
@@ -280,10 +280,10 @@ documentation::Documentation ScreenSpaceRenderable::Documentation() {
                 ScaleInfo.description
             },
             {
-                AlphaInfo.identifier,
+                OpacityInfo.identifier,
                 new DoubleVerifier,
                 Optional::Yes,
-                AlphaInfo.description
+                OpacityInfo.description
             },
             {
                 KeyTag,
@@ -362,7 +362,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
         glm::vec3(glm::pi<float>())
     )
     , _scale(ScaleInfo, 0.25f, 0.f, 2.f)
-    , _alpha(AlphaInfo, 1.f, 0.f, 1.f)
+    , _opacity(OpacityInfo, 1.f, 0.f, 1.f)
     , _delete(DeleteInfo)
 {
     if (dictionary.hasKey(KeyIdentifier)) {
@@ -372,7 +372,6 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     if (dictionary.hasKey(KeyName)) {
         setGuiName(dictionary.value<std::string>(KeyName));
     }
-
 
     addProperty(_enabled);
     addProperty(_useRadiusAzimuthElevation);
@@ -392,7 +391,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     });
 
     addProperty(_scale);
-    addProperty(_alpha);
+    addProperty(_opacity);
     addProperty(_localRotation);
 
     if (dictionary.hasKey(EnabledInfo.identifier)) {
@@ -424,8 +423,8 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
         _scale = static_cast<float>(dictionary.value<double>(ScaleInfo.identifier));
     }
 
-    if (dictionary.hasKey(AlphaInfo.identifier)) {
-        _alpha = static_cast<float>(dictionary.value<double>(AlphaInfo.identifier));
+    if (dictionary.hasKey(OpacityInfo.identifier)) {
+        _opacity = static_cast<float>(dictionary.value<double>(OpacityInfo.identifier));
     }
 
     if (dictionary.hasKey(UsePerspectiveProjectionInfo.identifier)) {
@@ -613,7 +612,7 @@ void ScreenSpaceRenderable::draw(glm::mat4 modelTransform) {
 
     _shader->activate();
 
-    _shader->setUniform(_uniformCache.alpha, _alpha);
+    _shader->setUniform(_uniformCache.alpha, _opacity);
     _shader->setUniform(_uniformCache.modelTransform, modelTransform);
 
     _shader->setUniform(


### PR DESCRIPTION
Missed during opacity rewrite. Don't think we need to notify the users of this change, since we kind of already did?