### PR TITLE
Fixes Problem with Profile Properties Not Handling Table Entries (Issue 1757)

### DIFF
--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -263,8 +263,7 @@ private:
      * \param L the lua state to push value to
      * \param value string representation of the value with which to set property
      */
-    void propertyPushValueFromProfileToLuaState(ghoul::lua::LuaState& L,
-        std::string& value);
+    void propertyPushProfileValueToLua(ghoul::lua::LuaState& L, std::string& value);
 
     /**
      * Accepts string version of a property value from a profile, and processes it
@@ -277,8 +276,7 @@ private:
      *        has already been pushed to the lua stack
      * \return The ProfilePropertyLua variant type translated from string representation
      */
-    ProfilePropertyLua propertyProcessValue(ghoul::lua::LuaState& L,
-        std::string& value, bool& didPushToLua);
+    ProfilePropertyLua propertyProcessValue(ghoul::lua::LuaState& L, std::string& value);
 
     /**
      * Accepts string version of a property value from a profile, and returns the
@@ -326,6 +324,7 @@ private:
     std::unique_ptr<SceneInitializer> _initializer;
     std::string _profilePropertyName;
     std::vector<InterestingTime> _interestingTimes;
+    bool _valueIsTable = false;
 
     std::mutex _programUpdateLock;
     std::set<ghoul::opengl::ProgramObject*> _programsToUpdate;

--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -33,6 +33,7 @@
 #include <ghoul/misc/easing.h>
 #include <ghoul/misc/exception.h>
 #include <ghoul/misc/memorypool.h>
+#include <functional>
 #include <mutex>
 #include <set>
 #include <unordered_map>
@@ -45,6 +46,14 @@ namespace openspace {
 
 namespace documentation { struct Documentation; }
 namespace scripting { struct LuaLibrary; }
+
+enum class PropertyValueType {
+    Boolean = 0,
+    Float,
+    String,
+    Table,
+    Nil
+};
 
 class SceneInitializer;
 
@@ -288,6 +297,40 @@ private:
  */
 void propertyPushValueFromProfileToLuaState(ghoul::lua::LuaState& L,
     const std::string& value);
+
+/**
+ * Accepts string version of a property value from a profile, and processes it
+ * according to the data type of the value
+ *
+ * \param L the lua state to (eventually) push to
+ * \param value string representation of the value with which to set property
+ * \param pushFn the std::function provided for pushing the result, which may be
+ *               a lambda that pushes to the lua state, or a lambda that pushes
+ *               to a vector (the vector will eventually be pushed to a lua table)
+ */
+void propertyProcessValue(ghoul::lua::LuaState& L, std::string& value,
+    std::function<void(auto v)>pushFn);
+
+/**
+ * Accepts string version of a property value from a profile, and returns the
+ * supported data types that can be pushed to a lua state. Currently, the full
+ * range of possible lua values is not supported.
+ *
+ * \param value string representation of the value with which to set property
+ */
+PropertyValueType getPropertyValueType(std::string& value);
+
+/**
+ * Accepts string version of a property value from a profile, and adds it to a vector
+ * which will later be used to push as a lua table containing values of type T
+ *
+ * \param L the lua state to (eventually) push to
+ * \param value string representation of the value with which to set property
+ * \param table the std::vector container which has elements of type T for a lua table
+ */
+template <typename T>
+void processPropertyValueTableEntries(ghoul::lua::LuaState& L, std::string& value,
+    std::vector<T>& table);
 
 } // namespace openspace
 

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -915,8 +915,14 @@ bool isBoolValue(const std::string& s) {
  */
 bool isFloatValue(const std::string& s) {
     try {
-        float converted = std::stof(s);
-        return true;
+        float converted = std::numeric_limits<float>::min();
+        converted = std::stof(s);
+        if (converted != std::numeric_limits<float>::min()) {
+            return true;
+        }
+        else {
+            return false;
+        }
     }
     catch (...) {
         return false;

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -923,4 +923,23 @@ bool isFloatValue(const std::string& s) {
     }
 }
 
+/**
+ * \ingroup LuaScripts
+ * isNilValue(const std::string& s):
+ * Used to check if a string is a lua 'nil' value. Returns false if not.
+ */
+bool isNilValue(const std::string& s) {
+    return (s == "nil");
+}
+
+/**
+ * \ingroup LuaScripts
+ * isTableValue(const std::string& s):
+ * Used to check if a string contains a lua table rather than an individual value.
+ * Returns false if not.
+ */
+bool isTableValue(const std::string& s) {
+    return ((s.front() == '{') && (s.back() == '}'));
+}
+
 }  // namespace openspace::luascriptfunctions


### PR DESCRIPTION
Fixes issue#1757 and allows a profile property to have a table value rather than just a single value. A table of numbers (floats) or strings is supported. Currently only one level of depth is supported (no table-within-a-table).