### PR TITLE
Added warning to keybinding editor for duplicate assignments

### DIFF
--- a/apps/OpenSpace/ext/launcher/include/profile/keybindingsdialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/keybindingsdialog.h
@@ -28,6 +28,7 @@
 #include <QDialog>
 
 #include <openspace/scene/profile.h>
+#include <openspace/util/keys.h>
 #include <QWidget>
 #include <QListWidgetItem>
 
@@ -68,6 +69,7 @@ private slots:
     void parseSelections();
     void chooseScripts();
     void keySelected(int index);
+    void keyModSelected(int index);
 
     /**
      * Adds scripts to the _scriptEdit from outside dialogs
@@ -83,12 +85,16 @@ private:
     int indexInKeyMapping(std::vector<int>& mapVector, int keyInt);
     bool areRequiredFormsFilled();
     bool isLineEmpty(int index);
+    void addStringToErrorDisplay(const QString& newString);
+    void checkForNumberKeyConflict(int key);
+    void checkForBindingConflict(int selectedModKey, int selectedKey);
 
     openspace::Profile& _profile;
     std::vector<openspace::Profile::Keybinding> _data;
     std::vector<int> _mapModKeyComboBoxIndexToKeyValue;
     std::vector<int> _mapKeyComboBoxIndexToKeyValue;
     bool _editModeNewItem = false;
+    int _currentKeybindingSelection = 0;
 
     QListWidget* _list = nullptr;
     QLabel* _keyModLabel = nullptr;

--- a/apps/OpenSpace/ext/launcher/src/profile/keybindingsdialog.cpp
+++ b/apps/OpenSpace/ext/launcher/src/profile/keybindingsdialog.cpp
@@ -379,7 +379,7 @@ void KeybindingsDialog::listItemAdded() {
     _documentationEdit->setText(QString::fromStdString(_data.back().documentation));
     _localCheck->setChecked(false);
     _scriptEdit->setText(QString::fromStdString(_data.back().script));
-    _currentKeybindingSelection = _data.size() - 1;
+    _currentKeybindingSelection = static_cast<int>(_data.size() - 1);
     _editModeNewItem = true;
 }
 
@@ -393,12 +393,12 @@ void KeybindingsDialog::checkForNumberKeyConflict(int key) {
 
 void KeybindingsDialog::checkForBindingConflict(int selectedModKey, int selectedKey) {
     const QString localWarn = "Warning: New selection conflicts with binding '";
-    if (_currentKeybindingSelection >= _data.size()) {
+    if (_currentKeybindingSelection >= static_cast<int>(_data.size())) {
         return;
     }
     KeyModifier newModifier = static_cast<KeyModifier>(selectedModKey);
     Key newKey = static_cast<Key>(selectedKey);
-    for (int i = 0; i < _data.size(); ++i) {
+    for (int i = 0; i < static_cast<int>(_data.size()); ++i) {
         if (i == _currentKeybindingSelection) {
             continue;
         }


### PR DESCRIPTION
Fix for issue #1461: Warns user of duplicate selections for keybindings in profile editor, but still allows the assignment.