### PR TITLE
Adding hi-res 75cm Bennu model from asteroidmission.org

### DIFF
--- a/data/assets/scene/solarsystem/missions/osirisrex/bennu.asset
+++ b/data/assets/scene/solarsystem/missions/osirisrex/bennu.asset
@@ -5,6 +5,15 @@ local models = asset.require('./models').models
 
 local BENNU_BODY = "2101955"
 
+local LightSources = {
+  {
+    Type = "SceneGraphLightSource",
+    Identifier = "Sun",
+    Node = sunTransforms.SolarSystemBarycenter.Identifier,
+    Intensity = 1.0
+  },
+}
+
 local Bennu = {
   Identifier = "Bennu",
   Parent = transforms.BennuBarycenter.Identifier,
@@ -16,39 +25,20 @@ local Bennu = {
     },
     Scale = {
       Type = "StaticScale",
-      Scale = 1000.0
+      Scale = 1.0
     }
   },
   Renderable = {
     Enabled = false,
     Type = "RenderableModel",
     Body = BENNU_BODY,
-    GeometryFile = models .. "/Bennu_v20_200k.stl",
+    GeometryFile = models .. "/Bennu_v20_200k_an.obj",
+    LightSources = LightSources,
+    SpecularIntensity = 0.0
   },
   GUI = {
     Path = "/Solar System/Asteroid"
   }
 }
 
-local BennuTrail = {
-  Identifier = "BennuTrail",
-  Parent = sunTransforms.SolarSystemBarycenter.Identifier,
-  Renderable = {
-    Type = "RenderableTrailTrajectory",
-    Translation = {
-      Type = "SpiceTranslation",
-      Target = BENNU_BODY,
-      Observer = "SUN"
-    },
-    Color = { 0.4, 0.0, 0.7 },
-    StartTime = "2015 JAN 01 00:00:00.000",
-    EndTime = "2023 MAY 31 00:00:00.000",
-    SampleInterval = 3600
-  },
-  GUI = {
-    Name = "Bennu Trail",
-    Path = "/Solar System/Asteroid"
-  }
-}
-
-assetHelper.registerSceneGraphNodesAndExport(asset, { Bennu, BennuTrail })
+assetHelper.registerSceneGraphNodesAndExport(asset, {Bennu})

--- a/data/assets/scene/solarsystem/missions/osirisrex/bennu.asset
+++ b/data/assets/scene/solarsystem/missions/osirisrex/bennu.asset
@@ -23,10 +23,6 @@ local Bennu = {
       SourceFrame = "IAU_BENNU",
       DestinationFrame = "GALACTIC"
     },
-    Scale = {
-      Type = "StaticScale",
-      Scale = 1.0
-    }
   },
   Renderable = {
     Enabled = false,

--- a/data/assets/scene/solarsystem/missions/osirisrex/osirisrex.asset
+++ b/data/assets/scene/solarsystem/missions/osirisrex/osirisrex.asset
@@ -1,3 +1,4 @@
+asset.require('./bennu')
 asset.require('./bennu_projection')
 asset.require('./model')
 asset.require('./trail')


### PR DESCRIPTION
Adds the hi-res Bennu model from here:
https://www.asteroidmission.org/updated-bennu-shape-model-3d-files/
to the osirisrex mission. The profile has the **BennuProjection** scenegraph node, which is the original low-res Bennu model that gets images projected onto it. This new **Bennu** scenegraph node is disabled by default, but looks much better than the original.
![image](https://user-images.githubusercontent.com/3966290/120960672-94d48e80-c719-11eb-9c58-ceda2d803260.png)


The Utah data server has these 2 new files:
http://openspace.sci.utah.edu/files/solarsystem/missions/osirisrex/bennu/models/v1_v2/Bennu_v20_200k_an.obj
http://openspace.sci.utah.edu/files/solarsystem/missions/osirisrex/bennu/models/v1_v2/Bennu_v20_200k_an.mtl
which will need to be added to the data.openspaceproject.com server.