### PR TITLE
Enable highlights in grids

### DIFF
--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -20,6 +20,10 @@ local speck = asset.syncedResource({
   Version = 2
 })
 
+local lightDay = 2.59020684E13
+local lightMonth = 7.771E14
+local lightYear = 9.4605284E15
+
 local radio = {
   Identifier = "RadioSphere",
   Parent = earth_transforms.EarthBarycenter.Identifier,
@@ -233,16 +237,13 @@ local plane1ld = {
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "1ld.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "1ld.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 10.3,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "Km"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightDay, 2*lightDay },
   },
   GUI = {
     Name = "1ld Grid",
@@ -260,16 +261,13 @@ local plane1lm = {
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "1lm.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "1lm.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 11.8,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "pc"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightMonth, 2*lightMonth },
   },
   GUI = {
     Name = "1lm Grid",
@@ -287,16 +285,13 @@ local plane1ly = {
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "1ly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "1ly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 13.0,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "pc"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
     Name = "1ly Grid",
@@ -311,19 +306,20 @@ local plane10ly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
+    },
+    Scale = {
+      Type = "StaticScale",
+      Scale = 10
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "10ly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "10ly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 14.17,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "pc"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
     Name = "10ly Grid",
@@ -338,19 +334,20 @@ local plane100ly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
+    },
+    Scale = {
+      Type = "StaticScale",
+      Scale = 100
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "100ly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "100ly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 15.0,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "pc"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
     Name = "100ly Grid",
@@ -365,19 +362,20 @@ local plane1kly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
+    },
+    Scale = {
+      Type = "StaticScale",
+      Scale = 1000
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "1kly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "1kly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 16.0,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "pc"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
     Name = "1kly Grid",
@@ -392,19 +390,20 @@ local plane10kly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
+    },
+    Scale = {
+      Type = "StaticScale",
+      Scale = 10000
     }
   },
   Renderable = {
-    Type = "RenderableDUMeshes",
+    Type = "RenderableGrid",
     Enabled = false,
     Opacity = 0.4,
-    File = speck .. "10kly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "10kly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 17.25,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "pc"
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
     Name = "10kly Grid",
@@ -431,6 +430,29 @@ local plane100kly = {
     Path = "/Other/Grids"
   }
 }
+--[[
+local plane100klynew = {
+  Identifier = "100klyGridnew",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 100000
+    }
+  },
+  Renderable = {
+    Type = "RenderableGrid",
+    Enabled = false,
+    Opacity = 0.4,
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
+  },
+  GUI = {
+    Name = "100kly Grid new",
+    Path = "/Other/Grids"
+  }
+}]]
 
 local plane1Mly = {
   Identifier = "1MlyGrid",
@@ -451,6 +473,29 @@ local plane1Mly = {
     Path = "/Other/Grids"
   }
 }
+--[[
+local plane1Mlynew = {
+  Identifier = "1MlyGridnew",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 1000000
+    }
+  },
+  Renderable = {
+    Type = "RenderableGrid",
+    Enabled = false,
+    Opacity = 0.4,
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
+  },
+  GUI = {
+    Name = "1Mly Grid new",
+    Path = "/Other/Grids"
+  }
+}]]
 
 local plane10Mly = {
   Identifier = "10MlyGrid",
@@ -471,6 +516,29 @@ local plane10Mly = {
     Path = "/Other/Grids"
   }
 }
+--[[
+local plane10Mlynew = {
+  Identifier = "10MlyGridnew",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 10000000
+    }
+  },
+  Renderable = {
+    Type = "RenderableGrid",
+    Enabled = false,
+    Opacity = 0.4,
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
+  },
+  GUI = {
+    Name = "10Mly Grid new",
+    Path = "/Other/Grids"
+  }
+}]]
 
 local plane100Mly = {
   Identifier = "100MlyGrid",
@@ -491,6 +559,29 @@ local plane100Mly = {
     Path = "/Other/Grids"
   }
 }
+--[[
+local plane100Mlynew = {
+  Identifier = "100MlyGridnew",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 100000000
+    }
+  },
+  Renderable = {
+    Type = "RenderableGrid",
+    Enabled = false,
+    Opacity = 0.4,
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
+  },
+  GUI = {
+    Name = "100Mly Grid new",
+    Path = "/Other/Grids"
+  }
+}]]
 
 local plane20Gly = {
   Identifier = "20GlyGrid",
@@ -511,6 +602,29 @@ local plane20Gly = {
     Path = "/Other/Grids"
   }
 }
+--[[
+local plane20Glynew = {
+  Identifier = "20GlyGridnew",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 20000000000
+    }
+  },
+  Renderable = {
+    Type = "RenderableGrid",
+    Enabled = false,
+    Opacity = 0.4,
+    Color = { 0.1, 0.5, 0.6 },
+    LineWidth = 2.0,
+    Segments = { 20, 20 },
+    Size = { 2*lightYear, 2*lightYear },
+  },
+  GUI = {
+    Name = "20Gly Grid new",
+    Path = "/Other/Grids"
+  }
+}]]
 
 local nodes = {
   radio, oort, ecliptic, eclipticLabels, equatorial, equatorialLabels,

--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -307,10 +307,6 @@ local plane10ly = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
     },
