### PR TITLE
Disable hover circle per default when setting a renderable (fixes #2153)

### DIFF
--- a/modules/skybrowser/skybrowsermodule.cpp
+++ b/modules/skybrowser/skybrowsermodule.cpp
@@ -307,6 +307,9 @@ void SkyBrowserModule::lookAtTarget(const std::string& id) {
 
 void SkyBrowserModule::setHoverCircle(SceneGraphNode* circle) {
     _hoverCircle = circle;
+
+    // Always disable it per default. It should only be visible on interaction
+    disableHoverCircle();
 }
 
 void SkyBrowserModule::moveHoverCircle(int i, bool useScript) {

--- a/modules/skybrowser/skybrowsermodule_lua.inl
+++ b/modules/skybrowser/skybrowsermodule_lua.inl
@@ -87,6 +87,12 @@ namespace {
     using namespace openspace;
 
     SceneGraphNode* circle = global::renderEngine->scene()->sceneGraphNode(identifier);
+    if (!circle) {
+        throw ghoul::lua::LuaError(fmt::format(
+            "Could not find node to set as hover circle: '{}'", identifier
+        ));
+    }
+
     global::moduleEngine->module<SkyBrowserModule>()->setHoverCircle(circle);
 }
 


### PR DESCRIPTION
and throw warning if setting to non-existing node