### PR TITLE
Fix that allows all days of month except monthly increment still at 1-28

### DIFF
--- a/modules/globebrowsing/src/timequantizer.cpp
+++ b/modules/globebrowsing/src/timequantizer.cpp
@@ -371,17 +371,31 @@ void TimeQuantizer::setResolution(const std::string& resolutionString) {
 
 void TimeQuantizer::verifyStartTimeRestrictions() {
     //If monthly time resolution then restrict to 28 days so every month is consistent
-    unsigned int dayUpperLimit = (_resolutionUnit == 'M') ? 28 : 31;
+    unsigned int dayUpperLimit;
+    std::string helpfulDescription = "the selected month";
+    if (_resolutionUnit == 'M') {
+        dayUpperLimit = 28;
+        helpfulDescription = "monthly increment";
+    }
+    else if (_resolutionUnit == 'y') {
+        //Get month sizes using a fixed non-leap year
+        dayUpperLimit = monthSize(_start.month(), 2001);
+        helpfulDescription += " on a yearly increment";
+    }
+    else {
+        dayUpperLimit = 31;
+    }
     if (_start.day() < 1 || _start.day() > dayUpperLimit) {
         throw ghoul::RuntimeError(fmt::format(
-            "Invalid start day value of {} for day of month. Valid days are 1 - {}",
+            "Invalid start day value of {} for {}, valid days are 1 - {}",
             _start.day(),
+            helpfulDescription,
             dayUpperLimit
         ));
     }
     if (_start.hour() != 0 || _start.minute() != 0 || _start.second() != 0) {
         throw ghoul::RuntimeError(fmt::format(
-            "Invalid start time value of {}:{}:{}. Time must be 00:00:00",
+            "Invalid start time value of {}:{}:{}, time must be 00:00:00",
             _start.hour(), _start.minute(), _start.second()
         ));
     }

--- a/modules/globebrowsing/src/timequantizer.cpp
+++ b/modules/globebrowsing/src/timequantizer.cpp
@@ -335,8 +335,8 @@ TimeQuantizer::TimeQuantizer(std::string start, std::string end,
     : _start(start)
     , _timerange(std::move(start), std::move(end))
 {
-    verifyStartTimeRestrictions();
     _resolution = parseTimeResolutionStr(resolution);
+    verifyStartTimeRestrictions();
 }
 
 double TimeQuantizer::parseTimeResolutionStr(const std::string& resolutionStr) {
@@ -366,13 +366,17 @@ void TimeQuantizer::setStartEndRange(const std::string& start, const std::string
 
 void TimeQuantizer::setResolution(const std::string& resolutionString) {
     _resolution = parseTimeResolutionStr(resolutionString);
+    verifyStartTimeRestrictions();
 }
 
 void TimeQuantizer::verifyStartTimeRestrictions() {
-    if (_start.day() < 1 || _start.day() > 28) {
+    //If monthly time resolution then restrict to 28 days so every month is consistent
+    unsigned int dayUpperLimit = (_resolutionUnit == 'M') ? 28 : 31;
+    if (_start.day() < 1 || _start.day() > dayUpperLimit) {
         throw ghoul::RuntimeError(fmt::format(
-            "Invalid start day value of {} for day of month. Valid days are 1 - 28",
-            _start.day()
+            "Invalid start day value of {} for day of month. Valid days are 1 - {}",
+            _start.day(),
+            dayUpperLimit
         ));
     }
     if (_start.hour() != 0 || _start.minute() != 0 || _start.second() != 0) {

--- a/tests/test_timequantizer.cpp
+++ b/tests/test_timequantizer.cpp
@@ -148,6 +148,15 @@ TEST_CASE("TimeQuantizer: Test years resolution", "[timequantizer]") {
     singleTimeTest(testT, t1, true, "2028-12-08T23:59:59", "2025-12-09T00:00:00.000");
     singleTimeTest(testT, t1, true, "2028-12-09T00:00:01", "2028-12-09T00:00:00.000");
 
+    try {
+        t1.setStartEndRange("2020-02-29T00:00:00", "2030-02-29T00:00:00");
+    }
+    catch (const ghoul::RuntimeError& e) {
+        REQUIRE(e.message.find("Invalid start day value of 29 for the selected month "
+            "on a yearly increment, valid days are 1 - 28") != std::string::npos);
+    }
+    t1.setStartEndRange("2020-02-28T00:00:00", "2030-02-28T00:00:00");
+
     SpiceManager::deinitialize();
 }
 
@@ -216,7 +225,8 @@ TEST_CASE("TimeQuantizer: Test months resolution", "[timequantizer]") {
         t1.setStartEndRange("2017-01-30T00:00:00", "2020-09-01T00:00:00");
     }
     catch (const ghoul::RuntimeError& e) {
-        REQUIRE(e.message.find("Invalid start day value of 30 for day of month. Valid days are 1 - 28") != std::string::npos);
+        REQUIRE(e.message.find("Invalid start day value of 30 for monthly increment, "
+                               "valid days are 1 - 28") != std::string::npos);
     }
 
     t1.setStartEndRange("2016-01-17T00:00:00", "2020-09-01T00:00:00");

--- a/tests/test_timequantizer.cpp
+++ b/tests/test_timequantizer.cpp
@@ -191,6 +191,11 @@ TEST_CASE("TimeQuantizer: Test days resolution", "[timequantizer]") {
     singleTimeTest(testT, t1, true, "2020-03-01T00:30:00", "2020-03-01T00:00:00.000");
     singleTimeTest(testT, t1, true, "2019-03-04T00:00:02", "2019-03-04T00:00:00.000");
 
+    t1.setStartEndRange("2020-01-31T00:00:00", "2020-07-31T00:00:00");
+    t1.setResolution("1d");
+
+    singleTimeTest(testT, t1, true, "2020-03-01T00:30:00", "2020-03-01T00:00:00.000");
+
     SpiceManager::deinitialize();
 }
 
@@ -206,6 +211,13 @@ TEST_CASE("TimeQuantizer: Test months resolution", "[timequantizer]") {
 
     singleTimeTest(testT, t1, true, "2017-03-03T05:15:45", "2017-02-28T00:00:00.000");
     singleTimeTest(testT, t1, true, "2017-03-29T00:15:45", "2017-03-28T00:00:00.000");
+
+    try {
+        t1.setStartEndRange("2017-01-30T00:00:00", "2020-09-01T00:00:00");
+    }
+    catch (const ghoul::RuntimeError& e) {
+        REQUIRE(e.message.find("Invalid start day value of 30 for day of month. Valid days are 1 - 28") != std::string::npos);
+    }
 
     t1.setStartEndRange("2016-01-17T00:00:00", "2020-09-01T00:00:00");
     t1.setResolution("2M");
@@ -333,7 +345,7 @@ TEST_CASE("TimeQuantizer: Test start time pre-existing object", "[timequantizer]
     globebrowsing::TimeQuantizer t1;
 
     singleStartTimeTest(t1, "2017-01-20T00:00:00", "Invalid start", false);
-    singleStartTimeTest(t1, "2017-01-29T00:00:00", "Invalid start day value", true);
+    singleStartTimeTest(t1, "2017-01-29T00:00:00", "Invalid start day value", false);
     singleStartTimeTest(t1, "2017-01-28T12:00:00", "Invalid start time value", true);
     singleStartTimeTest(t1, "2017-01-28T00:01:00", "Invalid start time value", true);
     singleStartTimeTest(t1, "2017-01-28T00:00:01", "Invalid start time value", true);
@@ -347,7 +359,7 @@ TEST_CASE("TimeQuantizer: Test start time using constructor", "[timequantizer]")
     loadLSKKernel();
 
     singleStartTimeTest("2017-01-20T00:00:00", "Invalid start", false);
-    singleStartTimeTest("2017-01-29T00:00:00", "Invalid start day value", true);
+    singleStartTimeTest("2017-01-32T00:00:00", "For January the day must be at least 1.0D0 and less than 3.2E+01", true);
     singleStartTimeTest("2017-01-28T12:00:00", "Invalid start time value", true);
     singleStartTimeTest("2017-01-28T00:01:00", "Invalid start time value", true);
     singleStartTimeTest("2017-01-28T00:00:01", "Invalid start time value", true);


### PR DESCRIPTION
Timequantizer still requires start/end days to be in 1-28 range for monthly increment, but allows the full day range for any other increment.