### PR TITLE
Issue/1669

### DIFF
--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -1771,7 +1771,8 @@ void SessionRecording::moveAheadInTime() {
     using namespace std::chrono;
 
     bool paused = global::timeManager->isPaused();
-    if (_state == SessionState::PlaybackPaused) {
+    bool playbackPaused = (_state == SessionState::PlaybackPaused);
+    if (playbackPaused) {
         _playbackPauseOffset
             += global::windowDelegate->applicationTime() - _previousTime;
     }
@@ -1793,10 +1794,12 @@ void SessionRecording::moveAheadInTime() {
             global::navigationHandler->orbitalNavigator().anchorNode();
         const Renderable* focusRenderable = focusNode->renderable();
         if (!focusRenderable || focusRenderable->renderedWithDesiredData()) {
-            _saveRenderingCurrentRecordedTime_interpolation +=
-                _saveRenderingDeltaTime_interpolation_usec;
-            _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
-            global::renderEngine->takeScreenshot();
+            if (!playbackPaused) {
+                _saveRenderingCurrentRecordedTime_interpolation +=
+                    _saveRenderingDeltaTime_interpolation_usec;
+                _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
+                global::renderEngine->takeScreenshot();
+            }
         }
     }
 }

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -1775,7 +1775,7 @@ void SessionRecording::moveAheadInTime() {
         if (!focusRenderable || focusRenderable->renderedWithDesiredData()) {
             _saveRenderingCurrentRecordedTime_interpolation +=
                 _saveRenderingDeltaTime_interpolation_usec;
-            saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
+            _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
             global::renderEngine->takeScreenshot();
         }
     }

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -1773,12 +1773,10 @@ void SessionRecording::moveAheadInTime() {
             global::navigationHandler->orbitalNavigator().anchorNode();
         const Renderable* focusRenderable = focusNode->renderable();
         if (!focusRenderable || focusRenderable->renderedWithDesiredData()) {
-            if (!paused) {
-                _saveRenderingCurrentRecordedTime_interpolation +=
-                    _saveRenderingDeltaTime_interpolation_usec;
-               _saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
-                global::renderEngine->takeScreenshot();
-            }
+            _saveRenderingCurrentRecordedTime_interpolation +=
+                _saveRenderingDeltaTime_interpolation_usec;
+            saveRenderingCurrentRecordedTime += _saveRenderingDeltaTime;
+            global::renderEngine->takeScreenshot();
         }
     }
 }


### PR DESCRIPTION
Partial fix for issue #1669 but does not resolve that issue. There is a fundamental timing problem with playback while saving frames where simulation time is not in sync with playback when delta time is changed. However, this fix avoids problems with playback hanging on a recorded pause.
Also contains a fix from Emma Broman that allows the playback-with-frames to be paused while playing back.