### PR TITLE
Feature/gui mouseinteraction fix

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -276,6 +276,15 @@ void checkJoystickStatus() {
     }
 }
 
+bool isGuiWindow(sgct::Window* window) {
+    if (Engine::instance().windows().size() == 1) {
+        // If we only have one window, assume it's also the GUI window.
+        // It might not have been given the 'GUI' tag
+        return true;
+    }
+    return window->hasTag("GUI");
+}
+
 //
 //  Init function
 //
@@ -574,7 +583,7 @@ void mainPostDrawFunc() {
 
 
 void mainKeyboardCallback(sgct::Key key, sgct::Modifier modifiers, sgct::Action action,
-                          int)
+                          int, sgct::Window* window)
 {
     ZoneScoped
     LTRACE("main::mainKeyboardCallback(begin)");
@@ -582,7 +591,9 @@ void mainKeyboardCallback(sgct::Key key, sgct::Modifier modifiers, sgct::Action 
     const openspace::Key k = openspace::Key(key);
     const KeyModifier m = KeyModifier(modifiers);
     const KeyAction a = KeyAction(action);
-    global::openSpaceEngine->keyboardCallback(k, m, a);
+    const IsGuiWindow isGui = IsGuiWindow(isGuiWindow(window));
+
+    global::openSpaceEngine->keyboardCallback(k, m, a, isGui);
 
     LTRACE("main::mainKeyboardCallback(begin)");
 }
@@ -590,7 +601,7 @@ void mainKeyboardCallback(sgct::Key key, sgct::Modifier modifiers, sgct::Action 
 
 
 void mainMouseButtonCallback(sgct::MouseButton key, sgct::Modifier modifiers,
-                             sgct::Action action)
+                             sgct::Action action, sgct::Window* window)
 {
     ZoneScoped
     LTRACE("main::mainMouseButtonCallback(begin)");
@@ -598,36 +609,42 @@ void mainMouseButtonCallback(sgct::MouseButton key, sgct::Modifier modifiers,
     const openspace::MouseButton k = openspace::MouseButton(key);
     const openspace::MouseAction a = openspace::MouseAction(action);
     const openspace::KeyModifier m = openspace::KeyModifier(modifiers);
-    global::openSpaceEngine->mouseButtonCallback(k, a, m);
+    const IsGuiWindow isGui = IsGuiWindow(isGuiWindow(window));
+
+    global::openSpaceEngine->mouseButtonCallback(k, a, m, isGui);
 
     LTRACE("main::mainMouseButtonCallback(end)");
 }
 
 
 
-void mainMousePosCallback(double x, double y) {
+void mainMousePosCallback(double x, double y, sgct::Window* window) {
     ZoneScoped
-    global::openSpaceEngine->mousePositionCallback(x, y);
+    const IsGuiWindow isGui = IsGuiWindow(isGuiWindow(window));
+    global::openSpaceEngine->mousePositionCallback(x, y, isGui);
 }
 
 
 
-void mainMouseScrollCallback(double posX, double posY) {
+void mainMouseScrollCallback(double posX, double posY, sgct::Window* window) {
     ZoneScoped
     LTRACE("main::mainMouseScrollCallback(begin");
 
-    global::openSpaceEngine->mouseScrollWheelCallback(posX, posY);
+    const IsGuiWindow isGui = IsGuiWindow(isGuiWindow(window));
+    global::openSpaceEngine->mouseScrollWheelCallback(posX, posY, isGui);
 
     LTRACE("main::mainMouseScrollCallback(end)");
 }
 
 
 
-void mainCharCallback(unsigned int codepoint, int modifiers) {
+void mainCharCallback(unsigned int codepoint, int modifiers, sgct::Window* window) {
     ZoneScoped
 
     const KeyModifier m = KeyModifier(modifiers);
-    global::openSpaceEngine->charCallback(codepoint, m);
+    const IsGuiWindow isGui = IsGuiWindow(isGuiWindow(window));
+
+    global::openSpaceEngine->charCallback(codepoint, m, isGui);
 }
 
 

--- a/include/openspace/engine/globalscallbacks.h
+++ b/include/openspace/engine/globalscallbacks.h
@@ -28,10 +28,22 @@
 #include <openspace/util/keys.h>
 #include <openspace/util/mouse.h>
 #include <openspace/util/touch.h>
+#include <ghoul/misc/boolean.h>
 #include <functional>
 #include <vector>
 
+namespace openspace {
+    BooleanType(IsGuiWindow);
+} // namespace openspace
+
 namespace openspace::global::callback {
+
+using KeyboardCallback = std::function<bool(Key, KeyModifier, KeyAction, IsGuiWindow)>;
+using CharacterCallback = std::function<bool(unsigned int, KeyModifier, IsGuiWindow)>;
+using MouseButtonCallback =
+    std::function<bool(MouseButton, MouseAction, KeyModifier, IsGuiWindow)>;
+using MousePositionCallback = std::function<void(double, double, IsGuiWindow)>;
+using MouseScrollWheelCallback = std::function<bool(double, double, IsGuiWindow)>;
 
 inline std::vector<std::function<void()>>* initialize;
 inline std::vector<std::function<void()>>* deinitialize;
@@ -42,12 +54,11 @@ inline std::vector<std::function<void()>>* postSyncPreDraw;
 inline std::vector<std::function<void()>>* render;
 inline std::vector<std::function<void()>>* draw2D;
 inline std::vector<std::function<void()>>* postDraw;
-inline std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>* keyboard;
-inline std::vector<std::function<bool(unsigned int, KeyModifier)>>* character;
-inline std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>*
-    mouseButton;
-inline std::vector<std::function<void(double, double)>>* mousePosition;
-inline std::vector<std::function<bool(double, double)>>* mouseScrollWheel;
+inline std::vector<KeyboardCallback>* keyboard;
+inline std::vector<CharacterCallback>* character;
+inline std::vector<MouseButtonCallback>* mouseButton;
+inline std::vector<MousePositionCallback>* mousePosition;
+inline std::vector<MouseScrollWheelCallback>* mouseScrollWheel;
 inline std::vector<std::function<bool(TouchInput)>>* touchDetected;
 inline std::vector<std::function<bool(TouchInput)>>* touchUpdated;
 inline std::vector<std::function<void(TouchInput)>>* touchExit;

--- a/include/openspace/engine/openspaceengine.h
+++ b/include/openspace/engine/openspaceengine.h
@@ -25,6 +25,7 @@
 #ifndef __OPENSPACE_CORE___OPENSPACEENGINE___H__
 #define __OPENSPACE_CORE___OPENSPACEENGINE___H__
 
+#include <openspace/engine/globalscallbacks.h>
 #include <openspace/properties/optionproperty.h>
 #include <openspace/properties/propertyowner.h>
 #include <openspace/properties/property.h>
@@ -92,11 +93,14 @@ public:
     void drawOverlays();
     void postDraw();
     void resetPropertyChangeFlags();
-    void keyboardCallback(Key key, KeyModifier mod, KeyAction action);
-    void charCallback(unsigned int codepoint, KeyModifier modifier);
-    void mouseButtonCallback(MouseButton button, MouseAction action, KeyModifier mods);
-    void mousePositionCallback(double x, double y);
-    void mouseScrollWheelCallback(double posX, double posY);
+    void keyboardCallback(Key key, KeyModifier mod, KeyAction action,
+        IsGuiWindow isGuiWindow);
+    void charCallback(unsigned int codepoint, KeyModifier modifier,
+        IsGuiWindow isGuiWindow);
+    void mouseButtonCallback(MouseButton button, MouseAction action,
+        KeyModifier mods, IsGuiWindow isGuiWindow);
+    void mousePositionCallback(double x, double y, IsGuiWindow isGuiWindow);
+    void mouseScrollWheelCallback(double posX, double posY, IsGuiWindow isGuiWindow);
     void touchDetectionCallback(TouchInput input);
     void touchUpdateCallback(TouchInput input);
     void touchExitCallback(TouchInput input);

--- a/modules/cefwebgui/src/guikeyboardhandler.cpp
+++ b/modules/cefwebgui/src/guikeyboardhandler.cpp
@@ -32,10 +32,10 @@ GUIKeyboardHandler::GUIKeyboardHandler() {
     _keyConsumed = false;
 
     global::callback::keyboard->emplace_back(
-        [&](Key, KeyModifier, KeyAction) -> bool {
+        [&](Key, KeyModifier, KeyAction, IsGuiWindow isGuiWindow) -> bool {
             const bool previous = _keyConsumed;
             _keyConsumed = false;
-            return previous;
+            return isGuiWindow ? previous : false;
         }
     );
 }

--- a/modules/skybrowser/skybrowsermodule.cpp
+++ b/modules/skybrowser/skybrowsermodule.cpp
@@ -166,8 +166,9 @@ SkyBrowserModule::SkyBrowserModule()
     _wwtImageCollectionUrl.setReadOnly(true);
 
     // Set callback functions
-    global::callback::mouseButton->emplace(global::callback::mouseButton->begin(),
-        [&](MouseButton, MouseAction action, KeyModifier) -> bool {
+    global::callback::mouseButton->emplace(
+        global::callback::mouseButton->begin(),
+        [&](MouseButton button, MouseAction action, KeyModifier, IsGuiWindow) -> bool {
             if (action == MouseAction::Press) {
                 _cameraRotation.stop();
             }

--- a/modules/webbrowser/src/eventhandler.cpp
+++ b/modules/webbrowser/src/eventhandler.cpp
@@ -149,7 +149,7 @@ namespace {
 namespace openspace {
 
 void EventHandler::initialize() {
-    global::callback::character->emplace_back(
+    global::callback::character->emplace(global::callback::character->begin(),
         [this](unsigned int charCode, KeyModifier mod) -> bool {
             if (_browserInstance) {
                 return charCallback(charCode, mod);
@@ -157,7 +157,7 @@ void EventHandler::initialize() {
             return false;
         }
     );
-    global::callback::keyboard->emplace_back(
+    global::callback::keyboard->emplace(global::callback::keyboard->begin(),
         [this](Key key, KeyModifier mod, KeyAction action) -> bool {
             if (_browserInstance) {
                 return keyboardCallback(key, mod, action);
@@ -165,7 +165,7 @@ void EventHandler::initialize() {
             return false;
         }
     );
-    global::callback::mousePosition->emplace_back(
+    global::callback::mousePosition->emplace(global::callback::mousePosition->begin(),
         [this](double x, double y) -> bool {
             if (_browserInstance) {
                 return mousePositionCallback(x, y);
@@ -173,15 +173,16 @@ void EventHandler::initialize() {
             return false;
         }
     );
-    global::callback::mouseButton->emplace_back(
         [this](MouseButton button, MouseAction action, KeyModifier mods) -> bool {
             if (_browserInstance) {
+    global::callback::mouseButton->emplace(global::callback::mouseButton->begin(),
                 return mouseButtonCallback(button, action, mods);
             }
             return false;
         }
     );
-    global::callback::mouseScrollWheel->emplace_back(
+    global::callback::mouseScrollWheel->emplace(
+        global::callback::mouseScrollWheel->begin(),
         [this](double x, double y) -> bool {
             if (_browserInstance) {
                 return mouseWheelCallback(glm::ivec2(x, y));
@@ -190,7 +191,7 @@ void EventHandler::initialize() {
         }
     );
 
-    global::callback::touchDetected->emplace_back(
+    global::callback::touchDetected->emplace(global::callback::touchDetected->begin(),
         [&](TouchInput input) -> bool {
             if (!_browserInstance) {
                 return false;
@@ -229,7 +230,7 @@ void EventHandler::initialize() {
         }
     );
 
-    global::callback::touchUpdated->emplace_back(
+    global::callback::touchUpdated->emplace(global::callback::touchUpdated->begin(),
         [&](TouchInput input) -> bool {
             if (!_browserInstance || _validTouchStates.empty()) {
                 return false;
@@ -267,7 +268,7 @@ void EventHandler::initialize() {
         }
     );
 
-    global::callback::touchExit->emplace_back(
+    global::callback::touchExit->emplace(global::callback::touchExit->begin(),
         [&](TouchInput input) {
             if (!_browserInstance) {
                 return;

--- a/modules/webbrowser/src/eventhandler.cpp
+++ b/modules/webbrowser/src/eventhandler.cpp
@@ -149,33 +149,41 @@ namespace {
 namespace openspace {
 
 void EventHandler::initialize() {
-    global::callback::character->emplace(global::callback::character->begin(),
-        [this](unsigned int charCode, KeyModifier mod) -> bool {
-            if (_browserInstance) {
+    global::callback::character->emplace(
+        global::callback::character->begin(),
+        [this](unsigned int charCode, KeyModifier mod, IsGuiWindow isGuiWindow) -> bool {
+            if (_browserInstance && isGuiWindow) {
                 return charCallback(charCode, mod);
             }
             return false;
         }
     );
-    global::callback::keyboard->emplace(global::callback::keyboard->begin(),
-        [this](Key key, KeyModifier mod, KeyAction action) -> bool {
-            if (_browserInstance) {
+    global::callback::keyboard->emplace(
+        global::callback::keyboard->begin(),
+        [this](Key key, KeyModifier mod, KeyAction action,
+            IsGuiWindow isGuiWindow) -> bool
+        {
+            if (_browserInstance && isGuiWindow) {
                 return keyboardCallback(key, mod, action);
             }
             return false;
         }
     );
-    global::callback::mousePosition->emplace(global::callback::mousePosition->begin(),
-        [this](double x, double y) -> bool {
-            if (_browserInstance) {
+    global::callback::mousePosition->emplace(
+        global::callback::mousePosition->begin(),
+        [this](double x, double y, IsGuiWindow isGuiWindow) -> bool {
+            if (_browserInstance && isGuiWindow) {
                 return mousePositionCallback(x, y);
             }
             return false;
         }
     );
-        [this](MouseButton button, MouseAction action, KeyModifier mods) -> bool {
-            if (_browserInstance) {
-    global::callback::mouseButton->emplace(global::callback::mouseButton->begin(),
+    global::callback::mouseButton->emplace(
+        global::callback::mouseButton->begin(),
+        [this](MouseButton button, MouseAction action,
+               KeyModifier mods, IsGuiWindow isGuiWindow) -> bool
+        {
+            if (_browserInstance && isGuiWindow) {
                 return mouseButtonCallback(button, action, mods);
             }
             return false;
@@ -183,15 +191,16 @@ void EventHandler::initialize() {
     );
     global::callback::mouseScrollWheel->emplace(
         global::callback::mouseScrollWheel->begin(),
-        [this](double x, double y) -> bool {
-            if (_browserInstance) {
+        [this](double x, double y, IsGuiWindow isGuiWindow) -> bool {
+            if (_browserInstance && isGuiWindow) {
                 return mouseWheelCallback(glm::ivec2(x, y));
             }
             return false;
         }
     );
 
-    global::callback::touchDetected->emplace(global::callback::touchDetected->begin(),
+    global::callback::touchDetected->emplace(
+        global::callback::touchDetected->begin(),
         [&](TouchInput input) -> bool {
             if (!_browserInstance) {
                 return false;
@@ -230,7 +239,8 @@ void EventHandler::initialize() {
         }
     );
 
-    global::callback::touchUpdated->emplace(global::callback::touchUpdated->begin(),
+    global::callback::touchUpdated->emplace(
+        global::callback::touchUpdated->begin(),
         [&](TouchInput input) -> bool {
             if (!_browserInstance || _validTouchStates.empty()) {
                 return false;
@@ -268,7 +278,8 @@ void EventHandler::initialize() {
         }
     );
 
-    global::callback::touchExit->emplace(global::callback::touchExit->begin(),
+    global::callback::touchExit->emplace(
+        global::callback::touchExit->begin(),
         [&](TouchInput input) {
             if (!_browserInstance) {
                 return;

--- a/src/engine/globalscallbacks.cpp
+++ b/src/engine/globalscallbacks.cpp
@@ -43,11 +43,11 @@ namespace {
         sizeof(std::vector<std::function<void()>>) +
         sizeof(std::vector<std::function<void()>>) +
         sizeof(std::vector<std::function<void()>>) +
-        sizeof(std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>) +
-        sizeof(std::vector<std::function<bool(unsigned int, KeyModifier)>>) +
-        sizeof(std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>) +
-        sizeof(std::vector<std::function<void(double, double)>>) +
-        sizeof(std::vector<std::function<bool(double, double)>>) +
+        sizeof(std::vector<KeyboardCallback>) +
+        sizeof(std::vector<CharacterCallback>) +
+        sizeof(std::vector<MouseButtonCallback>) +
+        sizeof(std::vector<MousePositionCallback>) +
+        sizeof(std::vector<MouseScrollWheelCallback>) +
         sizeof(std::vector<std::function<bool(TouchInput)>>) +
         sizeof(std::vector<std::function<bool(TouchInput)>>) +
         sizeof(std::vector<std::function<void(TouchInput)>>);
@@ -138,51 +138,44 @@ void create() {
 #endif // WIN32
 
 #ifdef WIN32
-    keyboard =
-        new (currentPos) std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>;
+    keyboard = new (currentPos) std::vector<KeyboardCallback>
     ghoul_assert(keyboard, "No keyboard");
-    currentPos += sizeof(std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>);
+    currentPos += sizeof(std::vector<KeyboardCallback>);
 #else // ^^^ WIN32 / !WIN32 vvv
-    keyboard = new std::vector<std::function<bool(Key, KeyModifier, KeyAction)>>;
+    keyboard = new std::vector<KeyboardCallback>;
 #endif // WIN32
 
 #ifdef WIN32
-    character =
-        new (currentPos) std::vector<std::function<bool(unsigned int, KeyModifier)>>;
+    character = new (currentPos) std::vector<CharacterCallback>;
     ghoul_assert(character, "No character");
-    currentPos += sizeof(std::vector<std::function<bool(unsigned int, KeyModifier)>>);
+    currentPos += sizeof(std::vector<CharacterCallback>);
 #else // ^^^ WIN32 / !WIN32 vvv
-    character = new std::vector<std::function<bool(unsigned int, KeyModifier)>>;
+    character = new std::vector<CharacterCallback>;
 #endif // WIN32
 
 #ifdef WIN32
-    mouseButton =
-        new (currentPos) std::vector<
-            std::function<bool(MouseButton, MouseAction, KeyModifier)>
-        >;
+    mouseButton = new (currentPos) std::vector<MouseButtonCallback>;
     ghoul_assert(mouseButton, "No mouseButton");
-    currentPos += sizeof(
-        std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>
-    );
+    currentPos += sizeof(std::vector<MouseButtonCallback>);
 #else // ^^^ WIN32 / !WIN32 vvv
-    mouseButton =
-        new std::vector<std::function<bool(MouseButton, MouseAction, KeyModifier)>>;
+    mouseButton = new std::vector<MouseButtonCallback>;
 #endif // WIN32
 
 #ifdef WIN32
-    mousePosition = new (currentPos) std::vector<std::function<void(double, double)>>;
+    mousePosition =
+        new (currentPos) std::vector<MousePositionCallback>;
     ghoul_assert(mousePosition, "No mousePosition");
-    currentPos += sizeof(std::vector<std::function<void(double, double)>>);
+    currentPos += sizeof(std::vector<MousePositionCallback>);
 #else // ^^^ WIN32 / !WIN32 vvv
-    mousePosition = new std::vector<std::function<void(double, double)>>;
+    mousePosition = new std::vector<MousePositionCallback>;
 #endif // WIN32
 
 #ifdef WIN32
-    mouseScrollWheel = new (currentPos) std::vector<std::function<bool(double, double)>>;
+    mouseScrollWheel = new (currentPos) std::vector<MouseScrollWheelCallback>;
     ghoul_assert(mouseScrollWheel, "No mouseScrollWheel");
-    currentPos += sizeof(std::vector<std::function<bool(double, double)>>);
+    currentPos += sizeof(std::vector<MouseScrollWheelCallback>);
 #else // ^^^ WIN32 / !WIN32 vvv
-    mouseScrollWheel = new std::vector<std::function<bool(double, double)>>;
+    mouseScrollWheel = new std::vector<MouseScrollWheelCallback>;
 #endif // WIN32
 
 #ifdef WIN32

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -31,7 +31,6 @@
 #include <openspace/engine/configuration.h>
 #include <openspace/engine/downloadmanager.h>
 #include <openspace/engine/globals.h>
-#include <openspace/engine/globalscallbacks.h>
 #include <openspace/engine/logfactory.h>
 #include <openspace/engine/moduleengine.h>
 #include <openspace/engine/syncengine.h>
@@ -1408,7 +1407,9 @@ void OpenSpaceEngine::resetPropertyChangeFlagsOfSubowners(properties::PropertyOw
     }
 }
 
-void OpenSpaceEngine::keyboardCallback(Key key, KeyModifier mod, KeyAction action) {
+void OpenSpaceEngine::keyboardCallback(Key key, KeyModifier mod, KeyAction action,
+                                       IsGuiWindow isGuiWindow)
+{
     ZoneScoped
 
     if (_loadingScreen) {
@@ -1421,9 +1422,9 @@ void OpenSpaceEngine::keyboardCallback(Key key, KeyModifier mod, KeyAction actio
         return;
     }
 
-    using F = std::function<bool (Key, KeyModifier, KeyAction)>;
+    using F = global::callback::KeyboardCallback;
     for (const F& func : *global::callback::keyboard) {
-        const bool isConsumed = func(key, mod, action);
+        const bool isConsumed = func(key, mod, action, isGuiWindow);
         if (isConsumed) {
             return;
         }
@@ -1441,12 +1442,14 @@ void OpenSpaceEngine::keyboardCallback(Key key, KeyModifier mod, KeyAction actio
     global::interactionMonitor->markInteraction();
 }
 
-void OpenSpaceEngine::charCallback(unsigned int codepoint, KeyModifier modifier) {
+void OpenSpaceEngine::charCallback(unsigned int codepoint, KeyModifier modifier,
+                                   IsGuiWindow isGuiWindow)
+{
     ZoneScoped
 
-    using F = std::function<bool (unsigned int, KeyModifier)>;
+    using F = global::callback::CharacterCallback;
     for (const F& func : *global::callback::character) {
-        bool isConsumed = func(codepoint, modifier);
+        bool isConsumed = func(codepoint, modifier, isGuiWindow);
         if (isConsumed) {
             return;
         }
@@ -1456,22 +1459,22 @@ void OpenSpaceEngine::charCallback(unsigned int codepoint, KeyModifier modifier)
     global::interactionMonitor->markInteraction();
 }
 
-void OpenSpaceEngine::mouseButtonCallback(MouseButton button,
-                                          MouseAction action,
-                                          KeyModifier mods)
+void OpenSpaceEngine::mouseButtonCallback(MouseButton button, MouseAction action,
+                                          KeyModifier mods, IsGuiWindow isGuiWindow)
 {
     ZoneScoped
 
-    using F = std::function<bool (MouseButton, MouseAction, KeyModifier)>;
+    using F = global::callback::MouseButtonCallback;
     for (const F& func : *global::callback::mouseButton) {
-        bool isConsumed = func(button, action, mods);
+        bool isConsumed = func(button, action, mods, isGuiWindow);
         if (isConsumed) {
             // If the mouse was released, we still want to forward it to the navigation
-            // handler in order to reliably terminate a rotation or zoom. Accidentally
+            // handler in order to reliably terminate a rotation or zoom, or to the other
+            // callbacks to for example release a drag and drop of a UI window. Accidentally
             // moving the cursor over a UI window is easy to miss and leads to weird
             // continuing movement
             if (action == MouseAction::Release) {
-                break;
+                continue;
             }
             else {
                 return;
@@ -1479,8 +1482,9 @@ void OpenSpaceEngine::mouseButtonCallback(MouseButton button,
         }
     }
 
-    // Check if the user clicked on one of the 'buttons' the RenderEngine is drawing
-    if (action == MouseAction::Press) {
+    // Check if the user clicked on one of the 'buttons' the RenderEngine is drawing.
+    // Only handle the clicks if we are in a GUI window
+    if (action == MouseAction::Press && isGuiWindow) {
         bool isConsumed = global::renderEngine->mouseActivationCallback(_mousePosition);
         if (isConsumed) {
             return;
@@ -1491,12 +1495,14 @@ void OpenSpaceEngine::mouseButtonCallback(MouseButton button,
     global::interactionMonitor->markInteraction();
 }
 
-void OpenSpaceEngine::mousePositionCallback(double x, double y) {
+void OpenSpaceEngine::mousePositionCallback(double x, double y,
+                                            IsGuiWindow isGuiWindow)
+{
     ZoneScoped
 
-    using F = std::function<void (double, double)>;
+    using F = global::callback::MousePositionCallback;
     for (const F& func : *global::callback::mousePosition) {
-        func(x, y);
+        func(x, y, isGuiWindow);
     }
 
     global::navigationHandler->mousePositionCallback(x, y);
@@ -1505,12 +1511,14 @@ void OpenSpaceEngine::mousePositionCallback(double x, double y) {
     _mousePosition = glm::vec2(static_cast<float>(x), static_cast<float>(y));
 }
 
-void OpenSpaceEngine::mouseScrollWheelCallback(double posX, double posY) {
+void OpenSpaceEngine::mouseScrollWheelCallback(double posX, double posY,
+                                               IsGuiWindow isGuiWindow)
+{
     ZoneScoped
 
-    using F = std::function<bool (double, double)>;
+    using F = global::callback::MouseScrollWheelCallback;
     for (const F& func : *global::callback::mouseScrollWheel) {
-        bool isConsumed = func(posX, posY);
+        bool isConsumed = func(posX, posY, isGuiWindow);
         if (isConsumed) {
             return;
         }


### PR DESCRIPTION
Aims to fix interaction problems when hovering/clicking with the mouse in a non-GUI window, when having a setup with more than one window (e.g. the single_gui.json setup)

Previously, clicking with the mouse in the rendering window without the GUI also triggered mouse clicks in all the other windows, including the GUI windows. This was disturbing for interaction in the single_gui setup

Now, the GUI modules (ImGui and webbrowser) check to see if the clicked window is actually an interaction window

related PR in SGCT: https://github.com/sgct/sgct/pull/55 (note that you might have to check out the latest commit in that branch for it to work)


Will do some more through testing before considering a merge, but feel free to look at the implementation and try it out already