-    Scale = {
-      Type = "StaticScale",
-      Scale = 10
-    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -319,7 +315,7 @@ local plane10ly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 10*2*lightYear, 10*2*lightYear },
   },
   GUI = {
     Name = "10ly Grid",
@@ -335,10 +331,6 @@ local plane100ly = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
     },
-    Scale = {
-      Type = "StaticScale",
-      Scale = 100
-    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -347,7 +339,7 @@ local plane100ly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 100*2*lightYear, 100*2*lightYear },
   },
   GUI = {
     Name = "100ly Grid",
@@ -363,10 +355,6 @@ local plane1kly = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
     },
-    Scale = {
-      Type = "StaticScale",
-      Scale = 1E3
-    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -375,7 +363,7 @@ local plane1kly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 1E3*2*lightYear, 1E3*2*lightYear },
   },
   GUI = {
     Name = "1kly Grid",
@@ -391,10 +379,6 @@ local plane10kly = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
     },
-    Scale = {
-      Type = "StaticScale",
-      Scale = 10E3
-    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -403,7 +387,7 @@ local plane10kly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 10E3*2*lightYear, 10E3*2*lightYear },
   },
   GUI = {
     Name = "10kly Grid",
@@ -413,12 +397,6 @@ local plane10kly = {
 
 local plane100kly = {
   Identifier = "100klyGrid",
-  Transform = {
-    Scale = {
-      Type = "StaticScale",
-      Scale = 100E3
-    }
-  },
   Renderable = {
     Type = "RenderableGrid",
     Enabled = false,
@@ -428,7 +406,7 @@ local plane100kly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 100E3*2*lightYear, 100E3*2*lightYear },
   },
   GUI = {
     Name = "100kly Grid",
@@ -438,12 +416,6 @@ local plane100kly = {
 
 local plane1Mly = {
   Identifier = "1MlyGrid",
-  Transform = {
-    Scale = {
-      Type = "StaticScale",
-      Scale = 1E6
-    }
-  },
   Renderable = {
     Type = "RenderableGrid",
     Enabled = false,
@@ -453,7 +425,7 @@ local plane1Mly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 1E6*2*lightYear, 1E6*2*lightYear },
   },
   GUI = {
     Name = "1Mly Grid",
@@ -463,12 +435,6 @@ local plane1Mly = {
 
 local plane10Mly = {
   Identifier = "10MlyGrid",
-  Transform = {
-    Scale = {
-      Type = "StaticScale",
-      Scale = 10E6
-    }
-  },
   Renderable = {
     Type = "RenderableGrid",
     Enabled = false,
@@ -478,7 +444,7 @@ local plane10Mly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 10E6*2*lightYear, 10E6*2*lightYear },
   },
   GUI = {
     Name = "10Mly Grid",
@@ -488,12 +454,6 @@ local plane10Mly = {
 
 local plane100Mly = {
   Identifier = "100MlyGrid",
-  Transform = {
-    Scale = {
-      Type = "StaticScale",
-      Scale = 100E6
-    }
-  },
   Renderable = {
     Type = "RenderableGrid",
     Enabled = false,
@@ -503,7 +463,7 @@ local plane100Mly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 100E6*2*lightYear, 100E6*2*lightYear },
   },
   GUI = {
     Name = "100Mly Grid",
@@ -513,12 +473,6 @@ local plane100Mly = {
 
 local plane20Gly = {
   Identifier = "20GlyGrid",
-  Transform = {
-    Scale = {
-      Type = "StaticScale",
-      Scale = 20E9
-    }
-  },
   Renderable = {
     Type = "RenderableGrid",
     Enabled = false,
@@ -528,7 +482,7 @@ local plane20Gly = {
     LineWidth = 2.0,
     Segments = { 40, 40 },
     HighlightRate = { 5, 5 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 20E9*2*lightYear, 20E9*2*lightYear },
   },
   GUI = {
     Name = "20Gly Grid",

--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -365,7 +365,7 @@ local plane1kly = {
     },
     Scale = {
       Type = "StaticScale",
-      Scale = 1000
+      Scale = 1E3
     }
   },
   Renderable = {
@@ -393,7 +393,7 @@ local plane10kly = {
     },
     Scale = {
       Type = "StaticScale",
-      Scale = 10000
+      Scale = 10E3
     }
   },
   Renderable = {
@@ -416,7 +416,7 @@ local plane100kly = {
   Transform = {
     Scale = {
       Type = "StaticScale",
-      Scale = 100000
+      Scale = 100E3
     }
   },
   Renderable = {
@@ -441,7 +441,7 @@ local plane1Mly = {
   Transform = {
     Scale = {
       Type = "StaticScale",
-      Scale = 1000000
+      Scale = 1E6
     }
   },
   Renderable = {
@@ -466,7 +466,7 @@ local plane10Mly = {
   Transform = {
     Scale = {
       Type = "StaticScale",
-      Scale = 10000000
+      Scale = 10E6
     }
   },
   Renderable = {
@@ -491,7 +491,7 @@ local plane100Mly = {
   Transform = {
     Scale = {
       Type = "StaticScale",
-      Scale = 100000000
+      Scale = 100E6
     }
   },
   Renderable = {
@@ -516,7 +516,7 @@ local plane20Gly = {
   Transform = {
     Scale = {
       Type = "StaticScale",
-      Scale = 20000000000
+      Scale = 20E9
     }
   },
   Renderable = {

--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -413,26 +413,6 @@ local plane10kly = {
 
 local plane100kly = {
   Identifier = "100klyGrid",
-  Renderable = {
-    Type = "RenderableDUMeshes",
-    Enabled = false,
-    Opacity = 0.4,
-    File = speck .. "100kly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "100kly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 18.6,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "Mpc"
-  },
-  GUI = {
-    Name = "100kly Grid",
-    Path = "/Other/Grids"
-  }
-}
---[[
-local plane100klynew = {
-  Identifier = "100klyGridnew",
   Transform = {
     Scale = {
       Type = "StaticScale",
@@ -444,38 +424,20 @@ local plane100klynew = {
     Enabled = false,
     Opacity = 0.4,
     Color = { 0.1, 0.5, 0.6 },
+    HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
+    HighlightRate = { 5, 5},
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
-    Name = "100kly Grid new",
-    Path = "/Other/Grids"
-  }
-}]]
-
-local plane1Mly = {
-  Identifier = "1MlyGrid",
-  Renderable = {
-    Type = "RenderableDUMeshes",
-    Enabled = false,
-    Opacity = 0.4,
-    File = speck .. "1Mly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "1Mly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 19.6,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "Mpc"
-  },
-  GUI = {
-    Name = "1Mly Grid",
+    Name = "100kly Grid",
     Path = "/Other/Grids"
   }
 }
---[[
-local plane1Mlynew = {
-  Identifier = "1MlyGridnew",
+
+local plane1Mly = {
+  Identifier = "1MlyGrid",
   Transform = {
     Scale = {
       Type = "StaticScale",
@@ -487,38 +449,20 @@ local plane1Mlynew = {
     Enabled = false,
     Opacity = 0.4,
     Color = { 0.1, 0.5, 0.6 },
+    HighlightColor = {0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
+    HighlightRate = { 5, 5},
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
-    Name = "1Mly Grid new",
-    Path = "/Other/Grids"
-  }
-}]]
-
-local plane10Mly = {
-  Identifier = "10MlyGrid",
-  Renderable = {
-    Type = "RenderableDUMeshes",
-    Enabled = false,
-    Opacity = 0.4,
-    File = speck .. "10Mly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "10Mly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 20.6,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "Mpc"
-  },
-  GUI = {
-    Name = "10Mly Grid",
+    Name = "1Mly Grid",
     Path = "/Other/Grids"
   }
 }
---[[
-local plane10Mlynew = {
-  Identifier = "10MlyGridnew",
+
+local plane10Mly = {
+  Identifier = "10MlyGrid",
   Transform = {
     Scale = {
       Type = "StaticScale",
@@ -530,38 +474,20 @@ local plane10Mlynew = {
     Enabled = false,
     Opacity = 0.4,
     Color = { 0.1, 0.5, 0.6 },
+    HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
+    HighlightRate = { 5, 5},
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
-    Name = "10Mly Grid new",
-    Path = "/Other/Grids"
-  }
-}]]
-
-local plane100Mly = {
-  Identifier = "100MlyGrid",
-  Renderable = {
-    Type = "RenderableDUMeshes",
-    Enabled = false,
-    Opacity = 0.4,
-    File = speck .. "100Mly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "100Mly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 21.6,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "Mpc"
-  },
-  GUI = {
-    Name = "100Mly Grid",
+    Name = "10Mly Grid",
     Path = "/Other/Grids"
   }
 }
---[[
-local plane100Mlynew = {
-  Identifier = "100MlyGridnew",
+
+local plane100Mly = {
+  Identifier = "100MlyGrid",
   Transform = {
     Scale = {
       Type = "StaticScale",
@@ -573,38 +499,20 @@ local plane100Mlynew = {
     Enabled = false,
     Opacity = 0.4,
     Color = { 0.1, 0.5, 0.6 },
+    HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
+    HighlightRate = { 5, 5},
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
-    Name = "100Mly Grid new",
-    Path = "/Other/Grids"
-  }
-}]]
-
-local plane20Gly = {
-  Identifier = "20GlyGrid",
-  Renderable = {
-    Type = "RenderableDUMeshes",
-    Enabled = false,
-    Opacity = 0.4,
-    File = speck .. "20Gly.speck",
-    MeshColor = {{ 0.1, 0.5, 0.6 }},
-    LabelFile = speck .. "20Gly.label",
-    TextColor = { 0.0, 0.2, 0.5 },
-    TextSize = 23.6,
-    TextMinMaxSize = { 0, 30 },
-    Unit = "Mpc"
-  },
-  GUI = {
-    Name = "20Gly Grid",
+    Name = "100Mly Grid",
     Path = "/Other/Grids"
   }
 }
---[[
-local plane20Glynew = {
-  Identifier = "20GlyGridnew",
+
+local plane20Gly = {
+  Identifier = "20GlyGrid",
   Transform = {
     Scale = {
       Type = "StaticScale",
@@ -616,15 +524,17 @@ local plane20Glynew = {
     Enabled = false,
     Opacity = 0.4,
     Color = { 0.1, 0.5, 0.6 },
+    HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
-    Segments = { 20, 20 },
+    Segments = { 40, 40 },
+    HighlightRate = { 5, 5},
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
-    Name = "20Gly Grid new",
+    Name = "20Gly Grid",
     Path = "/Other/Grids"
   }
-}]]
+}
 
 local nodes = {
   radio, oort, ecliptic, eclipticLabels, equatorial, equatorialLabels,

--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -427,7 +427,7 @@ local plane100kly = {
     HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    HighlightRate = { 5, 5},
+    HighlightRate = { 5, 5 },
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
@@ -449,10 +449,10 @@ local plane1Mly = {
     Enabled = false,
     Opacity = 0.4,
     Color = { 0.1, 0.5, 0.6 },
-    HighlightColor = {0.3, 0.7, 0.8 },
+    HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    HighlightRate = { 5, 5},
+    HighlightRate = { 5, 5 },
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
@@ -477,7 +477,7 @@ local plane10Mly = {
     HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    HighlightRate = { 5, 5},
+    HighlightRate = { 5, 5 },
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
@@ -502,7 +502,7 @@ local plane100Mly = {
     HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    HighlightRate = { 5, 5},
+    HighlightRate = { 5, 5 },
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {
@@ -527,7 +527,7 @@ local plane20Gly = {
     HighlightColor = { 0.3, 0.7, 0.8 },
     LineWidth = 2.0,
     Segments = { 40, 40 },
-    HighlightRate = { 5, 5},
+    HighlightRate = { 5, 5 },
     Size = { 2*lightYear, 2*lightYear },
   },
   GUI = {

--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -243,7 +243,7 @@ local plane1ld = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightDay, 2*lightDay },
+    Size = { 2*lightDay, 2*lightDay }
   },
   GUI = {
     Name = "1ld Grid",
@@ -267,7 +267,7 @@ local plane1lm = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightMonth, 2*lightMonth },
+    Size = { 2*lightMonth, 2*lightMonth }
   },
   GUI = {
     Name = "1lm Grid",
@@ -291,7 +291,7 @@ local plane1ly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 2*lightYear, 2*lightYear },
+    Size = { 2*lightYear, 2*lightYear }
   },
   GUI = {
     Name = "1ly Grid",
@@ -306,7 +306,7 @@ local plane10ly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
-    },
+    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -315,7 +315,7 @@ local plane10ly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 10*2*lightYear, 10*2*lightYear },
+    Size = { 10*2*lightYear, 10*2*lightYear }
   },
   GUI = {
     Name = "10ly Grid",
@@ -330,7 +330,7 @@ local plane100ly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
-    },
+    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -339,7 +339,7 @@ local plane100ly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 100*2*lightYear, 100*2*lightYear },
+    Size = { 100*2*lightYear, 100*2*lightYear }
   },
   GUI = {
     Name = "100ly Grid",
@@ -354,7 +354,7 @@ local plane1kly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
-    },
+    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -363,7 +363,7 @@ local plane1kly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 1E3*2*lightYear, 1E3*2*lightYear },
+    Size = { 1E3*2*lightYear, 1E3*2*lightYear }
   },
   GUI = {
     Name = "1kly Grid",
@@ -378,7 +378,7 @@ local plane10kly = {
     Rotation = {
       Type = "StaticRotation",
       Rotation = eclipticRotationMatrix
-    },
+    }
   },
   Renderable = {
     Type = "RenderableGrid",
@@ -387,7 +387,7 @@ local plane10kly = {
     Color = { 0.1, 0.5, 0.6 },
     LineWidth = 2.0,
     Segments = { 20, 20 },
-    Size = { 10E3*2*lightYear, 10E3*2*lightYear },
+    Size = { 10E3*2*lightYear, 10E3*2*lightYear }
   },
   GUI = {
     Name = "10kly Grid",
@@ -406,7 +406,7 @@ local plane100kly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 100E3*2*lightYear, 100E3*2*lightYear },
+    Size = { 100E3*2*lightYear, 100E3*2*lightYear }
   },
   GUI = {
     Name = "100kly Grid",
@@ -425,7 +425,7 @@ local plane1Mly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 1E6*2*lightYear, 1E6*2*lightYear },
+    Size = { 1E6*2*lightYear, 1E6*2*lightYear }
   },
   GUI = {
     Name = "1Mly Grid",
@@ -444,7 +444,7 @@ local plane10Mly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 10E6*2*lightYear, 10E6*2*lightYear },
+    Size = { 10E6*2*lightYear, 10E6*2*lightYear }
   },
   GUI = {
     Name = "10Mly Grid",
@@ -463,7 +463,7 @@ local plane100Mly = {
     LineWidth = 2.0,
     Segments = { 20, 20 },
     HighlightRate = { 5, 5 },
-    Size = { 100E6*2*lightYear, 100E6*2*lightYear },
+    Size = { 100E6*2*lightYear, 100E6*2*lightYear }
   },
   GUI = {
     Name = "100Mly Grid",
@@ -482,7 +482,7 @@ local plane20Gly = {
     LineWidth = 2.0,
     Segments = { 40, 40 },
     HighlightRate = { 5, 5 },
-    Size = { 20E9*2*lightYear, 20E9*2*lightYear },
+    Size = { 20E9*2*lightYear, 20E9*2*lightYear }
   },
   GUI = {
     Name = "20Gly Grid",
@@ -502,7 +502,7 @@ asset.onInitialize(function()
     openspace.addSceneGraphNode(node)
   end
 end)
-  
+
 asset.onDeinitialize(function()
   for i = #nodes, 1, -1 do
     local node = nodes[i]

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -58,7 +58,9 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo HighlightRateInfo = {
         "HighlightRate",
         "Highlight Rate",
-        "The rate the columns and rows are highlighted"
+        "The rate that the columns and rows are highlighted, counted with respect to the "
+        "center of the grid. If the number of segments in the grid is odd, the "
+        "highlighting might be offsett from the center."
     };
 
     constexpr openspace::properties::Property::PropertyInfo LineWidthInfo = {
@@ -285,16 +287,15 @@ void RenderableGrid::update(const UpdateData&) {
             const float x1 = x0 + step.x;
 
             // Line in y direction
+            bool shouldHighlight = false;
             if (_highlightRate.value().y != 0) {
                 int rest = static_cast<int>(i - center.y) % _highlightRate.value().y;
-                if (abs(rest) == 0) {
-                    _highlightArray.push_back({ x0, y0, 0.f });
-                    _highlightArray.push_back({ x0, y1, 0.f });
-                }
-                else {
-                    _varray.push_back({ x0, y0, 0.f });
-                    _varray.push_back({ x0, y1, 0.f });
-                }
+                shouldHighlight = abs(rest) == 0;
+            }
+
+            if (shouldHighlight) {
+                _highlightArray.push_back({ x0, y0, 0.f });
+                _highlightArray.push_back({ x0, y1, 0.f });
             }
             else {
                 _varray.push_back({ x0, y0, 0.f });
@@ -302,16 +303,15 @@ void RenderableGrid::update(const UpdateData&) {
             }
 
             // Line in x direction
+            shouldHighlight = false;
             if (_highlightRate.value().x != 0) {
                 int rest = static_cast<int>(j - center.x) % _highlightRate.value().x;
-                if (abs(rest) == 0) {
-                    _highlightArray.push_back({ x0, y0, 0.f });
-                    _highlightArray.push_back({ x1, y0, 0.f });
-                }
-                else {
-                    _varray.push_back({ x0, y0, 0.f });
-                    _varray.push_back({ x1, y0, 0.f });
-                }
+                shouldHighlight = abs(rest) == 0;
+            }
+
+            if (shouldHighlight) {
+                _highlightArray.push_back({ x0, y0, 0.f });
+                _highlightArray.push_back({ x1, y0, 0.f });
             }
             else {
                 _varray.push_back({ x0, y0, 0.f });

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -115,7 +115,7 @@ RenderableGrid::RenderableGrid(const ghoul::Dictionary& dictionary)
     , _color(ColorInfo, glm::vec3(0.5f), glm::vec3(0.f), glm::vec3(1.f))
     , _highlightColor(HighlightColorInfo, glm::vec3(0.8f), glm::vec3(0.f), glm::vec3(1.f))
     , _segments(SegmentsInfo, glm::uvec2(10), glm::uvec2(1), glm::uvec2(200))
-    , _highlightRate(HighlightRateInfo, glm::uvec2(5), glm::uvec2(0), glm::uvec2(200))
+    , _highlightRate(HighlightRateInfo, glm::uvec2(0), glm::uvec2(0), glm::uvec2(200))
     , _lineWidth(LineWidthInfo, 0.5f, 1.f, 20.f)
     , _highlightLineWidth(HighlightLineWidthInfo, 0.5f, 1.f, 20.f)
     , _size(SizeInfo, glm::vec2(1.f), glm::vec2(1.f), glm::vec2(1e11f))
@@ -375,6 +375,7 @@ void RenderableGrid::update(const UpdateData&) {
         _varray.data(),
         GL_STATIC_DRAW
     );
+    glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), nullptr);
 
     // Major grid

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -325,16 +325,16 @@ void RenderableGrid::update(const UpdateData&) {
         const float x0 = -halfSize.x + i * step.x;
         const float x1 = x0 + step.x;
 
+        bool shouldHighlight = false;
         if (_highlightRate.value().x != 0) {
-            int rest = static_cast<int>(nSegments.y - center.x) % _highlightRate.value().x;
-            if (abs(rest) == 0) {
-                _highlightArray.push_back({ x0, halfSize.y, 0.f });
-                _highlightArray.push_back({ x1, halfSize.y, 0.f });
-            }
-            else {
-                _varray.push_back({ x0, halfSize.y, 0.f });
-                _varray.push_back({ x1, halfSize.y, 0.f });
-            }
+            int rest =
+                static_cast<int>(nSegments.y - center.x) % _highlightRate.value().x;
+            shouldHighlight = abs(rest) == 0;
+        }
+
+        if (shouldHighlight) {
+            _highlightArray.push_back({ x0, halfSize.y, 0.f });
+            _highlightArray.push_back({ x1, halfSize.y, 0.f });
         }
         else {
             _varray.push_back({ x0, halfSize.y, 0.f });
@@ -347,16 +347,15 @@ void RenderableGrid::update(const UpdateData&) {
         const float y0 = -halfSize.y + i * step.y;
         const float y1 = y0 + step.y;
 
+        bool shouldHighlight = false;
         if (_highlightRate.value().y != 0) {
-            int rest = static_cast<int>(nSegments.x - center.y) % _highlightRate.value().y;
-            if (abs(rest) == 0) {
-                _highlightArray.push_back({ halfSize.x, y0, 0.f });
-                _highlightArray.push_back({ halfSize.x, y1, 0.f });
-            }
-            else {
-                _varray.push_back({ halfSize.x, y0, 0.f });
-                _varray.push_back({ halfSize.x, y1, 0.f });
-            }
+            int rest =
+                static_cast<int>(nSegments.x - center.y) % _highlightRate.value().y;
+            shouldHighlight = abs(rest) == 0;
+        }
+        if (shouldHighlight) {
+            _highlightArray.push_back({ halfSize.x, y0, 0.f });
+            _highlightArray.push_back({ halfSize.x, y1, 0.f });
         }
         else {
             _varray.push_back({ halfSize.x, y0, 0.f });

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -213,7 +213,7 @@ void RenderableGrid::render(const RenderData& data, RendererTasks&){
     glm::dmat4 modelTransform =
         glm::translate(glm::dmat4(1.0), data.modelTransform.translation) * // Translation
         glm::dmat4(data.modelTransform.rotation) *  // Spice rotation
-        glm::scale(glm::dmat4(1.0), glm::dvec3(data.modelTransform.scale));
+        glm::scale(glm::dmat4(1.0), data.modelTransform.scale);
 
     glm::dmat4 modelViewTransform = data.camera.combinedViewMatrix() * modelTransform;
 
@@ -264,9 +264,10 @@ void RenderableGrid::update(const UpdateData&) {
         return;
     }
 
-    const glm::vec2 halfSize = _size.value() / 2.f;
+    const glm::dvec2 halfSize = static_cast<glm::dvec2>(_size.value()) / 2.0;
     const glm::uvec2 nSegments = _segments.value();
-    const glm::vec2 step = _size.value() / static_cast<glm::vec2>(nSegments);
+    const glm::dvec2 step =
+        static_cast<glm::dvec2>(_size.value()) / static_cast<glm::dvec2>(nSegments);
 
     const int nLines = (2 * nSegments.x * nSegments.y) + nSegments.x + nSegments.y;
     const int nVertices = 2 * nLines;
@@ -280,11 +281,11 @@ void RenderableGrid::update(const UpdateData&) {
     const glm::uvec2 center = glm::uvec2(nSegments.x / 2.f, nSegments.y / 2.f);
     for (unsigned int i = 0; i < nSegments.x; ++i) {
         for (unsigned int j = 0; j < nSegments.y; ++j) {
-            const float y0 = -halfSize.y + j * step.y;
-            const float y1 = y0 + step.y;
+            const double y0 = -halfSize.y + j * step.y;
+            const double y1 = y0 + step.y;
 
-            const float x0 = -halfSize.x + i * step.x;
-            const float x1 = x0 + step.x;
+            const double x0 = -halfSize.x + i * step.x;
+            const double x1 = x0 + step.x;
 
             // Line in y direction
             bool shouldHighlight = false;
@@ -294,12 +295,12 @@ void RenderableGrid::update(const UpdateData&) {
             }
 
             if (shouldHighlight) {
-                _highlightArray.push_back({ x0, y0, 0.f });
-                _highlightArray.push_back({ x0, y1, 0.f });
+                _highlightArray.push_back({ x0, y0, 0.0 });
+                _highlightArray.push_back({ x0, y1, 0.0 });
             }
             else {
-                _varray.push_back({ x0, y0, 0.f });
-                _varray.push_back({ x0, y1, 0.f });
+                _varray.push_back({ x0, y0, 0.0 });
+                _varray.push_back({ x0, y1, 0.0 });
             }
 
             // Line in x direction
@@ -310,20 +311,20 @@ void RenderableGrid::update(const UpdateData&) {
             }
 
             if (shouldHighlight) {
-                _highlightArray.push_back({ x0, y0, 0.f });
-                _highlightArray.push_back({ x1, y0, 0.f });
+                _highlightArray.push_back({ x0, y0, 0.0 });
+                _highlightArray.push_back({ x1, y0, 0.0 });
             }
             else {
-                _varray.push_back({ x0, y0, 0.f });
-                _varray.push_back({ x1, y0, 0.f });
+                _varray.push_back({ x0, y0, 0.0 });
+                _varray.push_back({ x1, y0, 0.0 });
             }
         }
     }
 
     // last x row
     for (unsigned int i = 0; i < nSegments.x; ++i) {
-        const float x0 = -halfSize.x + i * step.x;
-        const float x1 = x0 + step.x;
+        const double x0 = -halfSize.x + i * step.x;
+        const double x1 = x0 + step.x;
 
         bool shouldHighlight = false;
         if (_highlightRate.value().x != 0) {
@@ -333,19 +334,19 @@ void RenderableGrid::update(const UpdateData&) {
         }
 
         if (shouldHighlight) {
-            _highlightArray.push_back({ x0, halfSize.y, 0.f });
-            _highlightArray.push_back({ x1, halfSize.y, 0.f });
+            _highlightArray.push_back({ x0, halfSize.y, 0.0 });
+            _highlightArray.push_back({ x1, halfSize.y, 0.0 });
         }
         else {
-            _varray.push_back({ x0, halfSize.y, 0.f });
-            _varray.push_back({ x1, halfSize.y, 0.f });
+            _varray.push_back({ x0, halfSize.y, 0.0 });
+            _varray.push_back({ x1, halfSize.y, 0.0 });
         }
     }
 
     // last y col
     for (unsigned int i = 0; i < nSegments.y; ++i) {
-        const float y0 = -halfSize.y + i * step.y;
-        const float y1 = y0 + step.y;
+        const double y0 = -halfSize.y + i * step.y;
+        const double y1 = y0 + step.y;
 
         bool shouldHighlight = false;
         if (_highlightRate.value().y != 0) {
@@ -354,12 +355,12 @@ void RenderableGrid::update(const UpdateData&) {
             shouldHighlight = abs(rest) == 0;
         }
         if (shouldHighlight) {
-            _highlightArray.push_back({ halfSize.x, y0, 0.f });
-            _highlightArray.push_back({ halfSize.x, y1, 0.f });
+            _highlightArray.push_back({ halfSize.x, y0, 0.0 });
+            _highlightArray.push_back({ halfSize.x, y1, 0.0 });
         }
         else {
-            _varray.push_back({ halfSize.x, y0, 0.f });
-            _varray.push_back({ halfSize.x, y1, 0.f });
+            _varray.push_back({ halfSize.x, y0, 0.0 });
+            _varray.push_back({ halfSize.x, y1, 0.0 });
         }
     }
 
@@ -375,7 +376,7 @@ void RenderableGrid::update(const UpdateData&) {
         GL_STATIC_DRAW
     );
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), nullptr);
+    glVertexAttribPointer(0, 3, GL_DOUBLE, GL_FALSE, sizeof(Vertex), nullptr);
 
     // Major grid
     glBindVertexArray(_highlightVaoID);
@@ -386,7 +387,7 @@ void RenderableGrid::update(const UpdateData&) {
         _highlightArray.data(),
         GL_STATIC_DRAW
     );
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), nullptr);
+    glVertexAttribPointer(0, 3, GL_DOUBLE, GL_FALSE, sizeof(Vertex), nullptr);
 
     glBindVertexArray(0);
 

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -60,7 +60,7 @@ namespace {
         "Highlight Rate",
         "The rate that the columns and rows are highlighted, counted with respect to the "
         "center of the grid. If the number of segments in the grid is odd, the "
-        "highlighting might be offsett from the center."
+        "highlighting might be offset from the center."
     };
 
     constexpr openspace::properties::Property::PropertyInfo LineWidthInfo = {

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -274,8 +274,8 @@ void RenderableGrid::update(const UpdateData&) {
     _highlightArray.reserve(nVertices);
     // OBS! Could be optimized further by removing duplicate vertices
 
+    // If the number of segments are uneven the center won't be completly centered
     const glm::uvec2 center = glm::uvec2(nSegments.x / 2.f, nSegments.y / 2.f);
-
     for (unsigned int i = 0; i < nSegments.x; ++i) {
         for (unsigned int j = 0; j < nSegments.y; ++j) {
             const float y0 = -halfSize.y + j * step.y;
@@ -375,7 +375,6 @@ void RenderableGrid::update(const UpdateData&) {
         _varray.data(),
         GL_STATIC_DRAW
     );
-    glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), nullptr);
 
     // Major grid
@@ -387,7 +386,6 @@ void RenderableGrid::update(const UpdateData&) {
         _highlightArray.data(),
         GL_STATIC_DRAW
     );
-    glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), nullptr);
 
     glBindVertexArray(0);

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -129,7 +129,8 @@ RenderableGrid::RenderableGrid(const ghoul::Dictionary& dictionary)
     _color.setViewOption(properties::Property::ViewOptions::Color);
     addProperty(_color);
 
-    _highlightColor = p.highlightColor.value_or(_highlightColor);
+    // If no highlight color is specified then use the base color
+    _highlightColor = p.highlightColor.value_or(_color);
     _highlightColor.setViewOption(properties::Property::ViewOptions::Color);
     addProperty(_highlightColor);
 
@@ -144,7 +145,8 @@ RenderableGrid::RenderableGrid(const ghoul::Dictionary& dictionary)
     _lineWidth = p.lineWidth.value_or(_lineWidth);
     addProperty(_lineWidth);
 
-    _highlightLineWidth = p.highlightLineWidth.value_or(_highlightLineWidth);
+    // If no highlight line width is specified then use the base line width
+    _highlightLineWidth = p.highlightLineWidth.value_or(_lineWidth);
     addProperty(_highlightLineWidth);
 
     _size.setExponent(10.f);

--- a/modules/base/rendering/grids/renderablegrid.h
+++ b/modules/base/rendering/grids/renderablegrid.h
@@ -61,19 +61,25 @@ protected:
     ghoul::opengl::ProgramObject* _gridProgram = nullptr;
 
     properties::Vec3Property _color;
+    properties::Vec3Property _highlightColor;
     // @TODO (abock, 2021-01-28)  This was a UVec2Property before, but it wasn't supported
     // be the codegen.  As soon as it does, this should be changed back
     properties::IVec2Property _segments;
+    properties::IVec2Property _highlightRate;
     properties::FloatProperty _lineWidth;
+    properties::FloatProperty _highlightLineWidth;
     properties::Vec2Property _size;
 
     bool _gridIsDirty = true;
 
     GLuint _vaoID = 0;
     GLuint _vBufferID = 0;
+    GLuint _highlightVaoID = 0;
+    GLuint _highlightVBufferID = 0;
 
     GLenum _mode = GL_LINES;
     std::vector<Vertex> _varray;
+    std::vector<Vertex> _highlightArray;
 };
 
 }// namespace openspace

--- a/modules/base/rendering/grids/renderablegrid.h
+++ b/modules/base/rendering/grids/renderablegrid.h
@@ -55,7 +55,7 @@ public:
 
 protected:
     struct Vertex {
-        float location[3];
+        double location[3];
     };
 
     ghoul::opengl::ProgramObject* _gridProgram = nullptr;

--- a/modules/base/shaders/grid_vs.glsl
+++ b/modules/base/shaders/grid_vs.glsl
@@ -37,11 +37,11 @@ void main() {
   dvec4 objPosDouble = dvec4(in_position, 1.0);
   dvec4 positionViewSpace = modelViewTransform * objPosDouble;
   dvec4 positionClipSpace = MVPTransform * objPosDouble;
-    
+
   positionClipSpace.z = 0.0;
-    
+
   vs_depthClipSpace = float(positionClipSpace.w);
   vs_positionViewSpace = vec4(positionViewSpace);
-    
+
   gl_Position = vec4(positionClipSpace);
 }

--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -30,7 +30,7 @@
 #include <openspace/engine/globals.h>
 #include <openspace/events/event.h>
 #include <openspace/events/eventengine.h>
-#include <openspace/navigation/navigationhandler.h> 
+#include <openspace/navigation/navigationhandler.h>
 #include <openspace/scene/scenegraphnode.h>
 #include <openspace/util/factorymanager.h>
 #include <openspace/util/memorymanager.h>
@@ -207,7 +207,7 @@ Renderable::Renderable(const ghoul::Dictionary& dictionary)
     if (p.renderBinMode.has_value()) {
         setRenderBin(codegen::map<Renderable::RenderBin>(*p.renderBinMode));
     }
-    
+
     _dimInAtmosphere = p.dimInAtmosphere.value_or(_dimInAtmosphere);
     addProperty(_dimInAtmosphere);
 }
@@ -313,7 +313,7 @@ void Renderable::registerUpdateRenderBinFromOpacity() {
 }
 
 float Renderable::opacity() const {
-    // Rendering should depend on if camera is in the atmosphere and if camera is at the 
+    // Rendering should depend on if camera is in the atmosphere and if camera is at the
     // dark part of the globe
     return _dimInAtmosphere ?
         _opacity * _fade * global::navigationHandler->camera()->atmosphereDimmingFactor() :


### PR DESCRIPTION
Add the possibility to, for example, highlight every 5th line in the grid with a thicker line and/or a different color. 

The previous `RenderableDUMeshes` grids have now been converted to use the `RenderableGrid` class instead.
Closes #1683