### PR TITLE
Fixes for resizing multiple windows. 

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -327,6 +327,9 @@ void mainPreSyncFunc() {
     ZoneScoped
     LTRACE("main::mainPreSyncFunc(begin)");
 
+    currentWindow = Engine::instance().windows().front().get();
+    currentViewport = currentWindow->viewports().front().get();
+
     try {
         global::openSpaceEngine->preSynchronization();
     }

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -572,6 +572,8 @@ void RenderEngine::updateRenderer() {
         _renderer.setResolution(renderingResolution());
 
         using FR = ghoul::fontrendering::FontRenderer;
+        //@TODO - micah 2022-03-09
+        //We could replace the defaultRenderer with SceneRenderer, DashboardRenderer
         FR::defaultRenderer().setFramebufferSize(fontResolution());
         FR::defaultProjectionRenderer().setFramebufferSize(renderingResolution());
         //Override the aspect ratio property value to match that of resized window
@@ -802,6 +804,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
 void RenderEngine::renderOverlays(const ShutdownInformation& shutdownInfo) {
     ZoneScoped
+    ghoul::fontrendering::FontRenderer::defaultRenderer().setFramebufferSize(global::renderEngine->fontResolution());
 
     const bool isMaster = global::windowDelegate->isMaster();
     if (isMaster || _showOverlayOnSlaves) {


### PR DESCRIPTION
This PR allows you to resize the gui and rendering windows independently. 

NOTE: In regards to the fonts, I don't think this is the ideal solution.

I think a more ideal solution would be to have separate font renderers for the 3D scene, and for the Dashboard. Going even further, we could allow multiple dashboards, and associate them with a specific viewport.