### PR TITLE
Various precision fixes for camera paths

### DIFF
--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -192,6 +192,9 @@ bool Path::hasReachedEnd() const {
         return true;
     }
 
+    // @TODO (emmbr, 2022-11-07) Handle linear paths separately, as they might 
+    // abort prematurely due to the "isPositionFinished" condition
+
     bool isPositionFinished = (_traveledDistance / pathLength()) >= 1.0;
 
     constexpr double RotationEpsilon = 0.0001;

--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -724,7 +724,7 @@ Path createPathFromDictionary(const ghoul::Dictionary& dictionary,
 
         LINFO(
             "Switching to a linear path, to avoid problems with precision due to "
-            "immense path length"
+            "immense path length or precision problems"
         );
 
         return createPathFromDictionary(dictionary, Path::Type::Linear);

--- a/src/navigation/pathnavigator.cpp
+++ b/src/navigation/pathnavigator.cpp
@@ -537,18 +537,25 @@ SceneGraphNode* PathNavigator::findNodeNearTarget(const SceneGraphNode* node) {
 }
 
 void PathNavigator::removeRollRotation(CameraPose& pose, double deltaTime) {
-    const glm::dvec3 anchorPos = anchor()->worldPosition();
+    // The actual position for the camera does not really matter. Use the origin,
+    // to avoid precision problems when we have large values for the position
+    const glm::dvec3 cameraPos = glm::dvec3(0.0);
     const glm::dvec3 cameraDir = glm::normalize(
         pose.rotation * Camera::ViewDirectionCameraSpace
     );
-    const double anchorToPosDistance = glm::distance(anchorPos, pose.position);
-    const double notTooCloseDistance = deltaTime * anchorToPosDistance;
-    glm::dvec3 lookAtPos = pose.position + notTooCloseDistance * cameraDir;
+
+    // The actual distance does not really matter either. Just have to far 
+    // enough away from the camera
+    constexpr double NotTooCloseDistance = 10000.0;
+
+    glm::dvec3 lookAtPos = cameraPos + NotTooCloseDistance * cameraDir;
+
     glm::dquat rollFreeRotation = ghoul::lookAtQuaternion(
-        pose.position,
+        cameraPos,
         lookAtPos,
         camera()->lookUpVectorWorldSpace()
     );
+
     pose.rotation = rollFreeRotation;
 }
 

--- a/src/navigation/pathnavigator.cpp
+++ b/src/navigation/pathnavigator.cpp
@@ -544,7 +544,7 @@ void PathNavigator::removeRollRotation(CameraPose& pose, double deltaTime) {
         pose.rotation * Camera::ViewDirectionCameraSpace
     );
 
-    // The actual distance does not really matter either. Just have to far 
+    // The actual distance does not really matter either. Just has to be far
     // enough away from the camera
     constexpr double NotTooCloseDistance = 10000.0;
 

--- a/src/util/collisionhelper.cpp
+++ b/src/util/collisionhelper.cpp
@@ -24,6 +24,8 @@
 
 #include <openspace/util/collisionhelper.h>
 
+#include <ghoul/misc/exception.h>
+
 namespace openspace::collision {
 
 // Source: http://paulbourke.net/geometry/circlesphere/raysphere.c


### PR DESCRIPTION
A collection of fixes for precision-related issues, all discovered when trying to address #2212. This is one of the most troublesome cases for the camera paths; Flying to a small (close to zero-bounding sphere) object far out in space. The position coordinates are so large that we can't always do the computations for the paths with sufficient precision. This PR adds a few checks for that in problematic situations

Also note that the RadialGrids do not get a valid bounding sphere computed until the first time they are enabled, which was why the problem appeared for the 1 AU size rings for the exoplanet systems specifically. Everything works better if the objects have correctly sized bounding spheres. 

Closes #2212, and probably also solves the "shaky" movements that users have reported when flying to ISS sometimes

