### PR TITLE
FixedRotation that depends on other nodes now updates correctly even if time is paused

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -41,36 +41,36 @@ local initializeAndAddNodes = function()
     },
     Tag = { "earth_satellite", "ISS" },
     GUI = {
-        Path = "/Solar System/Planets/Earth/Satellites/ISS"
+      Path = "/Solar System/Planets/Earth/Satellites/ISS"
     }
   }
 
   local parentNode = {
-     Identifier = "ISSModel",
-      Parent = iss.Identifier,
-      Transform = {
-        Rotation = {
-          Type = "FixedRotation",
-          Attached = "ISSModel",
-          XAxis = { 0.01, -1.0, 0.56 },
-          XAxisOrthogonal = true,
-          YAxis = transforms.EarthInertial.Identifier
-        }
-      },
-      Renderable = {
-        Type = "RenderableModel",
-        GeometryFile = models .. "ISS.fbx",
-        ModelScale = "Centimeter",
-        LightSources = {
-          sun.LightSource
-        },
-        PerformShading = true,
-        DisableFaceCulling = true
-      },
-      GUI = {
-        Name = "ISS Model",
-        Path = "/Solar System/Planets/Earth/Satellites/ISS"
+    Identifier = "ISSModel",
+    Parent = iss.Identifier,
+    Transform = {
+      Rotation = {
+        Type = "FixedRotation",
+        Attached = "ISSModel",
+        XAxis = { 0.01, -1.0, 0.56 },
+        XAxisOrthogonal = true,
+        YAxis = transforms.EarthInertial.Identifier
       }
+    },
+    Renderable = {
+      Type = "RenderableModel",
+      GeometryFile = models .. "ISS.fbx",
+      ModelScale = "Centimeter",
+      LightSources = {
+        sun.LightSource
+      },
+      PerformShading = true,
+      DisableFaceCulling = true
+    },
+    GUI = {
+      Name = "ISS Model",
+      Path = "/Solar System/Planets/Earth/Satellites/ISS"
+    }
   }
 
   local issTrail = {

--- a/modules/base/rotation/fixedrotation.cpp
+++ b/modules/base/rotation/fixedrotation.cpp
@@ -485,6 +485,20 @@ bool FixedRotation::initialize() {
     return res;
 }
 
+void FixedRotation::update(const UpdateData& data) {
+    bool anyAxisIsObjectType = (
+        _xAxis.type == Axis::Type::Object ||
+        _yAxis.type == Axis::Type::Object ||
+        _zAxis.type == Axis::Type::Object
+    );
+
+    if (_attachedNode || anyAxisIsObjectType) {
+        requireUpdate();
+    }
+
+    Rotation::update(data);
+}
+
 glm::dmat3 FixedRotation::matrix(const UpdateData&) const {
     if (!_enabled) {
         return glm::dmat3();

--- a/modules/base/rotation/fixedrotation.h
+++ b/modules/base/rotation/fixedrotation.h
@@ -47,6 +47,7 @@ public:
 
     static documentation::Documentation Documentation();
 
+    void update(const UpdateData& data) override;
     glm::dmat3 matrix(const UpdateData& data) const override;
 
 private:


### PR DESCRIPTION
This fixes the symptom of issue #1751, and also covers some edge cases when a node transformation might update even if the simulation time is not running. 

However, I suspect that this issue might return as the underlying cause seems to have been that the check against the cached time in the general `Rotation::update` function does not trigger correctly if time is paused: https://github.com/OpenSpace/OpenSpace/blob/0c042369934f34b55c34003673e5969698574675/src/scene/rotation.cpp#L82
(Wondering if the `UpdateData` might not be correctly updated, for some reason, when the time is paused 🤔 Anyhow, that might need more investigation). Open to ideas!