### PR TITLE
Fix problem when pause in session recording and outputting frames (#1669)

### DIFF
--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -1770,8 +1770,8 @@ bool SessionRecording::addKeyframe(Timestamps t3stamps,
 void SessionRecording::moveAheadInTime() {
     using namespace std::chrono;
 
-    bool paused = global::timeManager->isPaused();
-    if (_state == SessionState::PlaybackPaused) {
+    bool playbackPaused = (_state == SessionState::PlaybackPaused);
+    if (playbackPaused) {
         _playbackPauseOffset
             += global::windowDelegate->applicationTime() - _previousTime;
     }
@@ -1780,7 +1780,7 @@ void SessionRecording::moveAheadInTime() {
     double currTime = currentTime();
     lookForNonCameraKeyframesThatHaveComeDue(currTime);
     updateCameraWithOrWithoutNewKeyframes(currTime);
-    //Unfortunately the first frame is sometimes rendered because globebrowsing reports
+    // Unfortunately the first frame is sometimes rendered because globebrowsing reports
     // that all chunks are rendered when they apparently are not.
     if (_saveRendering_isFirstFrame) {
         _saveRendering_isFirstFrame = false;
@@ -1793,10 +1793,10 @@ void SessionRecording::moveAheadInTime() {
             global::navigationHandler->orbitalNavigator().anchorNode();
         const Renderable* focusRenderable = focusNode->renderable();
         if (!focusRenderable || focusRenderable->renderedWithDesiredData()) {
-            if (!paused) {
+            if (!playbackPaused) {
                 _saveRenderingCurrentRecordedTime_interpolation +=
                     _saveRenderingDeltaTime_interpolation_usec;
-               _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
+                _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
                 global::renderEngine->takeScreenshot();
             }
         }


### PR DESCRIPTION
Seems to me like this should fix #1669, but maybe @GPayne could verify?

Tried it out a bit and the session recording and output frames behave how I would expect it with this change. However, I noticed that the screenshots are triggered a few frames before the actual session recording starts playing back. So, we get a few extra screenshots before the session recording, and also some before the playback is resumed after it has been paused (when the GUI bar is orange)

Anyhow, it works much better than the pause preventing the session recording from being played back at all 😃 