### PR TITLE
Apply FOV changes to all windows rather than only the first window

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -912,7 +912,9 @@ void setSgctDelegateFunctions() {
     sgctDelegate.setHorizFieldOfView = [](float hFovDeg) {
         ZoneScoped
 
-        Engine::instance().windows().front()->setHorizFieldOfView(hFovDeg);
+        for (std::unique_ptr<sgct::Window> const& w : Engine::instance().windows()) {
+            w->setHorizFieldOfView(hFovDeg);
+        }
     };
     #ifdef WIN32
     sgctDelegate.getNativeWindowHandle = [](size_t windowIndex) -> void* {


### PR DESCRIPTION
Fix for issue #2371, so that setting the field-of-view in one window (e.g. GUI window) will apply this setting to all windows (the reason for the issue is that the FOV change is applied only to the non-rendering GUI window).
This will help with the common scenario where one window only has the GUI (no rendering), and a second window is used for an external display.

Note that it may not be desirable to change the FOV on all windows. Another approach to fix this could be to tailor it only to the GUI-window scenario (e.g. **single_gui.json**, **gui_projector.json**), and look for a window with a "GUI" tag as is done [here](https://github.com/OpenSpace/OpenSpace/blob/f6988ea5b0e1e2816deca281069028d965f919f4/apps/OpenSpace/main.cpp#L816).

Please add a comment to this PR if you feel the second approach described above would be preferable.
