### PR TITLE
Fix bug for screenspace sky browser scale crash

### DIFF
--- a/modules/skybrowser/include/browser.h
+++ b/modules/skybrowser/include/browser.h
@@ -29,7 +29,7 @@
 #include <openspace/documentation/documentation.h>
 #include <openspace/properties/stringproperty.h>
 #include <openspace/properties/triggerproperty.h>
-#include <openspace/properties/vector/vec2property.h>
+#include <openspace/properties/vector/ivec2property.h>
 
 #ifdef _MSC_VER
 #pragma warning (push)
@@ -74,17 +74,17 @@ public:
     void updateBrowserSize();
     void reload();
 
-    glm::vec2 browserPixelDimensions() const;
+    void setRatio(float ratio);
     float browserRatio() const;
-    void setCallbackDimensions(const std::function<void(const glm::dvec2&)>& function);
 
 protected:
-    properties::Vec2Property _browserDimensions;
+    properties::IVec2Property _browserDimensions;
     properties::StringProperty _url;
     properties::TriggerProperty _reload;
 
     std::unique_ptr<ghoul::opengl::Texture> _texture;
 
+    void updateBrowserDimensions();
     void executeJavascript(const std::string& script) const;
 
     bool _isUrlDirty = false;

--- a/modules/skybrowser/include/screenspaceskybrowser.h
+++ b/modules/skybrowser/include/screenspaceskybrowser.h
@@ -52,7 +52,6 @@ public:
 
     double setVerticalFovWithScroll(float scroll);
     void setOpacity(float opacity);
-    void setRatio(float ratio);
     void setIdInBrowser() const;
     void setIsInitialized(bool isInitialized);
 
@@ -77,13 +76,11 @@ private:
 
     // Flags
     bool _isSyncedWithWwt = false;
-    bool _textureDimensionsIsDirty = false;
-    bool _ratioIsDirty = false;
-    bool _radiusIsDirty = false;
     bool _isInitialized = false;
+    bool _radiusIsDirty = false;
     int _borderRadiusTimer = -1;
 
-    float _ratio = 1.f;
+    float _lastTextureQuality = 1.f;
 };
 
 } // namespace openspace

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -105,7 +105,7 @@ documentation::Documentation ScreenSpaceSkyBrowser::Documentation() {
 ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary)
     : ScreenSpaceRenderable(dictionary)
     , WwtCommunicator(dictionary)
-    , _textureQuality(TextureQualityInfo, 0.5f, 0.25f, 1.f)
+    , _textureQuality(TextureQualityInfo, 1.f, 0.25f, 1.f)
     , _isHidden(IsHiddenInfo, true)
 {
     _identifier = makeUniqueIdentifier(_identifier);

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -122,16 +122,11 @@ ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary
     addProperty(_textureQuality);
     addProperty(_verticalFov);
 
-    _textureQuality.onChange([this]() { _textureDimensionsIsDirty = true; });
+    _textureQuality.onChange([this]() { _isDimensionsDirty = true; });
 
     if (global::windowDelegate->isMaster()) {
         _borderColor = randomBorderColor();
     }
-
-    _scale.onChange([this]() {
-        updateTextureResolution();
-        _borderRadiusTimer = 0;
-    });
 
     _useRadiusAzimuthElevation.onChange(
         [this]() {
@@ -160,7 +155,6 @@ ScreenSpaceSkyBrowser::~ScreenSpaceSkyBrowser() {
 bool ScreenSpaceSkyBrowser::initializeGL() {
     WwtCommunicator::initializeGL();
     ScreenSpaceRenderable::initializeGL();
-    updateTextureResolution();
     return true;
 }
 
@@ -192,19 +186,18 @@ void ScreenSpaceSkyBrowser::setIsInitialized(bool isInitialized) {
 }
 
 void ScreenSpaceSkyBrowser::updateTextureResolution() {
-    // Scale texture depending on the height of the window
-    // Set texture size to the actual pixel size it covers
-    glm::vec2 pixels = glm::vec2(global::windowDelegate->currentSubwindowSize());
+    // Check if texture quality has changed. If it has, adjust accordingly
+    if (abs(_textureQuality.value() - _lastTextureQuality) > glm::epsilon<float>()) {
+        float diffTextureQuality = _textureQuality / _lastTextureQuality;
+        glm::vec2 newRes = glm::vec2(_browserDimensions.value()) * diffTextureQuality;
+        _browserDimensions = glm::ivec2(newRes);
+        _lastTextureQuality = _textureQuality.value();
+    }
+    _objectSize = glm::ivec3(_browserDimensions.value(), 1);
 
-    // If the scale is 1, it covers half the window. Hence multiplication with 2
-    float newResY = pixels.y * 2.f * _scale;
-    float newResX = newResY * _ratio;
-    glm::vec2 newSize = glm::vec2(newResX , newResY) * _textureQuality.value();
-
-    _browserDimensions = glm::ivec2(newSize);
-    _texture->setDimensions(glm::ivec3(newSize, 1));
-    _objectSize = glm::ivec3(_texture->dimensions());
+    // The radius has to be updated when the texture resolution has changed
     _radiusIsDirty = true;
+    _borderRadiusTimer = 0;
 }
 
 void ScreenSpaceSkyBrowser::addDisplayCopy(const glm::vec3& raePosition, int nCopies) {
@@ -313,16 +306,9 @@ void ScreenSpaceSkyBrowser::render() {
 }
 
 void ScreenSpaceSkyBrowser::update() {
-    // Texture of window is 1x1 when minimized
-    bool isWindow = global::windowDelegate->currentSubwindowSize() != glm::ivec2(1);
-    bool isWindowResized = global::windowDelegate->windowHasResized();
-    if ((isWindowResized && isWindow) || _textureDimensionsIsDirty) {
+    // Check for dirty flags
+    if (_isDimensionsDirty) {
         updateTextureResolution();
-        _textureDimensionsIsDirty = false;
-    }
-    if (_ratioIsDirty) {
-        updateTextureResolution();
-        _ratioIsDirty = false;
     }
     if (_shouldReload) {
         _isInitialized = false;
@@ -367,11 +353,6 @@ glm::mat4 ScreenSpaceSkyBrowser::scaleMatrix() {
 
 void ScreenSpaceSkyBrowser::setOpacity(float opacity) {
     _opacity = opacity;
-}
-
-void ScreenSpaceSkyBrowser::setRatio(float ratio) {
-    _ratio = ratio;
-    _ratioIsDirty = true;
 }
 
 float ScreenSpaceSkyBrowser::opacity() const {


### PR DESCRIPTION
* Removed some functionality that was "too smart" and a bit unnecessary. The class adjusted its texture depending on window resolution etc, which is not ideal in a cluster setup
* Removed unused functions and variables
* Moved functions to classes where they made more sense