### PR TITLE
Fix sky browser space craft pointing

### DIFF
--- a/modules/skybrowser/include/screenspaceskybrowser.h
+++ b/modules/skybrowser/include/screenspaceskybrowser.h
@@ -49,12 +49,14 @@ public:
     float opacity() const;
     glm::dvec2 fineTuneVector(const glm::dvec2& drag);
     bool isInitialized() const;
+    bool pointSpaceCraft() const;
 
     double setVerticalFovWithScroll(float scroll);
     void setOpacity(float opacity);
     void setRatio(float ratio);
     void setIdInBrowser() const;
     void setIsInitialized(bool isInitialized);
+    void setPointSpaceCraft(bool point);
 
     void updateTextureResolution();
 
@@ -70,6 +72,7 @@ private:
     static constexpr int RadiusTimeOut = 25;
     properties::FloatProperty _textureQuality;
     properties::BoolProperty _isHidden;
+    properties::BoolProperty _pointSpaceCraft;
     std::vector<std::unique_ptr<properties::Vec3Property>> _displayCopies;
     std::vector<std::unique_ptr<properties::BoolProperty>> _showDisplayCopies;
 

--- a/modules/skybrowser/include/targetbrowserpair.h
+++ b/modules/skybrowser/include/targetbrowserpair.h
@@ -75,6 +75,7 @@ public:
     void setBrowserRatio(float ratio);
     void setVerticalFovWithScroll(float scroll);
     void setImageCollectionIsLoaded(bool isLoaded);
+    void setPointSpaceCraft(bool shouldPoint);
     void applyRoll();
 
     double verticalFov() const;
@@ -85,6 +86,7 @@ public:
     std::string browserId() const;
     std::string targetRenderableId() const;
     std::string targetNodeId() const;
+    bool pointSpaceCraft() const;
 
     ScreenSpaceSkyBrowser* browser() const;
     std::vector<int> selectedImages() const;

--- a/modules/skybrowser/skybrowsermodule.cpp
+++ b/modules/skybrowser/skybrowsermodule.cpp
@@ -537,7 +537,6 @@ scripting::LuaLibrary SkyBrowserModule::luaLibrary() const {
             codegen::lua::ScrollOverBrowser,
             codegen::lua::LoadingImageCollectionComplete,
             codegen::lua::ShowAllTargetsAndBrowsers,
-            codegen::lua::PointSpaceCraft,
             codegen::lua::GetWwtImageCollectionUrl,
             codegen::lua::StopAnimations,
             codegen::lua::SetBorderRadius,

--- a/modules/skybrowser/skybrowsermodule_lua.inl
+++ b/modules/skybrowser/skybrowsermodule_lua.inl
@@ -107,6 +107,14 @@ namespace {
                 );
                 module->startRotatingCamera(dir);
             }
+
+            if (selected->pointSpaceCraft()) {
+                global::eventEngine->publishEvent<events::EventPointSpacecraft>(
+                    image.equatorialSpherical.x,
+                    image.equatorialSpherical.y,
+                    module->spaceCraftAnimationTime()
+                    );
+            }
         }
     }
 }
