### PR TITLE
Fix for issue #1739 to prevent filtering of paths in asset directories

### DIFF
--- a/apps/OpenSpace/ext/launcher/include/filesystemaccess.h
+++ b/apps/OpenSpace/ext/launcher/include/filesystemaccess.h
@@ -34,6 +34,22 @@ public:
      *
      * \param fileExtension string that defines the filter used to find files. Only
      *                      files with this extension will be recognized (e.g. '.xml')
+     * \param hideFileExtensions if true then file extensions will be removed from the
+     *                           listed files in the output
+     * \param useCheckboxes if true then the text output format will contain a '0' as
+     *                      the first character in the line (this first character is
+     *                      used to represent checked ('1'), uncheck ('0') or doesn't
+     *                      exist in filesystem ('x') states.
+     */
+    FileSystemAccess(std::string fileExtension, bool hideFileExtensions,
+        bool useCheckboxes);
+
+    /**
+     * Constructor for filesystemAccess class which will find files that are only in the
+     * provided approved paths
+     *
+     * \param fileExtension string that defines the filter used to find files. Only
+     *                      files with this extension will be recognized (e.g. '.xml')
      * \param approvedPaths vector or strings containing directory names to be included
      *                      in the search. These are directories at the base level of
      *                      the starting point of the search. Any sub-directories within
@@ -67,6 +83,7 @@ private:
     QFileSystemModel _filesystemModel;
     QDir::Filters _fileFilterOptions = QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot;
     std::string _fileExtension;
+    bool _useOnlyApprovedPaths = false;
     std::vector<std::string> _approvedPaths;
     bool _hideFileExtensions = true;
     bool _useCheckboxes = false;

--- a/apps/OpenSpace/ext/launcher/include/filesystemaccess.h
+++ b/apps/OpenSpace/ext/launcher/include/filesystemaccess.h
@@ -45,32 +45,12 @@ public:
         bool useCheckboxes);
 
     /**
-     * Constructor for filesystemAccess class which will find files that are only in the
-     * provided approved paths
-     *
-     * \param fileExtension string that defines the filter used to find files. Only
-     *                      files with this extension will be recognized (e.g. '.xml')
-     * \param approvedPaths vector or strings containing directory names to be included
-     *                      in the search. These are directories at the base level of
-     *                      the starting point of the search. Any sub-directories within
-     *                      these directories will be included.
-     * \param hideFileExtensions if true then file extensions will be removed from the
-     *                           listed files in the output
-     * \param useCheckboxes if true then the text output format will contain a '0' as
-     *                      the first character in the line (this first character is
-     *                      used to represent checked ('1'), uncheck ('0') or doesn't
-     *                      exist in filesystem ('x') states.
-     */
-    FileSystemAccess(std::string fileExtension,
-        std::vector<std::string> approvedPaths, bool hideFileExtensions,
-        bool useCheckboxes);
-
-    /**
      * Function that uses the #QtFileSystemModel class to search the given directory
      *
      * \param dir The directory from which to start the search from
      */
-    std::string useQtFileSystemModelToTraverseDir(std::string dir, bool usersAssets = false);
+    std::string useQtFileSystemModelToTraverseDir(std::string dir,
+        bool usersAssets = false);
 
 private:
     void parseChildDirElements(QFileInfo item, std::string space, int level,
@@ -78,12 +58,10 @@ private:
         bool userAssets);
     void parseChildFile(std::string res, bool& hasDirHeaderBeenAdded,
         std::vector<std::string>& dirNames, std::vector<std::string>& output);
-    bool isApprovedPath(std::string path);
 
     QFileSystemModel _filesystemModel;
     QDir::Filters _fileFilterOptions = QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot;
     std::string _fileExtension;
-    bool _useOnlyApprovedPaths = false;
     std::vector<std::string> _approvedPaths;
     bool _hideFileExtensions = true;
     bool _useCheckboxes = false;

--- a/apps/OpenSpace/ext/launcher/src/filesystemaccess.cpp
+++ b/apps/OpenSpace/ext/launcher/src/filesystemaccess.cpp
@@ -25,10 +25,18 @@
 #include "filesystemaccess.h"
 
 FileSystemAccess::FileSystemAccess(std::string fileExtension,
-                                   std::vector<std::string> approvedPaths,
                                    bool hideFileExtensions, bool useCheckboxes)
     : _fileExtension(std::move(fileExtension))
+    , _hideFileExtensions(hideFileExtensions)
+    , _useCheckboxes(useCheckboxes)
+{}
+
+FileSystemAccess::FileSystemAccess(std::string fileExtension,
+    std::vector<std::string> approvedPaths,
+    bool hideFileExtensions, bool useCheckboxes)
+    : _fileExtension(std::move(fileExtension))
     , _approvedPaths(std::move(approvedPaths))
+    , _useOnlyApprovedPaths(true)
     , _hideFileExtensions(hideFileExtensions)
     , _useCheckboxes(useCheckboxes)
 {}
@@ -78,16 +86,19 @@ void FileSystemAccess::parseChildDirElements(QFileInfo fileInfo, std::string spa
 }
 
 bool FileSystemAccess::isApprovedPath(std::string path) {
-    bool approvedMatch = false;
     path.erase(0, path.find_first_not_of(" "));
 
-    for (const std::string& p : _approvedPaths) {
-        if (path.substr(0, p.length()).compare(p) == 0) {
-            approvedMatch = true;
-            break;
-        }
+    if (!_useOnlyApprovedPaths) {
+        return true;
     }
-    return approvedMatch;
+    else {
+        for (const std::string& p : _approvedPaths) {
+            if (path.substr(0, p.length()).compare(p) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 
 void FileSystemAccess::parseChildFile(std::string filename, bool& hasDirHeaderBeenAdded,

--- a/apps/OpenSpace/ext/launcher/src/filesystemaccess.cpp
+++ b/apps/OpenSpace/ext/launcher/src/filesystemaccess.cpp
@@ -31,17 +31,8 @@ FileSystemAccess::FileSystemAccess(std::string fileExtension,
     , _useCheckboxes(useCheckboxes)
 {}
 
-FileSystemAccess::FileSystemAccess(std::string fileExtension,
-    std::vector<std::string> approvedPaths,
-    bool hideFileExtensions, bool useCheckboxes)
-    : _fileExtension(std::move(fileExtension))
-    , _approvedPaths(std::move(approvedPaths))
-    , _useOnlyApprovedPaths(true)
-    , _hideFileExtensions(hideFileExtensions)
-    , _useCheckboxes(useCheckboxes)
-{}
-
-std::string FileSystemAccess::useQtFileSystemModelToTraverseDir(std::string dir, bool userAssets) {
+std::string FileSystemAccess::useQtFileSystemModelToTraverseDir(std::string dir,
+                                                                bool userAssets) {
     _filesystemModel.setRootPath(QString::fromStdString(dir));
     QModelIndex index = _filesystemModel.index(_filesystemModel.rootPath());
     QFileInfo fileInfo = _filesystemModel.fileInfo(index);
@@ -56,8 +47,10 @@ std::string FileSystemAccess::useQtFileSystemModelToTraverseDir(std::string dir,
 }
 
 void FileSystemAccess::parseChildDirElements(QFileInfo fileInfo, std::string space,
-                                         int level, std::vector<std::string>& dirNames,
-                                         std::vector<std::string>& output, bool userAssets)
+                                             int level,
+                                             std::vector<std::string>& dirNames,
+                                             std::vector<std::string>& output,
+                                             bool userAssets)
 {
     QDir dir(fileInfo.filePath());
     bool hasDirHeaderBeenAdded = false;
@@ -70,10 +63,8 @@ void FileSystemAccess::parseChildDirElements(QFileInfo fileInfo, std::string spa
             res = "${USER_ASSETS}/" + res;
         }
         if (fi.isDir()) {
-            if (level != 0 || (level == 0 && (isApprovedPath(res) || userAssets))) {
-                dirNames.push_back(res);
-                parseChildDirElements(fi, (space + " "), level + 1, dirNames, output, userAssets);
-            }
+            dirNames.push_back(res);
+            parseChildDirElements(fi, (space + " "), level + 1, dirNames, output, userAssets);
         }
         else {
             parseChildFile(res, hasDirHeaderBeenAdded, dirNames, output);
@@ -82,22 +73,6 @@ void FileSystemAccess::parseChildDirElements(QFileInfo fileInfo, std::string spa
     bool isThisDirAnEmptyDeadEnd = !hasDirHeaderBeenAdded;
     if (isThisDirAnEmptyDeadEnd && (dirNames.size() != 0)) {
         dirNames.pop_back();
-    }
-}
-
-bool FileSystemAccess::isApprovedPath(std::string path) {
-    path.erase(0, path.find_first_not_of(" "));
-
-    if (!_useOnlyApprovedPaths) {
-        return true;
-    }
-    else {
-        for (const std::string& p : _approvedPaths) {
-            if (path.substr(0, p.length()).compare(p) == 0) {
-                return true;
-            }
-        }
-        return false;
     }
 }
 

--- a/apps/OpenSpace/ext/launcher/src/profile/assettreemodel.cpp
+++ b/apps/OpenSpace/ext/launcher/src/profile/assettreemodel.cpp
@@ -149,9 +149,6 @@ void AssetTreeModel::importModelData(const std::string& assetBasePath,
     const std::string& userAssetBasePath) {
     FileSystemAccess assets(
         ".asset",
-        // @TODO (abock, 2021-03-24) We need some better solution for this;  what is the
-        // problem of just including all subfolders instead?
-        { "scene", "global", "customization", "dashboard", "examples", "util" },
         true,
         true
     );


### PR DESCRIPTION
This allows any .asset file contained in ${ASSETS} or ${USER_ASSETS} to be displayed in the asset selection GUI.
The previous version of filesystemaccess that accepts a list of approved paths is retained in an overloaded constructor for future use.