### PR TITLE
Fixed issue 1382: Enabling accurate normals when the height layer info wasn't available.

### DIFF
--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1695,9 +1695,13 @@ void RenderableGlobe::recompileShaders() {
 
     std::vector<std::pair<std::string, std::string>>& pairs =
         preprocessingData.keyValuePairs;
-
+    
+    const bool hasHeightLayer = !_layerManager.layerGroup(
+        layergroupid::HeightLayers
+    ).activeLayers().empty();
+    
     pairs.emplace_back("useAccurateNormals",
-        std::to_string(_generalProperties.useAccurateNormals)
+        std::to_string(_generalProperties.useAccurateNormals && hasHeightLayer)
     );
     pairs.emplace_back(
         "performShading",


### PR DESCRIPTION
The globebrowsing shader code was being compiled with support for accurate normals even when the data required (the height layer) wasn't available.
Now, the shader code is only added if the height information is available.
