### PR TITLE
Update faulty docs and function name for globebrowsing.getGeoPosition (#1662)

### DIFF
--- a/modules/globebrowsing/globebrowsingmodule.cpp
+++ b/modules/globebrowsing/globebrowsingmodule.cpp
@@ -398,20 +398,22 @@ scripting::LuaLibrary GlobeBrowsingModule::luaLibrary() const {
             "the surface of the specified globe."
         },
         {
-            "getGeoPosition",
-            &globebrowsing::luascriptfunctions::getGeoPosition,
+            "getLocalPositionFromGeo",
+            &globebrowsing::luascriptfunctions::getLocalPositionFromGeo,
             {},
             "string, number, number, number",
-            "Returns the specified surface position on the globe identified by the first "
-            "argument, as three floating point values - latitude, longitude and altitude "
-            "(degrees and meters)."
+            "Returns a position in the local Cartesian coordinate system of the globe "
+            "identified by the first argument, that corresponds to the given geographic "
+            "coordinates: latitude, longitude and altitude (in degrees and meters). In "
+            "the local coordinate system, the position (0,0,0) corresponds to the "
+            "globe's center."
         },
         {
             "getGeoPositionForCamera",
             &globebrowsing::luascriptfunctions::getGeoPositionForCamera,
             {},
             "void",
-            "Get geographic coordinates of the camera poosition in latitude, "
+            "Get geographic coordinates of the camera position in latitude, "
             "longitude, and altitude (degrees and meters)."
         },
         {

--- a/modules/globebrowsing/globebrowsingmodule_lua.inl
+++ b/modules/globebrowsing/globebrowsingmodule_lua.inl
@@ -287,8 +287,8 @@ int goToGeo(lua_State* L) {
     return 0;
 }
 
-int getGeoPosition(lua_State* L) {
-    ghoul::lua::checkArgumentsAndThrow(L, 4, "lua::getGeoPosition");
+int getLocalPositionFromGeo(lua_State* L) {
+    ghoul::lua::checkArgumentsAndThrow(L, 4, "lua::getLocalPositionFromGeo");
 
     const std::string& globeIdentifier = ghoul::lua::value<std::string>(L, 1);
     const double latitude = ghoul::lua::value<double>(L, 2);


### PR DESCRIPTION
New name: getLocalPositionFromGeo

This name actually corresponds to what the function does: Computes a cartesian position in the globe's local coordinate system that corresponds to the given Geo position (lat, long, altitude)

