### PR TITLE
prevent renderbin change for overlay renderables

### DIFF
--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -241,7 +241,7 @@ void Renderable::setRenderBinFromOpacity() {
 
 void Renderable::registerUpdateRenderBinFromOpacity() {
     _opacity.onChange([this](){
-        if (_renderBin != Renderable::RenderBin::PostDeferredTransparent) {
+        if ( (_renderBin != Renderable::RenderBin::PostDeferredTransparent) && (_renderBin != Renderable::RenderBin::Overlay) ) {
             if (_opacity >= 0.f && _opacity < 1.f) {
                 setRenderBin(Renderable::RenderBin::PreDeferredTransparent);
             }

--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -241,7 +241,9 @@ void Renderable::setRenderBinFromOpacity() {
 
 void Renderable::registerUpdateRenderBinFromOpacity() {
     _opacity.onChange([this](){
-        if ( (_renderBin != Renderable::RenderBin::PostDeferredTransparent) && (_renderBin != Renderable::RenderBin::Overlay) ) {
+        if ((_renderBin != Renderable::RenderBin::PostDeferredTransparent) &&
+            (_renderBin != Renderable::RenderBin::Overlay))
+        {
             if (_opacity >= 0.f && _opacity < 1.f) {
                 setRenderBin(Renderable::RenderBin::PreDeferredTransparent);
             }


### PR DESCRIPTION
Addressing https://github.com/OpenSpace/OpenSpace/issues/1484 
When changing the opacity of a trail, it's renderbin was also being changed by the default renderable behavior. 

we already had a case to prevent this default behavior to renderables that are marked as RenderBin::PostDeferredTransparent
 so I add ones that are marked as RenderBin::Overlay to this case. 

This changes ultimately changes the order in which the trail will be rendered here: https://github.com/OpenSpace/OpenSpace/blob/cdbc1c2695b90fe1b9af1b40e5fd6ed8b577ecf1/src/rendering/framebufferrenderer.cpp#L1137 and thus making it 'not interact' with the atmosphere 