### PR TITLE
Exoplanets cleanup

### DIFF
--- a/data/assets/scene/digitaluniverse/exoplanets.asset
+++ b/data/assets/scene/digitaluniverse/exoplanets.asset
@@ -13,7 +13,7 @@ local speck = asset.syncedResource({
     Name = "Exoplanets Speck Files",
     Type = "HttpSynchronization",
     Identifier = "digitaluniverse_exoplanets_speck",
-    Version = 1
+    Version = 2
 })
 
 local object = {

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -42,46 +42,6 @@ namespace {
 
 namespace openspace::exoplanets {
 
-std::string_view speckStarName(std::string_view csvName) {
-    if (csvName == "MOA-2009-BLG-387L") { return "MOA 2009-BLG-387L"; }
-    if (csvName == "OGLE-2007-BLG-368L") { return "OGLE 2007-BLG-368L"; }
-    if (csvName == "OGLE-2005-BLG-169L") { return "OGLE 2005-BLG-169L"; }
-    if (csvName == "OGLE-2005-BLG-071L") { return "OGLE 2005-BLG-71L"; }
-    if (csvName == "OGLE-2003-BLG-235L") { return "OGLE 2003-BLG-235L"; }
-    if (csvName == "MOA-2008-BLG-310L") { return "MOA 2008-BLG-310L"; }
-    if (csvName == "OGLE-2006-BLG-109L") { return "OGLE 2006-BLG-109L"; }
-    if (csvName == "HD 137388") { return "HD 137388 A"; }
-    if (csvName == "MOA-2010-BLG-477L") { return "MOA 2010-BLG-477L"; }
-    if (csvName == "MOA-2009-BLG-266L") { return "MOA 2009-BLG-266L"; }
-    if (csvName == "iot Dra") { return "HIP 75458"; }
-    if (csvName == "MOA-2007-BLG-400L") { return "MOA 2007-BLG-400L"; }
-    if (csvName == "OGLE-2011-BLG-0251L") { return "OGLE 2011-BLG-251L"; }
-    if (csvName == "OGLE-2005-BLG-390L") { return "OGLE 2005-BLG-390L"; }
-    if (csvName == "MOA-2007-BLG-192L") { return "MOA 2007-BLG-192L"; }
-    if (csvName == "MOA-2009-BLG-319L") { return "MOA 2009-BLG-319L"; }
-    return csvName;
-}
-
-std::string_view csvStarName(std::string_view name) {
-    if (name == "MOA 2009-BLG-387L") { return "MOA-2009-BLG-387L"; }
-    if (name == "OGLE 2007-BLG-368L") { return "OGLE-2007-BLG-368L"; }
-    if (name == "OGLE 2005-BLG-169L") { return "OGLE-2005-BLG-169L"; }
-    if (name == "OGLE 2005-BLG-71L") { return "OGLE-2005-BLG-071L"; }
-    if (name == "OGLE 2003-BLG-235L") { return "OGLE-2003-BLG-235L"; }
-    if (name == "MOA 2008-BLG-310L") { return "MOA-2008-BLG-310L"; }
-    if (name == "OGLE 2006-BLG-109L") { return "OGLE-2006-BLG-109L"; }
-    if (name == "HD 137388 A") { return "HD 137388"; }
-    if (name == "MOA 2010-BLG-477L") { return "MOA-2010-BLG-477L"; }
-    if (name == "MOA 2009-BLG-266L") { return "MOA-2009-BLG-266L"; }
-    if (name == "HIP 75458") { return "iot Dra"; }
-    if (name == "MOA 2007-BLG-400L") { return "MOA-2007-BLG-400L"; }
-    if (name == "OGLE 2011-BLG-251L") { return "OGLE-2011-BLG-0251L"; }
-    if (name == "OGLE 2005-BLG-390L") { return "OGLE-2005-BLG-390L"; }
-    if (name == "MOA 2007-BLG-192L") { return "MOA-2007-BLG-192L"; }
-    if (name == "MOA 2009-BLG-319L") { return "MOA-2009-BLG-319L"; }
-    return name;
-}
-
 bool hasSufficientData(const Exoplanet& p) {
     bool invalidPos = std::isnan(p.positionX)
         || std::isnan(p.positionY)

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -42,7 +42,7 @@ namespace {
 
 namespace openspace::exoplanets {
 
-bool isValidPosition(const glm::vec3 pos) {
+bool isValidPosition(const glm::vec3& pos) {
     return !glm::any(glm::isnan(pos));
 }
 

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -42,7 +42,7 @@ namespace {
 
 namespace openspace::exoplanets {
 
-bool hasSufficientData(const Exoplanet& p) {
+bool hasSufficientData(const ExoplanetDataEntry& p) {
     bool invalidPos = std::isnan(p.positionX)
         || std::isnan(p.positionY)
         || std::isnan(p.positionZ);

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -53,7 +53,7 @@ bool hasSufficientData(const Exoplanet& p) {
     return !invalidPos && hasSemiMajorAxis && hasOrbitalPeriod;
 }
 
-std::string starColor(float bv) {
+glm::vec3 starColor(float bv) {
     std::ifstream colorMap(absPath(BvColormapPath), std::ios::in);
 
     if (!colorMap.good()) {
@@ -61,7 +61,7 @@ std::string starColor(float bv) {
             "Failed to open colormap data file: '{}'",
             absPath(BvColormapPath)
         ));
-        return "";
+        return glm::vec3(0.f, 0.f, 0.f);
     }
 
     const int t = static_cast<int>(round(((bv + 0.4) / (2.0 + 0.4)) * 255));
@@ -72,12 +72,10 @@ std::string starColor(float bv) {
     colorMap.close();
 
     std::istringstream colorStream(color);
-    std::string r, g, b;
-    getline(colorStream, r, ' ');
-    getline(colorStream, g, ' ');
-    getline(colorStream, b, ' ');
+    float r, g, b;
+    colorStream >> r >> g >> b;
 
-    return fmt::format("{{ {}, {}, {} }}", r, g, b);
+    return glm::vec3(r, g, b);
 }
 
 glm::dmat4 computeOrbitPlaneRotationMatrix(float i, float bigom, float omega) {

--- a/modules/exoplanets/exoplanetshelper.cpp
+++ b/modules/exoplanets/exoplanetshelper.cpp
@@ -42,15 +42,18 @@ namespace {
 
 namespace openspace::exoplanets {
 
-bool hasSufficientData(const ExoplanetDataEntry& p) {
-    bool invalidPos = std::isnan(p.positionX)
-        || std::isnan(p.positionY)
-        || std::isnan(p.positionZ);
+bool isValidPosition(const glm::vec3 pos) {
+    return !glm::any(glm::isnan(pos));
+}
 
+bool hasSufficientData(const ExoplanetDataEntry& p) {
+    const glm::vec3 starPosition{ p.positionX , p.positionY, p.positionZ };
+
+    bool validStarPosition = isValidPosition(starPosition);
     bool hasSemiMajorAxis = !std::isnan(p.a);
     bool hasOrbitalPeriod = !std::isnan(p.per);
 
-    return !invalidPos && hasSemiMajorAxis && hasOrbitalPeriod;
+    return validStarPosition && hasSemiMajorAxis && hasOrbitalPeriod;
 }
 
 glm::vec3 starColor(float bv) {

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -70,7 +70,7 @@ struct Exoplanet {
 bool hasSufficientData(const Exoplanet& p);
 
 // Compute star color in RGB from b-v color index
-std::string starColor(float bv);
+glm::vec3 starColor(float bv);
 
 glm::dmat4 computeOrbitPlaneRotationMatrix(float i, float bigom, float omega);
 

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -66,12 +66,6 @@ struct Exoplanet {
     float positionZ;    // Star position's Z-coordinate in parsec
 };
 
-// Convert csv-file specific names to the corresponding name in the speck data file
-std::string_view speckStarName(std::string_view name);
-
-// Convert speck-file specific names to the corresponding name in the csv data file
-std::string_view csvStarName(std::string_view name);
-
 // Check if the exoplanet p has sufficient data for visualization
 bool hasSufficientData(const Exoplanet& p);
 

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -80,6 +80,8 @@ struct ExoplanetSystem {
     std::vector<ExoplanetDataEntry> planetsData;
 };
 
+bool isValidPosition(const glm::vec3 pos);
+
 // Check if the exoplanet p has sufficient data for visualization
 bool hasSufficientData(const ExoplanetDataEntry& p);
 

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -27,10 +27,11 @@
 
 #include <ghoul/glm.h>
 #include <string>
+#include <vector>
 
 namespace openspace::exoplanets {
 
-struct Exoplanet {
+struct ExoplanetDataEntry {
     float a;            // Orbital semi-major axis in AU
     double aUpper;      // Upper uncertainty of orbital semi-major axis
     double aLower;      // Lower uncertainty of orbital semi-major axis
@@ -66,8 +67,21 @@ struct Exoplanet {
     float positionZ;    // Star position's Z-coordinate in parsec
 };
 
+struct StarData {
+    glm::vec3 position; // In parsec
+    float radius;       // In solar radii
+    float bvColorIndex;
+};
+
+struct ExoplanetSystem {
+    std::string starName;
+    StarData starData;
+    std::vector<std::string> planetNames;
+    std::vector<ExoplanetDataEntry> planetsData;
+};
+
 // Check if the exoplanet p has sufficient data for visualization
-bool hasSufficientData(const Exoplanet& p);
+bool hasSufficientData(const ExoplanetDataEntry& p);
 
 // Compute star color in RGB from b-v color index
 glm::vec3 starColor(float bv);

--- a/modules/exoplanets/exoplanetshelper.h
+++ b/modules/exoplanets/exoplanetshelper.h
@@ -80,7 +80,7 @@ struct ExoplanetSystem {
     std::vector<ExoplanetDataEntry> planetsData;
 };
 
-bool isValidPosition(const glm::vec3 pos);
+bool isValidPosition(const glm::vec3& pos);
 
 // Check if the exoplanet p has sufficient data for visualization
 bool hasSufficientData(const ExoplanetDataEntry& p);

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -106,13 +106,14 @@ ExoplanetSystem findExoplanetSystemInData(std::string_view starName) {
             // Star data - Should not vary between planets, but one data entry might
             // lack data for the host star while another does not. So for every planet,
             // update star data if needed
-            if (p.positionX != system.starData.position.x) {
-                system.starData.position = { p.positionX, p.positionY, p.positionZ };
+            const glm::vec3 pos{ p.positionX, p.positionY, p.positionZ };
+            if (system.starData.position != pos && isValidPosition(pos)) {
+                system.starData.position = pos;
             }
-            if (system.starData.bvColorIndex != p.bmv) {
+            if (system.starData.bvColorIndex != p.bmv && !std::isnan(p.bmv)) {
                 system.starData.bvColorIndex = p.bmv;
             }
-            if (system.starData.radius != p.rStar) {
+            if (system.starData.radius != p.rStar && !std::isnan(p.rStar)) {
                 system.starData.radius = p.rStar;
             }
         }
@@ -146,9 +147,7 @@ void createExoplanetSystem(const std::string& starName) {
     }
 
     const glm::dvec3 starPosInParsec = static_cast<glm::dvec3>(system.starData.position);
-
-    bool positionIsInvalid = glm::any(glm::isnan(starPosInParsec));
-    if (positionIsInvalid) {
+    if (!isValidPosition(starPosInParsec)) {
         LERROR(fmt::format(
             "Insufficient data available for exoplanet system: '{}' -"
             "Could not determine star position", starName

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -56,13 +56,10 @@ constexpr const char* NoDataTextureFile =
 constexpr const char* DiscTextureFile =
     "${SYNC}/http/exoplanets_textures/1/disc_texture.png";
 
-void createExoplanetSystem(std::string_view starName) {
-    // If user have given name as in EOD, change it to speck-name
-    const std::string starNameSpeck = std::string(speckStarName(starName));
+void createExoplanetSystem(const std::string& starName) {
+    const std::string starIdentifier = createIdentifier(starName);
 
-    const std::string starIdentifier = createIdentifier(starNameSpeck);
-
-    std::string sanitizedStarName = starNameSpeck;
+    std::string sanitizedStarName = starName;
     sanitizeNameString(sanitizedStarName);
 
     const std::string guiPath = ExoplanetsGuiPath + sanitizedStarName;
@@ -108,7 +105,7 @@ void createExoplanetSystem(std::string_view starName) {
         std::string name;
         getline(ss, name, ',');
 
-        if (name.compare(0, name.length() - 2, starNameSpeck) == 0) {
+        if (name.compare(0, name.length() - 2, starName) == 0) {
             std::string location_s;
             getline(ss, location_s);
             long location = std::stol(location_s.c_str());
@@ -441,8 +438,7 @@ int removeExoplanetSystem(lua_State* L) {
 
     const int StringLocation = -1;
     const std::string starName = luaL_checkstring(L, StringLocation);
-    const std::string starNameSpeck = std::string(speckStarName(starName));
-    const std::string starIdentifier = createIdentifier(starNameSpeck);
+    const std::string starIdentifier = createIdentifier(starName);
 
     openspace::global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + starIdentifier + "');",

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -348,6 +348,12 @@ void createExoplanetSystem(const std::string& starName) {
             "}"
         "}";
 
+        openspace::global::scriptEngine->queueScript(
+            "openspace.addSceneGraphNode(" + planetTrailNode + ");"
+            "openspace.addSceneGraphNode(" + planetNode + ");",
+            scripting::ScriptEngine::RemoteScripting::Yes
+        );
+
         bool hasUpperAUncertainty = !std::isnan(planet.aUpper);
         bool hasLowerAUncertainty = !std::isnan(planet.aLower);
 
@@ -388,9 +394,7 @@ void createExoplanetSystem(const std::string& starName) {
             "}";
 
             openspace::global::scriptEngine->queueScript(
-                "openspace.addSceneGraphNode(" + discNode + ");"
-                "openspace.addSceneGraphNode(" + planetTrailNode + ");"
-                "openspace.addSceneGraphNode(" + planetNode + ");",
+                "openspace.addSceneGraphNode(" + discNode + ");",
                 scripting::ScriptEngine::RemoteScripting::Yes
             );
         }

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -85,7 +85,7 @@ ExoplanetSystem findExoplanetSystemInData(std::string_view starName) {
         std::string name;
         getline(ss, name, ',');
 
-        if (name.compare(0, name.length() - 2, starName) == 0) {
+        if (name.substr(0, name.length() - 2) == starName) {
             std::string location_s;
             getline(ss, location_s);
             long location = std::stol(location_s.c_str());
@@ -134,7 +134,7 @@ void createExoplanetSystem(const std::string& starName) {
     SceneGraphNode* existingStarNode = sceneGraphNode(starIdentifier);
     if (existingStarNode) {
         LERROR(fmt::format(
-            "Adding of exoplanet system '{}' failed. The system has already been added.",
+            "Adding of exoplanet system '{}' failed. The system has already been added",
             starName
         ));
         return;
@@ -146,16 +146,17 @@ void createExoplanetSystem(const std::string& starName) {
         return;
     }
 
-    const glm::dvec3 starPosInParsec = static_cast<glm::dvec3>(system.starData.position);
+    const glm::vec3 starPosInParsec = system.starData.position;
     if (!isValidPosition(starPosInParsec)) {
         LERROR(fmt::format(
-            "Insufficient data available for exoplanet system: '{}' -"
+            "Insufficient data available for exoplanet system: '{}'. "
             "Could not determine star position", starName
         ));
         return;
     }
 
-    const glm::dvec3 starPos = starPosInParsec * distanceconstants::Parsec;
+    const glm::dvec3 starPos =
+        static_cast<glm::dvec3>(starPosInParsec) * distanceconstants::Parsec;
     const glm::dmat3 exoplanetSystemRotation = computeSystemRotation(starPos);
     const float solarRadius = static_cast<float>(distanceconstants::SolarRadius);
 

--- a/modules/exoplanets/tasks/exoplanetsdatapreparationtask.cpp
+++ b/modules/exoplanets/tasks/exoplanetsdatapreparationtask.cpp
@@ -161,7 +161,7 @@ void ExoplanetsDataPreparationTask::perform(
         progressCallback(static_cast<float>(exoplanetCount) / static_cast<float>(total));
 
         std::string component;
-        std::string speckStarname;
+        std::string starName;
 
         float ra = std::numeric_limits<float>::quiet_NaN();     // decimal degrees
         float dec = std::numeric_limits<float>::quiet_NaN();    // decimal degrees
@@ -248,9 +248,8 @@ void ExoplanetsDataPreparationTask::perform(
             }
             // Star - name and position
             else if (column == "hostname") {
-                std::string name = readStringData(data);
-                speckStarname = std::string(speckStarName(name));
-                glm::vec3 position = starPosition(speckStarname);
+                starName = readStringData(data);
+                glm::vec3 position = starPosition(starName);
                 p.positionX = position[0];
                 p.positionY = position[1];
                 p.positionZ = position[2];
@@ -308,7 +307,7 @@ void ExoplanetsDataPreparationTask::perform(
 
         // Create look-up table
         long pos = static_cast<long>(binFile.tellp());
-        std::string planetName = speckStarname + " " + component;
+        std::string planetName = starName + " " + component;
         lutFile << planetName << "," << pos << std::endl;
 
         binFile.write(reinterpret_cast<char*>(&p), sizeof(Exoplanet));

--- a/modules/exoplanets/tasks/exoplanetsdatapreparationtask.cpp
+++ b/modules/exoplanets/tasks/exoplanetsdatapreparationtask.cpp
@@ -153,7 +153,7 @@ void ExoplanetsDataPreparationTask::perform(
         return result;
     };
 
-    Exoplanet p;
+    ExoplanetDataEntry p;
     std::string data;
     int exoplanetCount = 0;
     while (getline(inputDataFile, planetRow)) {
@@ -310,7 +310,7 @@ void ExoplanetsDataPreparationTask::perform(
         std::string planetName = starName + " " + component;
         lutFile << planetName << "," << pos << std::endl;
 
-        binFile.write(reinterpret_cast<char*>(&p), sizeof(Exoplanet));
+        binFile.write(reinterpret_cast<char*>(&p), sizeof(ExoplanetDataEntry));
     }
 
     progressCallback(1.f);


### PR DESCRIPTION
- Exoplanet code cleanup (ugly matching of names in speck file)
- Now possible to add exoplanet systems where one or a few planets are having insufficient data. Good for example for the Kepler-80 system, where there is enough data for 5/6 exoplanets (previously this one could not be added at all)