### PR TITLE
Issue/1908 - Add enabled property to Exoplanets and Skybrowser

### DIFF
--- a/data/assets/base.asset
+++ b/data/assets/base.asset
@@ -4,6 +4,9 @@
 
 asset.require("./base_blank")
 
+-- Optional components
+asset.require("components/exoplanets/exoplanets")
+
 -- Specifying which other assets should be loaded in this scene
 asset.require("scene/solarsystem/sun/sun")
 asset.require("scene/solarsystem/sun/glare")
@@ -19,10 +22,6 @@ asset.require("scene/milkyway/constellations/constellation_art")
 asset.require("scene/milkyway/constellations/constellation_keybinds")
 asset.require("scene/milkyway/objects/orionnebula/orionnebula")
 asset.require("util/launcher_images")
-
--- For exoplanet system visualizations
-asset.require("scene/milkyway/exoplanets/exoplanets_data")
-asset.require("scene/milkyway/exoplanets/exoplanets_textures")
 
 asset.require("scene/digitaluniverse/2dF")
 asset.require("scene/digitaluniverse/2mass")

--- a/data/assets/components/exoplanets/default_settings.asset
+++ b/data/assets/components/exoplanets/default_settings.asset
@@ -1,0 +1,24 @@
+asset.onInitialize(function () 
+  local settings = {
+    Enabled = true,
+    ShowComparisonCircle = false,
+    ShowHabitableZone = true,
+    UseOptimisticZone = true,
+    HabitableZoneOpacity = 0.1
+  }
+
+  for propKey, value in pairs(settings) do 
+    -- TODO: how to not override potential settings in cfg?
+    local p = "Modules.Exoplanets." .. propKey;
+    openspace.setPropertyValueSingle(p, value)
+  end
+end)
+
+asset.meta = {
+  Name = "Exolanet Default Settings",
+  Version = "1.0",
+  Description = [[ Some default settings related to the exoplanet module ]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/components/exoplanets/exoplanets.asset
+++ b/data/assets/components/exoplanets/exoplanets.asset
@@ -1,0 +1,3 @@
+asset.require("./default_settings")
+asset.require("./exoplanets_data")
+asset.require("./exoplanets_textures")

--- a/data/assets/components/exoplanets/exoplanets_data.asset
+++ b/data/assets/components/exoplanets/exoplanets_data.asset
@@ -13,6 +13,8 @@ local colormaps = asset.syncedResource({
 })
 
 asset.onInitialize(function () 
+  -- Set the default data files used for the exoplanet system creation
+  -- (Check if already set, to not override value set in another file)
   local p = "Modules.Exoplanets.DataFolder";
   if (openspace.getPropertyValue(p) == "") then
     openspace.setPropertyValueSingle(p, DataPath)

--- a/data/assets/components/exoplanets/exoplanets_textures.asset
+++ b/data/assets/components/exoplanets/exoplanets_textures.asset
@@ -1,5 +1,6 @@
-local habitableZoneTextures =
-    asset.require("../habitable_zones/habitable_zone_textures").TexturesPath
+local habitableZoneTextures = asset.require(
+  "scene/milkyway/habitable_zones/habitable_zone_textures"
+).TexturesPath
 
 local sunTextures = asset.syncedResource({
   Type = "HttpSynchronization",
@@ -25,7 +26,7 @@ asset.onInitialize(function ()
   local hzTexture = habitableZoneTextures .. "hot_to_cold_faded.png"
 
   -- Set the default textures used for the exoplanet system creation
-  -- (Check if already set, to not override value in config file)
+  -- (Check if already set, to not override value set in another file)
   local p = "Modules.Exoplanets.StarTexture";
   if (openspace.getPropertyValue(p) == "") then
     openspace.setPropertyValueSingle(p, starTexture)

--- a/modules/exoplanets/exoplanetsmodule.cpp
+++ b/modules/exoplanets/exoplanetsmodule.cpp
@@ -51,6 +51,12 @@
 #include "exoplanetsmodule_lua.inl"
 
 namespace {
+    constexpr const openspace::properties::Property::PropertyInfo EnabledInfo = {
+        "Enabled",
+        "Enabled",
+        "Decides if the GUI for this module should be enabled."
+    };
+
     constexpr const openspace::properties::Property::PropertyInfo DataFolderInfo = {
         "DataFolder",
         "Data Folder",
@@ -139,6 +145,9 @@ namespace {
     constexpr const char LookupTableFileName[] = "lookup.txt";
 
     struct [[codegen::Dictionary(ExoplanetsModule)]] Parameters {
+        // [[codegen::verbatim(EnabledInfo.description)]]
+        std::optional<bool> enabled;
+
         // [[codegen::verbatim(DataFolderInfo.description)]]
         std::optional<std::filesystem::path> dataFolder [[codegen::directory()]];
 
@@ -181,6 +190,7 @@ using namespace exoplanets;
 
 ExoplanetsModule::ExoplanetsModule()
     : OpenSpaceModule(Name)
+    , _enabled(EnabledInfo)
     , _exoplanetsDataFolder(DataFolderInfo)
     , _bvColorMapPath(BvColorMapInfo)
     , _starTexturePath(StarTextureInfo)
@@ -191,9 +201,11 @@ ExoplanetsModule::ExoplanetsModule()
     , _showComparisonCircle(ShowComparisonCircleInfo, false)
     , _showHabitableZone(ShowHabitableZoneInfo, true)
     , _useOptimisticZone(UseOptimisticZoneInfo, true)
-    , _habitableZoneOpacity(HabitableZoneOpacityInfo, 0.1f, 0.0f, 1.0f)
+    , _habitableZoneOpacity(HabitableZoneOpacityInfo, 0.1f, 0.f, 1.f)
 {
     _exoplanetsDataFolder.setReadOnly(true);
+
+    addProperty(_enabled);
 
     addProperty(_exoplanetsDataFolder);
     addProperty(_bvColorMapPath);
@@ -224,7 +236,7 @@ std::string ExoplanetsModule::exoplanetsDataPath() const {
 
 std::string ExoplanetsModule::lookUpTablePath() const {
     ghoul_assert(hasDataFiles(), "Data files not loaded");
-    
+
     return absPath(
         fmt::format("{}/{}", _exoplanetsDataFolder.value(), LookupTableFileName)
     ).string();
@@ -272,6 +284,8 @@ float ExoplanetsModule::habitableZoneOpacity() const {
 
 void ExoplanetsModule::internalInitialize(const ghoul::Dictionary& dict) {
     const Parameters p = codegen::bake<Parameters>(dict);
+
+    _enabled = p.enabled.value_or(true);
 
     if (p.dataFolder.has_value()) {
         _exoplanetsDataFolder = p.dataFolder.value().string();

--- a/modules/exoplanets/exoplanetsmodule.h
+++ b/modules/exoplanets/exoplanetsmodule.h
@@ -74,6 +74,8 @@ protected:
     properties::BoolProperty _useOptimisticZone;
 
     properties::FloatProperty _habitableZoneOpacity;
+
+    properties::BoolProperty _enabled;
 };
 
 } // namespace openspace

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -186,12 +186,6 @@ ModuleConfigurations = {
     },
     Space = {
         ShowExceptions = false
-    },
-    Exoplanets = {
-        ShowComparisonCircle = false,
-        ShowHabitableZone = true,
-        UseOptimisticZone = true,
-        HabitableZoneOpacity = 0.1
     }
 }
 


### PR DESCRIPTION
Add property to disable exoplanets module and set from asset instead of config file

TODO: 
- Do the same thing for skybrowser module, once it's merged
- Update exoplanets data and version of exoplanets_data.asset

Related GUI PR: https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/80 