@@ -794,22 +802,6 @@ namespace {
     for (const std::unique_ptr<TargetBrowserPair>& pair : pairs) {
         pair->setEnabled(show);
     }
-}
-
-/**
- * Point spacecraft to the equatorial coordinates the target points to. Takes an
- * identifier to a sky browser.
- */
-[[codegen::luawrap]] void pointSpaceCraft(std::string identifier) {
-    using namespace openspace;
-    SkyBrowserModule* module = global::moduleEngine->module<SkyBrowserModule>();
-    TargetBrowserPair* pair = module->pair(identifier);
-    glm::dvec2 equatorial = pair->targetDirectionEquatorial();
-    global::eventEngine->publishEvent<events::EventPointSpacecraft>(
-        equatorial.x,
-        equatorial.y,
-        module->spaceCraftAnimationTime()
-        );
 }
 
 /**

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -70,12 +70,22 @@ namespace {
         "be"
     };
 
+    constexpr openspace::properties::Property::PropertyInfo PointSpaceCraftInfo = {
+        "PointSpaceCraft",
+        "Point Space Craft",
+        "If checked, spacecrafts will point towards the coordinate of an image upon "
+        "selection."
+    };
+
     struct [[codegen::Dictionary(ScreenSpaceSkyBrowser)]] Parameters {
         // [[codegen::verbatim(TextureQualityInfo.description)]]
         std::optional<float> textureQuality;
 
         // [[codegen::verbatim(IsHiddenInfo.description)]]
         std::optional<bool> isHidden;
+
+        // [[codegen::verbatim(PointSpaceCraftInfo.description)]]
+        std::optional<bool> pointSpaceCraft;
     };
 
 #include "screenspaceskybrowser_codegen.cpp"
@@ -107,6 +117,7 @@ ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary
     , WwtCommunicator(dictionary)
     , _textureQuality(TextureQualityInfo, 0.5f, 0.25f, 1.f)
     , _isHidden(IsHiddenInfo, true)
+    , _pointSpaceCraft(PointSpaceCraftInfo, false)
 {
     _identifier = makeUniqueIdentifier(_identifier);
 
@@ -114,6 +125,7 @@ ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary
     const Parameters p = codegen::bake<Parameters>(dictionary);
     _textureQuality = p.textureQuality.value_or(_textureQuality);
     _isHidden = p.isHidden.value_or(_isHidden);
+    _pointSpaceCraft = p.pointSpaceCraft.value_or(_pointSpaceCraft);
 
     addProperty(_isHidden);
     addProperty(_url);
@@ -121,6 +133,7 @@ ScreenSpaceSkyBrowser::ScreenSpaceSkyBrowser(const ghoul::Dictionary& dictionary
     addProperty(_reload);
     addProperty(_textureQuality);
     addProperty(_verticalFov);
+    addProperty(_pointSpaceCraft);
 
     _textureQuality.onChange([this]() { _textureDimensionsIsDirty = true; });
 
@@ -183,12 +196,20 @@ bool ScreenSpaceSkyBrowser::isInitialized() const {
     return _isInitialized;
 }
 
+bool ScreenSpaceSkyBrowser::pointSpaceCraft() const {
+    return _pointSpaceCraft;
+}
+
 void ScreenSpaceSkyBrowser::setIdInBrowser() const {
     WwtCommunicator::setIdInBrowser(identifier());
 }
 
 void ScreenSpaceSkyBrowser::setIsInitialized(bool isInitialized) {
     _isInitialized = isInitialized;
+}
+
+void ScreenSpaceSkyBrowser::setPointSpaceCraft(bool point) {
+    _pointSpaceCraft = point;
 }
 
 void ScreenSpaceSkyBrowser::updateTextureResolution() {

--- a/modules/skybrowser/src/targetbrowserpair.cpp
+++ b/modules/skybrowser/src/targetbrowserpair.cpp
@@ -147,6 +147,10 @@ std::string TargetBrowserPair::targetNodeId() const {
     return _targetNode->identifier();
 }
 
+bool TargetBrowserPair::pointSpaceCraft() const {
+    return _browser->pointSpaceCraft();
+}
+
 double TargetBrowserPair::verticalFov() const {
     return _browser->verticalFov();
 }
@@ -271,6 +275,10 @@ void TargetBrowserPair::setImageCollectionIsLoaded(bool isLoaded) {
 
 void TargetBrowserPair::applyRoll() {
     _targetRenderable->applyRoll();
+}
+
+void TargetBrowserPair::setPointSpaceCraft(bool shouldPoint) {
+    _browser->setPointSpaceCraft(shouldPoint);
 }
 
 void TargetBrowserPair::incrementallyAnimateToCoordinate() {


### PR DESCRIPTION
This PR makes the pointing of the space craft a property you can set in the settings in the GUI. If checked, the spacecraft will be pointed when an image is selected. To be used with  https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/129