### PR TITLE
Fix filename when downloading multiple files in urlsync

### DIFF
--- a/modules/sync/syncs/urlsynchronization.cpp
+++ b/modules/sync/syncs/urlsynchronization.cpp
@@ -147,7 +147,7 @@ void UrlSynchronization::start() {
         std::vector<std::unique_ptr<HttpFileDownload>> downloads;
 
         for (const std::string& url : _urls) {
-            if (_filename.empty()) {
+            if (_filename.empty() || _urls.size() > 1) {
                 std::string name = std::filesystem::path(url).filename().string();
 
                 // We can not create filenames with question marks


### PR DESCRIPTION
Before it would download all the files to the same location based on the first file's name in the list.