### PR TITLE
update cef and a few calls for it

### DIFF
--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -168,8 +168,6 @@ if (OS_MACOSX)
   ADD_LOGICAL_TARGET("cef_sandbox_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
   foreach(target IN LISTS Targets)
     # Helper executable target.
-        message(STATUS "set tar : ${target}")
-
     add_executable(${target} MACOSX_BUNDLE ${WEBBROWSER_HELPER_SOURCES})
     SET_EXECUTABLE_TARGET_PROPERTIES(${target})
     # add_cef_logical_target("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -56,7 +56,7 @@ cmake_policy(SET CMP0074 NEW)
 # Specify the CEF distribution version.
 
 # Release from 03/21/2022 verified to work on Windows.
-set(CEF_VERSION "99.2.12+g2977b3a+chromium-99.0.4844.74")
+set(CEF_VERSION "91.1.23+g04c8d56+chromium-91.0.4472.164")
 
 # Removing - micahnyc 03/21/2022
 # 73.1.13 has an issue on MacOS: The GUI freezing upon interaction.

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -55,14 +55,15 @@ cmake_policy(SET CMP0074 NEW)
 
 # Specify the CEF distribution version.
 
-# Release from 04/24/2019 verified to work on Windows.
-set(CEF_VERSION "73.1.13+g6e3c989+chromium-73.0.3683.75")
+# Release from 03/21/2022 verified to work on Windows.
+set(CEF_VERSION "99.2.12+g2977b3a+chromium-99.0.4844.74")
 
+# Removing - micahnyc 03/21/2022
 # 73.1.13 has an issue on MacOS: The GUI freezing upon interaction.
 # Therefore, we fall back to 3.3578.1867 from 01/29/2019
-if (APPLE)
-  set(CEF_VERSION "3.3578.1867.g0f6d65a")
-endif ()
+#if (APPLE)
+#  set(CEF_VERSION "3.3578.1867.g0f6d65a")
+#endif ()
 
 # CEF Sandbox is not working with the latest Visual Studio, so we disable it for now.
 if (WIN32)

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -129,7 +129,9 @@ set(WEBBROWSER_SOURCES ${WEBBROWSER_SOURCES} ${WEBBROWSER_RESOURCES_SOURCES})
 
 # CEF helper sources
 set(WEBBROWSER_HELPER_SOURCES src/webbrowserapp.cpp)
-set(WEBBROWSER_HELPER_SOURCES_MACOSX src/processhelpermac.cpp)
+if (OS_MACOSX)
+  list(APPEND WEBBROWSER_HELPER_SOURCES src/processhelpermac.cpp)
+endif()
 set(WEBBROWSER_HELPER_SOURCES_WINDOWS src/processhelperwindows.cpp)
 APPEND_PLATFORM_SOURCES(WEBBROWSER_HELPER_SOURCES)
 
@@ -152,30 +154,43 @@ set(WEBBROWSER_RESOURCES_SRCS
 # Place Helper in separate executable
 # The naming style "<ApplicionName> Helper" is required by Chromium.
 set(CEF_HELPER_TARGET "OpenSpace Helper" CACHE INTERNAL "CEF_HELPER_TARGET")
+set(CEF_HELPER_TARGET_GPU "OpenSpace Helper (GPU)" CACHE INTERNAL "CEF_HELPER_TARGET_GPU")
+set(CEF_HELPER_TARGET_RENDERER "OpenSpace Helper (Renderer)" CACHE INTERNAL "CEF_HELPER_TARGET_RENDERER")
 
 #
 # CEF platform-specific config
 #
 
+list(APPEND Targets ${CEF_HELPER_TARGET} ${CEF_HELPER_TARGET_GPU} ${CEF_HELPER_TARGET_RENDERER})
+
+
 if (OS_MACOSX)
-  # Helper executable target.
-  add_executable(${CEF_HELPER_TARGET} MACOSX_BUNDLE ${WEBBROWSER_HELPER_SOURCES})
-  SET_EXECUTABLE_TARGET_PROPERTIES(${CEF_HELPER_TARGET})
-  # add_cef_logical_target("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
-  add_dependencies(${CEF_HELPER_TARGET} libcef_dll_wrapper)
-  target_link_libraries(${CEF_HELPER_TARGET} libcef_dll_wrapper ${CEF_STANDARD_LIBS})
-  set_target_properties(${CEF_HELPER_TARGET} PROPERTIES
-    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/mac/helper-Info.plist
-  )
+  ADD_LOGICAL_TARGET("cef_sandbox_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
+  foreach(target IN LISTS Targets)
+    # Helper executable target.
+        message(STATUS "set tar : ${target}")
 
-  target_compile_options(${CEF_HELPER_TARGET} PRIVATE -Wno-deprecated-declarations)
-  target_compile_options(libcef_dll_wrapper PRIVATE -Wno-deprecated-declarations)
+    add_executable(${target} MACOSX_BUNDLE ${WEBBROWSER_HELPER_SOURCES})
+    SET_EXECUTABLE_TARGET_PROPERTIES(${target})
+    # add_cef_logical_target("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
+    add_dependencies(${target} libcef_dll_wrapper)
+    target_link_libraries(${target} libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+    set_target_properties(${target} PROPERTIES
+      MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/mac/helper-Info.plist
+    )
 
-  if (USE_SANDBOX)
-    # Logical target used to link the cef_sandbox library.
-    ADD_LOGICAL_TARGET("cef_sandbox_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
-    target_link_libraries(${CEF_HELPER_TARGET} cef_sandbox_lib)
-  endif ()
+    target_compile_options(${target} PRIVATE -Wno-deprecated-declarations)
+    target_compile_options(libcef_dll_wrapper PRIVATE -Wno-deprecated-declarations)
+
+    if (USE_SANDBOX)
+      # Logical target used to link the cef_sandbox library.
+      target_link_libraries(${target} cef_sandbox_lib)
+    endif ()
+  endforeach()
+
+set_property(TARGET ${CEF_HELPER_TARGET_GPU} PROPERTY FOLDER "Helper")
+set_property(TARGET ${CEF_HELPER_TARGET_RENDERER} PROPERTY FOLDER "Helper")
+
 endif ()
 
 if (OS_WINDOWS)

--- a/modules/webbrowser/cmake/patch/cmake/cef_variables.cmake
+++ b/modules/webbrowser/cmake/patch/cmake/cef_variables.cmake
@@ -100,7 +100,7 @@ if(OS_LINUX)
     -fno-rtti                       # Disable real-time type information
     -fno-threadsafe-statics         # Don't generate thread-safe statics
     -fvisibility-inlines-hidden     # Give hidden visibility to inlined class member functions
-    -std=gnu++11                    # Use the C++11 language standard including GNU extensions
+    -std=gnu++14                    # Use the C++14 language standard including GNU extensions
     -Wsign-compare                  # Warn about mixed signed/unsigned type comparisons
     )
   list(APPEND CEF_COMPILER_FLAGS_DEBUG
@@ -259,7 +259,7 @@ if(OS_MACOSX)
     -fno-threadsafe-statics         # Don't generate thread-safe statics
     -fobjc-call-cxx-cdtors          # Call the constructor/destructor of C++ instance variables in ObjC objects
     -fvisibility-inlines-hidden     # Give hidden visibility to inlined class member functions
-    -std=gnu++11                    # Use the C++11 language standard including GNU extensions
+    -std=gnu++14                    # Use the C++14 language standard including GNU extensions
     -Wno-narrowing                  # Don't warn about type narrowing
     -Wsign-compare                  # Warn about mixed signed/unsigned type comparisons
     )

--- a/modules/webbrowser/cmake/patch/cmake/cef_variables.cmake
+++ b/modules/webbrowser/cmake/patch/cmake/cef_variables.cmake
@@ -456,12 +456,10 @@ if(OS_WINDOWS)
   # List of CEF binary files.
   set(CEF_BINARY_FILES
     chrome_elf.dll
-    d3dcompiler_43.dll
     d3dcompiler_47.dll
     libcef.dll
     libEGL.dll
     libGLESv2.dll
-    natives_blob.bin
     snapshot_blob.bin
     v8_context_snapshot.bin
     #swiftshader
@@ -469,11 +467,9 @@ if(OS_WINDOWS)
 
   # List of CEF resource files.
   set(CEF_RESOURCE_FILES
-    cef.pak
-    cef_100_percent.pak
-    cef_200_percent.pak
-    cef_extensions.pak
-    devtools_resources.pak
+    chrome_100_percent.pak
+    chrome_200_percent.pak
+    resources.pak
     icudtl.dat
     locales
     )

--- a/modules/webbrowser/cmake/webbrowser_helpers.cmake
+++ b/modules/webbrowser/cmake/webbrowser_helpers.cmake
@@ -69,12 +69,16 @@ function(run_cef_macosx_config CEF_ROOT module_path)
 
   set(CEF_FINAL_APP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CEF_OUTPUT_PREFIX}${CEF_TARGET}.app")
   set(CEF_INTERMEDIATE_HELPER_APP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CEF_OUTPUT_PREFIX}${CEF_HELPER_TARGET}.app")
+  set(CEF_INTERMEDIATE_HELPER_APP_GPU "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CEF_OUTPUT_PREFIX}${CEF_HELPER_TARGET_GPU}.app")
+  set(CEF_INTERMEDIATE_HELPER_APP_RENDERER "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CEF_OUTPUT_PREFIX}${CEF_HELPER_TARGET_RENDERER}.app")
 
   set(CEF_FINAL_HELPER_APP "${CEF_FINAL_APP}/Contents/Frameworks/${CEF_HELPER_TARGET}.app")
+  set(CEF_FINAL_HELPER_APP_GPU "${CEF_FINAL_APP}/Contents/Frameworks/${CEF_HELPER_TARGET_GPU}.app")
+  set(CEF_FINAL_HELPER_APP_RENDERER "${CEF_FINAL_APP}/Contents/Frameworks/${CEF_HELPER_TARGET_RENDERER}.app")
   set(CEF_FRAMEWORK_LOCATION "${CEF_BINARY_DIR}/Chromium Embedded Framework.framework")
   set(CEF_FRAMEWORK_FINAL_LOCATION "${CEF_FINAL_APP}/Contents/Frameworks/Chromium Embedded Framework.framework")
 
-  add_dependencies(${CEF_TARGET} libcef_dll_wrapper "${CEF_HELPER_TARGET}")
+  add_dependencies(${CEF_TARGET} libcef_dll_wrapper "${CEF_HELPER_TARGET}" "${CEF_HELPER_TARGET_GPU}" "${CEF_HELPER_TARGET_RENDERER}")
 
   # target_link_libraries(${CEF_TARGET} PUBLIC libcef_lib libcef_dll_wrapper ${CEF_STANDARD_LIBS})
   target_link_libraries(${CEF_TARGET} PUBLIC libcef_dll_wrapper ${CEF_STANDARD_LIBS})
@@ -89,6 +93,8 @@ function(run_cef_macosx_config CEF_ROOT module_path)
     POST_BUILD
     # Copy the helper app bundle into the Frameworks directory.
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CEF_INTERMEDIATE_HELPER_APP}" "${CEF_FINAL_HELPER_APP}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CEF_INTERMEDIATE_HELPER_APP_GPU}" "${CEF_FINAL_HELPER_APP_GPU}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CEF_INTERMEDIATE_HELPER_APP_RENDERER}" "${CEF_FINAL_HELPER_APP_RENDERER}"
     # Copy the CEF framework into the Frameworks directory.
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CEF_FRAMEWORK_LOCATION}" "${CEF_FRAMEWORK_FINAL_LOCATION}"
     VERBATIM

--- a/modules/webbrowser/include/defaultbrowserlauncher.h
+++ b/modules/webbrowser/include/defaultbrowserlauncher.h
@@ -41,11 +41,17 @@ namespace openspace {
 
 class DefaultBrowserLauncher : public CefLifeSpanHandler, public CefRequestHandler {
 public:
-    bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
-        const CefString& targetUrl, const CefString& targetFrameName,
-        CefLifeSpanHandler::WindowOpenDisposition targetDisposition, bool userGesture,
-        const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo,
-        CefRefPtr<CefClient>& client, CefBrowserSettings& settings,
+    bool OnBeforePopup(CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefFrame> frame,
+        const CefString& targetUrl,
+        const CefString& targetFrameName,
+        CefLifeSpanHandler::WindowOpenDisposition targetDisposition,
+        bool userGesture,
+        const CefPopupFeatures& popupFeatures,
+        CefWindowInfo& windowInfo,
+        CefRefPtr<CefClient>& client,
+        CefBrowserSettings& settings,
+        CefRefPtr<CefDictionaryValue>& extra_info,
         bool* noJavascriptAccess) override;
 
     //bool OnOpenURLFromTab(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,

--- a/modules/webbrowser/src/browserinstance.cpp
+++ b/modules/webbrowser/src/browserinstance.cpp
@@ -48,7 +48,7 @@ BrowserInstance::BrowserInstance(WebRenderHandler* renderer,
     : _renderHandler(renderer)
     , _keyboardHandler(keyboardHandler)
 {
-    _client = new BrowserClient(_renderHandler, _keyboardHandler);
+    _client = new BrowserClient(renderer, keyboardHandler);
 
     CefWindowInfo windowInfo;
     windowInfo.SetAsWindowless(nullptr);
@@ -62,6 +62,7 @@ BrowserInstance::BrowserInstance(WebRenderHandler* renderer,
         _client.get(),
         url,
         browserSettings,
+        nullptr,
         nullptr
     );
 

--- a/modules/webbrowser/src/browserinstance.cpp
+++ b/modules/webbrowser/src/browserinstance.cpp
@@ -48,7 +48,7 @@ BrowserInstance::BrowserInstance(WebRenderHandler* renderer,
     : _renderHandler(renderer)
     , _keyboardHandler(keyboardHandler)
 {
-    _client = new BrowserClient(renderer, keyboardHandler);
+    _client = new BrowserClient(_renderHandler.get(), _keyboardHandler.get());
 
     CefWindowInfo windowInfo;
     windowInfo.SetAsWindowless(nullptr);

--- a/modules/webbrowser/src/defaultbrowserlauncher.cpp
+++ b/modules/webbrowser/src/defaultbrowserlauncher.cpp
@@ -38,6 +38,7 @@ bool DefaultBrowserLauncher::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefF
                                            CefLifeSpanHandler::WindowOpenDisposition,
                                            bool, const CefPopupFeatures&, CefWindowInfo&,
                                            CefRefPtr<CefClient>&, CefBrowserSettings&,
+                                           CefRefPtr<CefDictionaryValue>&,
                                            bool*)
 {
     // never permit CEF popups, always launch in default browser

--- a/modules/webbrowser/src/screenspacebrowser.cpp
+++ b/modules/webbrowser/src/screenspacebrowser.cpp
@@ -92,12 +92,10 @@ ScreenSpaceBrowser::ScreenSpaceBrowser(const ghoul::Dictionary& dictionary)
     _dimensions = windowDimensions;
 
     _renderHandler = new ScreenSpaceRenderHandler;
-    WebRenderHandler* renderer = (WebRenderHandler*)(&_renderHandler);
-    WebKeyboardHandler* keyboardHandler = new WebKeyboardHandler();
-    _keyboardHandler = keyboardHandler;
+    _keyboardHandler = new WebKeyboardHandler();
     _browserInstance = std::make_unique<BrowserInstance>(
-        renderer,
-        keyboardHandler
+        _renderHandler.get(),
+        _keyboardHandler.get()
     );
 
     _url.onChange([this]() { _isUrlDirty = true; });

--- a/modules/webbrowser/src/screenspacebrowser.cpp
+++ b/modules/webbrowser/src/screenspacebrowser.cpp
@@ -92,10 +92,12 @@ ScreenSpaceBrowser::ScreenSpaceBrowser(const ghoul::Dictionary& dictionary)
     _dimensions = windowDimensions;
 
     _renderHandler = new ScreenSpaceRenderHandler;
-    _keyboardHandler = new WebKeyboardHandler();
+    WebRenderHandler* renderer = (WebRenderHandler*)(&_renderHandler);
+    WebKeyboardHandler* keyboardHandler = new WebKeyboardHandler();
+    _keyboardHandler = keyboardHandler;
     _browserInstance = std::make_unique<BrowserInstance>(
-        _renderHandler,
-        _keyboardHandler
+        renderer,
+        keyboardHandler
     );
 
     _url.onChange([this]() { _isUrlDirty = true; });

--- a/modules/webbrowser/src/webbrowserapp.cpp
+++ b/modules/webbrowser/src/webbrowserapp.cpp
@@ -42,8 +42,10 @@ void WebBrowserApp::OnContextCreated(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
 void WebBrowserApp::OnBeforeCommandLineProcessing(const CefString&,
                                                   CefRefPtr<CefCommandLine> commandLine)
 {
-    commandLine->AppendSwitch("disable-gpu");
-    commandLine->AppendSwitch("disable-gpu-compositing");
+    commandLine->AppendSwitch("use-gl=desktop");
+    commandLine->AppendSwitch("ignore-gpu-blacklist");
+    commandLine->AppendSwitch("log-gpu-control-list-decisions");
+
     commandLine->AppendSwitch("enable-begin-frame-scheduling");
     commandLine->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
 }

--- a/modules/webbrowser/src/webbrowserapp.cpp
+++ b/modules/webbrowser/src/webbrowserapp.cpp
@@ -45,7 +45,7 @@ void WebBrowserApp::OnBeforeCommandLineProcessing(const CefString&,
     commandLine->AppendSwitch("use-gl=desktop");
     commandLine->AppendSwitch("ignore-gpu-blacklist");
     commandLine->AppendSwitch("log-gpu-control-list-decisions");
-
+    commandLine->AppendSwitch("use-mock-keychain");
     commandLine->AppendSwitch("enable-begin-frame-scheduling");
     commandLine->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
 }


### PR DESCRIPTION
There is an issue with the text fields in our gui after this update which needs to be addressed in the -WebGuiFrontend


When using the search fields, sometimes keyevents are sent through to openspace. When using a non search field (such as naming session recording, key events are never sent to openspace. 

In addition, if you check a box or use a slider, then use a search field, then the keyevents are not sent to openspace. 


I'm guessing there is a special behavior on how we have addressed the search fields in react which needs to be updated. 