### PR TITLE
Add property to determine whether the date should be added to the screenshot folder

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -218,6 +218,15 @@ void mainInitFunc(GLFWwindow*) {
 
     LTRACE("main::mainInitFunc(begin)");
 
+    //
+    //  Screenshots
+    //
+    // We save the startup value of the screenshots just in case we want to add a date
+    // to them later in the RenderEngine
+    std::string screenshotPath = absPath("${SCREENSHOTS}");
+    FileSys.registerPathToken("${STARTUP_SCREENSHOT}", screenshotPath);
+    Settings::instance().setCapturePath(screenshotPath);
+
     LDEBUG("Initializing OpenSpace Engine started");
     global::openSpaceEngine->initialize();
     LDEBUG("Initializing OpenSpace Engine finished");
@@ -320,27 +329,6 @@ void mainInitFunc(GLFWwindow*) {
         LWARNING("Spout was requested, but program was compiled without Spout support");
 #endif // OPENSPACE_HAS_SPOUT
     }
-
-
-    //
-    //  Screenshots
-    //
-    std::string screenshotPath = "${SCREENSHOTS}";
-    if (global::configuration->shouldUseScreenshotDate) {
-        std::time_t now = std::time(nullptr);
-        std::tm* nowTime = std::localtime(&now);
-        char mbstr[128];
-        strftime(mbstr, sizeof(mbstr), "%Y-%m-%d-%H-%M", nowTime);
-
-        FileSys.registerPathToken(
-            "${SCREENSHOTS}",
-            absPath(screenshotPath + '/' + std::string(mbstr)),
-            ghoul::filesystem::FileSystem::Override::Yes
-        );
-    }
-
-    Settings::instance().setCapturePath(absPath(screenshotPath));
-
 
     LTRACE("main::mainInitFunc(end)");
 }

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -201,6 +201,7 @@ private:
     properties::BoolProperty _showCameraInfo;
 
     properties::BoolProperty _applyWarping;
+    properties::BoolProperty _screenshotUseDate;
     properties::BoolProperty _showFrameInformation;
     properties::BoolProperty _disableMasterRendering;
 


### PR DESCRIPTION
Closes #1528 

Question:
As implemented right now the date that is used is *not* the startup time, but the time when the value was set to true.  This means that if you toggle the value on an off, there will then be two folders which will separate the screenshots.

Is this what we want?  I'd say yes since I can't see of a good reason why you'd want to turn on and off the date-addition otherwise