### PR TITLE
a new profile for the 2012 solar storm event, with looping hotkeys

### DIFF
--- a/data/assets/scene/solarsystem/heliosphere/2012/reset_loop_action.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/reset_loop_action.asset
@@ -1,0 +1,18 @@
+local resetLoopAction = {
+    Documentation = "Reset button. Sets time to start of dataset. No loop",
+    GuiPath = "2012July",
+    Identifier = "2012july.reset_loop",
+    IsLocal = false,
+    Name = "Reset button",
+    Command = "openspace.time.setTime('2012-JUL-01 07:00:00.00');\nopenspace.time.setDeltaTime(1400);\nopenspace.scriptScheduler.clear();"
+}
+
+asset.export(resetLoopAction)
+
+asset.onInitialize(function ()
+    openspace.action.registerAction(resetLoopAction)
+end)
+
+asset.onDeinitialize(function ()
+    openspace.asction.removeAction(resetLoopAction)
+end)

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
@@ -35,10 +35,14 @@ local colorRanges = {
   { 150, 900 },
   { 0, 3 },
 }
+
+local interactionSphere = 6380000  -- A value slightly bigger than earth radius
+
 ----------------------LUTZ's JULY TRACES-------------------------
 local BatsrusJ12OpenClosed = {
   Identifier = "FL_BATSRUS_J12_OpenClosed",
   Parent = transforms.GSMReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.openClosed,
@@ -69,6 +73,7 @@ local BatsrusJ12OpenClosed = {
 local BatsrusJ12FlowLines = {
   Identifier = "FL_BATSRUS_J12_FlowLines",
   Parent = transforms.GSMReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.velocityFlow,
@@ -96,6 +101,7 @@ local BatsrusJ12FlowLines = {
 local BatsrusAsherStaticSeedsFlowLines = {
   Identifier = "FL_BATSRUS_ASHER_STATIC_SSEDS_FlowLines",
   Parent = transforms.GSMReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.asherStatic,

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
@@ -70,8 +70,7 @@ local BatsrusJ12OpenClosed = {
     ColorTableRanges = colorRanges,
     MaskingEnabled = true,
     MaskingQuantity = 4, -- Topology
-    MaskingRanges = { {2.5, 3.0} }, -- Corresponds to closed fieldlines only
-    LoadAtRuntime = false
+    MaskingRanges = { {2.5, 3.0} } -- Corresponds to closed fieldlines only
   },
   GUI = {
     Name = "Fieldlines BATSRUS J12 Open/Closed",

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
@@ -71,7 +71,7 @@ local BatsrusJ12OpenClosed = {
     MaskingEnabled = true,
     MaskingQuantity = 4, -- Topology
     MaskingRanges = { {2.5, 3.0} }, -- Corresponds to closed fieldlines only
-    LoadAtRuntime = true
+    LoadAtRuntime = false
   },
   GUI = {
     Name = "Fieldlines BATSRUS J12 Open/Closed",

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_batsrus.asset
@@ -1,4 +1,5 @@
 local transforms = asset.require('scene/solarsystem/planets/earth/magnetosphere/transforms_magnetosphere.asset')
+asset.require('scene/solarsystem/heliosphere/2012/reset_loop_action.asset')
 
 -- Specifying transfer functions
 local transferFunctions = asset.syncedResource({
@@ -15,6 +16,15 @@ local fieldlineData = asset.syncedResource({
   Identifier = "sun_earth_event_july_2012-batsrus",
   Version = 1
 })
+
+local loop = {
+  Documentation = "Sets time to start of data, sets higher delta time and loops back from start, when at end of data.",
+  GuiPath = "2012July",
+  Identifier = "2012july.loop_batsrus",
+  IsLocal = false,
+  Name = "Loop BATSRUS",
+  Command = "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(1400);\nopenspace.time.setTime('2012-JUL-14 06:00:00.00');\nlocal StarttimescriptBatsrusLoop = \"openspace.time.setTime('2012 JUL 14 06:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 JUL 16 07:30:00', StarttimescriptBatsrusLoop);"
+}
 
 local batsrusTemperatureColorTable = transferFunctions .. "batsrus_temperature.txt"
 local batsrusDensityColorTable = transferFunctions .. "batsrus_density.txt"
@@ -124,6 +134,8 @@ local BatsrusAsherStaticSeedsFlowLines = {
 }
 
 asset.onInitialize(function ()
+  openspace.action.registerAction(loop)
+
   if not openspace.directoryExists(unzippedDataDestination.openClosed) then
     openspace.printInfo("Extracting " .. "Fieldlines from Batsrus model of 2012 event")
     openspace.unzipFile(fieldlineData .. "magnetic_fieldlines-open_closed.zip", unzippedDataDestination.openClosed, true)
@@ -147,6 +159,8 @@ asset.onDeinitialize(function ()
   openspace.removeSceneGraphNode(BatsrusAsherStaticSeedsFlowLines)
   openspace.removeSceneGraphNode(BatsrusJ12FlowLines)
   openspace.removeSceneGraphNode(BatsrusJ12OpenClosed)
+
+  openspace.action.removeAction(loop)
 end)
 
 asset.meta = {

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_enlil.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_enlil.asset
@@ -31,9 +31,13 @@ local colorRanges = {
   { 100, 2000 }
 }
 
+local interactionSphere = 695700000
+
+
 local ENLILSliceEqPlane11AU1 = {
   Identifier = "FL_ENLIL_slice_eqPlane_011AU_1",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.EqPlane011AU1,
@@ -58,6 +62,7 @@ local ENLILSliceEqPlane11AU1 = {
 local ENLILSliceEqPlane11AU2 = {
   Identifier = "FL_ENLIL_slice_eqPlane_011AU_2",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.EqPlane011AU2,
@@ -82,6 +87,7 @@ local ENLILSliceEqPlane11AU2 = {
 local ENLILSliceLat411AU1 = {
   Identifier = "FL_ENLIL_slice_lat4_011AU_1",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.Lat4011AU1,
@@ -106,6 +112,7 @@ local ENLILSliceLat411AU1 = {
 local ENLILSliceLat411AU2 = {
   Identifier = "FL_ENLIL_slice_lat4_011AU_2",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.Lat4011AU2,
@@ -130,6 +137,7 @@ local ENLILSliceLat411AU2 = {
 local ENLILEarth = {
   Identifier = "FL_ENLIL_earth",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.Earth,
@@ -151,6 +159,7 @@ local ENLILEarth = {
 local ENLILStereoA = {
   Identifier = "FL_ENLIL_stereoa",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = interactionSphere,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = unzippedDataDestination.StereoA,

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_enlil.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_enlil.asset
@@ -184,8 +184,7 @@ local ENLILStereoA = {
     ReversedFlow = true,
     ParticleSize = 5,
     ParticleSpacing = 25,
-    FlowSpeed = 25,
-    LoadAtRuntime = true
+    FlowSpeed = 25
   },
   GUI = {
     Name = "Fieldlines ENLIL STEREO A",

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_enlil.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_enlil.asset
@@ -1,4 +1,5 @@
 local transforms = asset.require('scene/solarsystem/sun/transforms_heliosphere.asset')
+asset.require('scene/solarsystem/heliosphere/2012/reset_loop_action.asset')
 
 local transferFunctions = asset.syncedResource({
   Name = "Fieldlines Transfer Functions",
@@ -13,6 +14,15 @@ local fieldlineData  = asset.syncedResource({
   Identifier = "sun_earth_event_july_2012-enlil",
   Version = 1
 })
+
+local loop = {
+  Documentation = "Sets time to start of data, sets high delta time and loops back from start when at end of data",
+  GuiPath = "2012July",
+  Identifier = "2012july.loop_enlil",
+  IsLocal = false,
+  Name = "Loop ENLIL",
+  Command = "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(43200);\nopenspace.time.setTime('2012-JUL-01 07:00:00.00');\nlocal StarttimescriptENLILLoop = \"openspace.time.setTime('2012 JUL 01 07:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 AUG 01 06:58:00', StarttimescriptENLILLoop);"
+}
 
 local enlilDensityColorTable = transferFunctions .. "enlil_density.txt"
 local enlilVelocityColorTable = transferFunctions .. "kroyw.txt"
@@ -184,6 +194,8 @@ local ENLILStereoA = {
 }
 
 asset.onInitialize(function ()
+  openspace.action.registerAction(loop)
+
   if not openspace.directoryExists(unzippedDataDestination.EqPlane011AU1) then
     openspace.printInfo("Extracting " .. "Fieldlines from ENLIL model of 2012 event")
     openspace.unzipFile(fieldlineData .. "011AU_eq_plane_1.zip", unzippedDataDestination.EqPlane011AU1, true)
@@ -225,6 +237,8 @@ asset.onDeinitialize(function ()
   openspace.removeSceneGraphNode(ENLILSliceLat411AU1)
   openspace.removeSceneGraphNode(ENLILSliceEqPlane11AU2)
   openspace.removeSceneGraphNode(ENLILSliceEqPlane11AU1)
+
+  openspace.action.removeAction(loop)
 end)
 
 asset.meta = {

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
@@ -54,7 +54,6 @@ local PFSS = {
       { 0, 2 },
       { -1, 1 },
     },
-    LoadAtRuntime = true
   },
   GUI = {
     Name = "Fieldlines PFSS",

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
@@ -25,6 +25,7 @@ local PFSSPaths = {
 local PFSS = {
   Identifier = "FL_PFSS",
   Parent = transforms.HEEQ180ReferenceFrame.Identifier,
+  InteractionSphere = 695700000,
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = PFSSPaths.SolarSoft,

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
@@ -14,6 +14,15 @@ local fieldlineData  = asset.syncedResource({
   Version = 1
 })
 
+local darkenSun = {
+  Documentation = "Makes the Sun turn black",
+  GuiPath = "2012July",
+  Identifier = "2012july.dark_sun",
+  IsLocal = false,
+  Name = "Dark sun",
+  Command = "local textureMultiplier = openspace.getPropertyValue(\"Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier\");\nif(textureMultiplier < 0.01) then\nopenspace.setPropertyValueSingle(\"Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier\", 1.0, 1);\nelse\nopenspace.setPropertyValueSingle(\"Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier\", 0.0, 1)\nend"
+}
+
 local pfssTransitionColorTable = transferFunctions .. "pfss_transition.txt"
 local pfssTopologyColorTable = transferFunctions .. "pfss_topology.txt"
 local pfssBsignColorTable = transferFunctions .. "pfss_bsign.txt"
@@ -54,6 +63,8 @@ local PFSS = {
 }
 
 asset.onInitialize(function ()
+  openspace.action.registerAction(darkenSun)
+
   if not openspace.directoryExists(PFSSPaths.SolarSoft) then
     openspace.printInfo("Extracting " .. "Fieldlines from PFSS model of 2012 event")
     openspace.unzipFile(fieldlineData .. "leilas_solar_soft.zip", PFSSPaths.SolarSoft, true)
@@ -70,6 +81,8 @@ end)
 
 asset.onDeinitialize(function ()
   openspace.removeSceneGraphNode(PFSS)
+  openspace.action.removeAction(darkenSun)
+
 end)
 
 asset.meta = {

--- a/data/assets/scene/solarsystem/planets/earth/magnetosphere/magnetosphere.asset
+++ b/data/assets/scene/solarsystem/planets/earth/magnetosphere/magnetosphere.asset
@@ -11,6 +11,7 @@ local fieldlinesDirectory = asset.syncedResource({
 local earthMagnetosphere = {
   Identifier = "EarthMagnetosphere",
   Parent = transforms.GSMReferenceFrame.Identifier,
+  InteractionSphere = 6380000,  -- A value slightly bigger than earth radius
   Renderable = {
     Type = "RenderableFieldlinesSequence",
     SourceFolder = fieldlinesDirectory,

--- a/data/profiles/solarstorm2012.profile
+++ b/data/profiles/solarstorm2012.profile
@@ -1,36 +1,36 @@
 {
   "actions": [
     {
-      "documentation": "Reset button. Sets time to start at start of dataset. No loop",
+      "documentation": "Reset button. Sets time to start of dataset. No loop",
       "gui_path": "2012July",
-      "identifier": "2012July.Reset-loop",
+      "identifier": "2012july.reset_loop",
       "is_local": false,
-      "name": "Reset button.",
+      "name": "Reset button",
       "script": "openspace.time.setTime('2012-JUL-01 07:00:00.00');\nopenspace.scriptScheduler.clear();"
     },
     {
-      "documentation": "Makes the sun turn black",
+      "documentation": "Makes the Sun turn black",
       "gui_path": "2012July",
-      "identifier": "2012July.Dark-sun",
+      "identifier": "2012july.dark_sun",
       "is_local": false,
       "name": "Dark sun",
       "script": "openspace.setPropertyValueSingle('Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier', 0.000000);"
     },
     {
-      "documentation": "Sets time to start of data. sets high delta time. loops from start when at end of data",
+      "documentation": "Sets time to start of data, sets high delta time and loops back from start when at end of data",
       "gui_path": "2012July",
-      "identifier": "2012July.loopEnlil",
+      "identifier": "2012july.loop_enlil",
       "is_local": false,
       "name": "Loop ENLIL",
-      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(43200);\nopenspace.time.setTime('2012-JUL-01 07:00:00.00');\nStarttimescriptENLILLoop = \"openspace.time.setTime('2012 JUL 01 07:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 AUG 01 06:58:00', StarttimescriptENLILLoop);"
+      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(43200);\nopenspace.time.setTime('2012-JUL-01 07:00:00.00');\nlocal StarttimescriptENLILLoop = \"openspace.time.setTime('2012 JUL 01 07:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 AUG 01 06:58:00', StarttimescriptENLILLoop);"
     },
     {
-      "documentation": "Sets time to start of data. Sets higher delta time. Loops back to start, at end of data.",
+      "documentation": "Sets time to start of data, sets higher delta time and loops back from start, when at end of data.",
       "gui_path": "2012July",
-      "identifier": "2012July.LoopBatsrus",
+      "identifier": "2012july.loop_batsrus",
       "is_local": false,
       "name": "Loop BATSRUS",
-      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(1400);\nopenspace.time.setTime('2012-JUL-14 06:00:00.00');\nStarttimescriptBatsrusLoop = \"openspace.time.setTime('2012 JUL 14 06:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 JUL 16 07:30:00', StarttimescriptBatsrusLoop);"
+      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(1400);\nopenspace.time.setTime('2012-JUL-14 06:00:00.00');\nlocal StarttimescriptBatsrusLoop = \"openspace.time.setTime('2012 JUL 14 06:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 JUL 16 07:30:00', StarttimescriptBatsrusLoop);"
     }
   ],
   "assets": [
@@ -69,19 +69,19 @@
   ],
   "keybindings": [
     {
-      "action": "2012July.Reset-loop",
+      "action": "2012july.reset_loop",
       "key": "R"
     },
     {
-      "action": "2012July.Dark-sun",
+      "action": "2012july.dark_sun",
       "key": "D"
     },
     {
-      "action": "2012July.loopEnlil",
+      "action": "2012july.loop_enlil",
       "key": "E"
     },
     {
-      "action": "2012July.LoopBatsrus",
+      "action": "2012july.loop_batsrus",
       "key": "B"
     }
   ],
@@ -94,8 +94,8 @@
     "ISS"
   ],
   "meta": {
-    "author": "CCMC",
-    "description": "This profile is showing several coronal mass ejection (CMEs) during July 2012.",
+    "author": "Community Coordinated Modeling Center, NASA Goddard",
+    "description": "This profile is showing several coronal mass ejection (CMEs) during July 2012, where the last one was incredible intense. Its strength was comparable to the most intense CME in recorded history, the Carrington Event of 1859, which caused damage to electric equipment world wide. Luckily this 2012 event missed earth. The event is modeled with ENLIL which spands across the solarsystem, from the Sun to Earth, Batsrus which is showing the interaction of the flow of the solar wind and Earths magnetosphere. There is also one time step of the PFSS model showing the Suns local magnetic structure.",
     "license": "MIT License",
     "name": "Solar storm 2012",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/solarstorm2012.profile
+++ b/data/profiles/solarstorm2012.profile
@@ -1,0 +1,124 @@
+{
+  "actions": [
+    {
+      "documentation": "Reset button. Sets time to start at start of dataset. No loop",
+      "gui_path": "2012July",
+      "identifier": "2012July.Reset-loop",
+      "is_local": false,
+      "name": "Reset button.",
+      "script": "openspace.time.setTime('2012-JUL-01 07:00:00.00');\nopenspace.scriptScheduler.clear();"
+    },
+    {
+      "documentation": "Makes the sun turn black",
+      "gui_path": "2012July",
+      "identifier": "2012July.Dark-sun",
+      "is_local": false,
+      "name": "Dark sun",
+      "script": "openspace.setPropertyValueSingle('Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier', 0.000000);"
+    },
+    {
+      "documentation": "Sets time to start of data. sets high delta time. loops from start when at end of data",
+      "gui_path": "2012July",
+      "identifier": "2012July.loopEnlil",
+      "is_local": false,
+      "name": "Loop ENLIL",
+      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(43200);\nopenspace.time.setTime('2012-JUL-01 07:00:00.00');\nStarttimescriptENLILLoop = \"openspace.time.setTime('2012 JUL 01 07:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 AUG 01 06:58:00', StarttimescriptENLILLoop);"
+    },
+    {
+      "documentation": "Sets time to start of data. Sets higher delta time. Loops back to start, at end of data.",
+      "gui_path": "2012July",
+      "identifier": "2012July.LoopBatsrus",
+      "is_local": false,
+      "name": "Loop BATSRUS",
+      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(1400);\nopenspace.time.setTime('2012-JUL-14 06:00:00.00');\nStarttimescriptBatsrusLoop = \"openspace.time.setTime('2012 JUL 14 06:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 JUL 16 07:30:00', StarttimescriptBatsrusLoop);"
+    }
+  ],
+  "assets": [
+    "base",
+    "dashboard/default_dashboard",
+    "scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines"
+  ],
+  "camera": {
+    "altitude": 74000000000.0,
+    "anchor": "Sun",
+    "latitude": 20.5877,
+    "longitude": -35.1924,
+    "type": "goToGeo"
+  },
+  "delta_times": [
+    1.0,
+    5.0,
+    30.0,
+    60.0,
+    300.0,
+    1800.0,
+    3600.0,
+    43200.0,
+    86400.0,
+    604800.0,
+    1209600.0,
+    2592000.0,
+    5184000.0,
+    7776000.0,
+    15552000.0,
+    31536000.0,
+    63072000.0,
+    157680000.0,
+    315360000.0,
+    630720000.0
+  ],
+  "keybindings": [
+    {
+      "action": "2012July.Reset-loop",
+      "key": "R"
+    },
+    {
+      "action": "2012July.Dark-sun",
+      "key": "D"
+    },
+    {
+      "action": "2012July.loopEnlil",
+      "key": "E"
+    },
+    {
+      "action": "2012July.LoopBatsrus",
+      "key": "B"
+    }
+  ],
+  "mark_nodes": [
+    "Earth",
+    "Mars",
+    "Moon",
+    "Sun",
+    "Venus",
+    "ISS"
+  ],
+  "meta": {
+    "author": "CCMC",
+    "description": "This profile is showing several coronal mass ejection (CMEs) during July 2012.",
+    "license": "MIT License",
+    "name": "Solar storm 2012",
+    "url": "https://www.openspaceproject.com",
+    "version": "1.0"
+  },
+  "properties": [
+    {
+      "name": "Scene.Sun.Renderable.Enabled",
+      "type": "setPropertyValue",
+      "value": "true"
+    },
+    {
+      "name": "Scene.SunGlare.Renderable.Enabled",
+      "type": "setPropertyValue",
+      "value": "false"
+    }
+  ],
+  "time": {
+    "type": "absolute",
+    "value": "2012-07-14T07:00:00"
+  },
+  "version": {
+    "major": 1,
+    "minor": 1
+  }
+}

--- a/data/profiles/solarstorm2012.profile
+++ b/data/profiles/solarstorm2012.profile
@@ -2,7 +2,9 @@
   "assets": [
     "base",
     "dashboard/default_dashboard",
-    "scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines"
+    "scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines",
+    "scene/solarsystem/planets/earth/magnetosphere/magnetosphere",
+    "scene/solarsystem/planets/earth/magnetosphere/transforms_magnetosphere"
   ],
   "camera": {
     "altitude": 294000000000.0,
@@ -76,6 +78,11 @@
     {
       "name": "Scene.SunGlare.Renderable.Enabled",
       "type": "setPropertyValue",
+      "value": "false"
+    },
+    {
+      "name": "Scene.EarthMagnetosphere.Renderable.Enabled",
+      "type": "setPropertyValueSingle",
       "value": "false"
     }
   ],

--- a/data/profiles/solarstorm2012.profile
+++ b/data/profiles/solarstorm2012.profile
@@ -1,48 +1,14 @@
 {
-  "actions": [
-    {
-      "documentation": "Reset button. Sets time to start of dataset. No loop",
-      "gui_path": "2012July",
-      "identifier": "2012july.reset_loop",
-      "is_local": false,
-      "name": "Reset button",
-      "script": "openspace.time.setTime('2012-JUL-01 07:00:00.00');\nopenspace.scriptScheduler.clear();"
-    },
-    {
-      "documentation": "Makes the Sun turn black",
-      "gui_path": "2012July",
-      "identifier": "2012july.dark_sun",
-      "is_local": false,
-      "name": "Dark sun",
-      "script": "openspace.setPropertyValueSingle('Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier', 0.000000);"
-    },
-    {
-      "documentation": "Sets time to start of data, sets high delta time and loops back from start when at end of data",
-      "gui_path": "2012July",
-      "identifier": "2012july.loop_enlil",
-      "is_local": false,
-      "name": "Loop ENLIL",
-      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(43200);\nopenspace.time.setTime('2012-JUL-01 07:00:00.00');\nlocal StarttimescriptENLILLoop = \"openspace.time.setTime('2012 JUL 01 07:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 AUG 01 06:58:00', StarttimescriptENLILLoop);"
-    },
-    {
-      "documentation": "Sets time to start of data, sets higher delta time and loops back from start, when at end of data.",
-      "gui_path": "2012July",
-      "identifier": "2012july.loop_batsrus",
-      "is_local": false,
-      "name": "Loop BATSRUS",
-      "script": "openspace.scriptScheduler.clear();\nopenspace.time.setDeltaTime(1400);\nopenspace.time.setTime('2012-JUL-14 06:00:00.00');\nlocal StarttimescriptBatsrusLoop = \"openspace.time.setTime('2012 JUL 14 06:00:00')\";\nopenspace.scriptScheduler.loadScheduledScript('2012 JUL 16 07:30:00', StarttimescriptBatsrusLoop);"
-    }
-  ],
   "assets": [
     "base",
     "dashboard/default_dashboard",
     "scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines"
   ],
   "camera": {
-    "altitude": 74000000000.0,
+    "altitude": 294000000000.0,
     "anchor": "Sun",
-    "latitude": 20.5877,
-    "longitude": -35.1924,
+    "latitude": 35.8,
+    "longitude": 87.1,
     "type": "goToGeo"
   },
   "delta_times": [

--- a/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
+++ b/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
@@ -579,6 +579,10 @@ bool RenderableFieldlinesSequence::prepareForOsflsStreaming() {
     }
     _states.push_back(newState);
     _nStates = _startTimes.size();
+    if (_nStates == 1) {
+        // loading dynamicaly is not nessesary if only having one set in the sequence 
+        _loadingStatesDynamically = false;
+    }
     _activeStateIndex = 0;
     return true;
 }
@@ -1044,9 +1048,8 @@ void RenderableFieldlinesSequence::update(const UpdateData& data) {
     bool needUpdate = false;
     const double currentTime = data.time.j2000Seconds();
     const bool isInInterval = (currentTime >= _startTimes[0]) &&
-                              (currentTime < _sequenceEndTime) ||
-                               _nStates == 1;
-
+                              (currentTime < _sequenceEndTime);
+    
     // Check if current time in OpenSpace is within sequence interval
     if (isInInterval) {
         const size_t nextIdx = _activeTriggerTimeIndex + 1;
@@ -1068,6 +1071,15 @@ void RenderableFieldlinesSequence::update(const UpdateData& data) {
                 _activeStateIndex = _activeTriggerTimeIndex;
             }
         } // else {we're still in same state as previous frame (no changes needed)}
+    }
+    // if only one state
+    else if (_nStates == 1) {
+        _activeTriggerTimeIndex = 0;
+        _activeStateIndex = 0;
+        if (!_hasBeenUpdated) {
+            updateVertexPositionBuffer();
+        }
+        _hasBeenUpdated = true;
     }
     else {
         // Not in interval => set everything to false

--- a/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
+++ b/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
@@ -826,7 +826,6 @@ bool RenderableFieldlinesSequence::getStatesFromCdfFiles() {
 std::unordered_map<std::string, std::vector<glm::vec3>>
     extractSeedPointsFromFiles(std::filesystem::path filePath)
 {
-    std::vector<std::string> files;
     std::unordered_map<std::string, std::vector<glm::vec3>> outMap;
 
     if (!std::filesystem::is_directory(filePath)) {

--- a/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
+++ b/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
@@ -1044,7 +1044,8 @@ void RenderableFieldlinesSequence::update(const UpdateData& data) {
     bool needUpdate = false;
     const double currentTime = data.time.j2000Seconds();
     const bool isInInterval = (currentTime >= _startTimes[0]) &&
-                              (currentTime < _sequenceEndTime);
+                              (currentTime < _sequenceEndTime) ||
+                               _nStates == 1;
 
     // Check if current time in OpenSpace is within sequence interval
     if (isInInterval) {
@@ -1104,14 +1105,16 @@ void RenderableFieldlinesSequence::update(const UpdateData& data) {
         _newStateIsReady = false;
     }
 
-    if (_shouldUpdateColorBuffer) {
-        updateVertexColorBuffer();
-        _shouldUpdateColorBuffer = false;
-    }
+    if (_colorMethod == 1) { //By quantity
+        if (_shouldUpdateColorBuffer) {
+            updateVertexColorBuffer();
+            _shouldUpdateColorBuffer = false;
+        }
 
-    if (_shouldUpdateMaskingBuffer) {
-        updateVertexMaskingBuffer();
-        _shouldUpdateMaskingBuffer = false;
+        if (_shouldUpdateMaskingBuffer) {
+            updateVertexMaskingBuffer();
+            _shouldUpdateMaskingBuffer = false;
+        }
     }
 }
 
@@ -1131,6 +1134,9 @@ void RenderableFieldlinesSequence::updateActiveTriggerTimeIndex(double currentTi
     else {
         _activeTriggerTimeIndex = static_cast<int>(_nStates) - 1;
     }
+    if (_nStates == 1) {
+        _activeTriggerTimeIndex = 0;
+    }
 }
 
 // Reading state from disk. Must be thread safe
@@ -1149,6 +1155,7 @@ void unbindGL() {
 }
 
 void RenderableFieldlinesSequence::updateVertexPositionBuffer() {
+    if (_activeStateIndex == -1) { return; }
     glBindVertexArray(_vertexArrayObject);
     glBindBuffer(GL_ARRAY_BUFFER, _vertexPositionBuffer);
 
@@ -1168,6 +1175,7 @@ void RenderableFieldlinesSequence::updateVertexPositionBuffer() {
 }
 
 void RenderableFieldlinesSequence::updateVertexColorBuffer() {
+    if (_activeStateIndex == -1) { return; }
     glBindVertexArray(_vertexArrayObject);
     glBindBuffer(GL_ARRAY_BUFFER, _vertexColorBuffer);
 
@@ -1193,6 +1201,7 @@ void RenderableFieldlinesSequence::updateVertexColorBuffer() {
 }
 
 void RenderableFieldlinesSequence::updateVertexMaskingBuffer() {
+    if (_activeStateIndex == -1) { return; }
     glBindVertexArray(_vertexArrayObject);
     glBindBuffer(GL_ARRAY_BUFFER, _vertexMaskingBuffer);
 

--- a/modules/fieldlinessequence/rendering/renderablefieldlinessequence.h
+++ b/modules/fieldlinessequence/rendering/renderablefieldlinessequence.h
@@ -107,6 +107,10 @@ private:
     // True when new state is loaded or user change which quantity used for masking out
     // line segments
     bool _shouldUpdateMaskingBuffer = false;
+    // note Elon: rework the case of only one state
+    // hasBeenUpdated only gets sets once, first iteration of update function, to 
+    // guarantee the vertext position buffer to be initialized.
+    bool _hasBeenUpdated = false;
 
     // Active index of _states. If(==-1)=>no state available for current time. Always the
     // same as _activeTriggerTimeIndex if(_loadingStatesDynamically==true), else

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -91,6 +91,7 @@ ReadOnlyProfiles = {
     "newhorizons",
     "osirisrex",
     "rosetta",
+    "solarstorm2012",
     "touch",
     "voyager"
 }


### PR DESCRIPTION
This creates a new public profile for the 2012 july solar storm event, with ENLIL, PFSS and BATSRUS models.
Only thing I can think of is to set camera position better. How can I find the current camera position, so that I can copy it ?

Needs to be added to list of profile in .cfg also. 