### PR TITLE
Fix for issue of scaling doesn't update border radius

### DIFF
--- a/modules/skybrowser/include/screenspaceskybrowser.h
+++ b/modules/skybrowser/include/screenspaceskybrowser.h
@@ -37,7 +37,6 @@ namespace openspace {
 
 class ScreenSpaceSkyBrowser : public ScreenSpaceRenderable, public WwtCommunicator {
 public:
-    static constexpr int RadiusTimeOut = 25;
     explicit ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary);
     ~ScreenSpaceSkyBrowser() override;
 
@@ -68,6 +67,7 @@ public:
     static documentation::Documentation Documentation();
 
 private:
+    static constexpr int RadiusTimeOut = 25;
     properties::FloatProperty _textureQuality;
     properties::BoolProperty _isHidden;
     std::vector<std::unique_ptr<properties::Vec3Property>> _displayCopies;

--- a/modules/skybrowser/include/screenspaceskybrowser.h
+++ b/modules/skybrowser/include/screenspaceskybrowser.h
@@ -37,6 +37,7 @@ namespace openspace {
 
 class ScreenSpaceSkyBrowser : public ScreenSpaceRenderable, public WwtCommunicator {
 public:
+    static constexpr int RadiusTimeOut = 25;
     explicit ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary);
     ~ScreenSpaceSkyBrowser() override;
 
@@ -80,6 +81,7 @@ private:
     bool _ratioIsDirty = false;
     bool _radiusIsDirty = false;
     bool _isInitialized = false;
+    int _borderRadiusTimer = -1;
 
     float _ratio = 1.f;
 };

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -129,6 +129,7 @@ ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary
 
     _scale.onChange([this]() {
         updateTextureResolution();
+        _borderRadiusTimer = 0;
         });
 
     _useRadiusAzimuthElevation.onChange(
@@ -325,11 +326,15 @@ void ScreenSpaceSkyBrowser::update() {
     if (_shouldReload) {
         _isInitialized = false;
     }
-
-    if (_radiusIsDirty && _isInitialized) {
+    // After the texture has been updated, wait a little bit before updating the border
+    // radius so the browser has time to update its size
+    if (_radiusIsDirty && _isInitialized && _borderRadiusTimer == RadiusTimeOut) {
         setBorderRadius(_borderRadius);
         _radiusIsDirty = false;
+        _borderRadiusTimer = -1;
     }
+    _borderRadiusTimer++;
+    
 
     ScreenSpaceRenderable::update();
     WwtCommunicator::update();

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -130,7 +130,7 @@ ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary
     _scale.onChange([this]() {
         updateTextureResolution();
         _borderRadiusTimer = 0;
-        });
+    });
 
     _useRadiusAzimuthElevation.onChange(
         [this]() {
@@ -334,7 +334,6 @@ void ScreenSpaceSkyBrowser::update() {
         _borderRadiusTimer = -1;
     }
     _borderRadiusTimer++;
-    
 
     ScreenSpaceRenderable::update();
     WwtCommunicator::update();


### PR DESCRIPTION
This PR adds a timer to the scale onChange function that allows the browser to load for 25 frame updates before applying the border radius change.