### PR TITLE
Replace profile actions/keybind editor button with single close button

### DIFF
--- a/apps/OpenSpace/ext/launcher/include/profile/actiondialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/actiondialog.h
@@ -101,7 +101,7 @@ private:
         QDialogButtonBox* saveButtons = nullptr;
     } _keybindingWidgets;
 
-    QDialogButtonBox* _mainButtons = nullptr;
+    QDialogButtonBox* _mainButton = nullptr;
 };
 
 #endif // __OPENSPACE_UI_LAUNCHER___ACTIONDIALOG___H__


### PR DESCRIPTION
In the profile editor for actions & keybindings: Switched from main save & cancel buttons to a single "Close" button. This new button doesn't really do anything, because of changes to save behavior in the actions and keybindings sections. Pressing Save in either of those sections will save the corresponding data.
The new Close button is necessary to be consistent with other editor dialog windows, because otherwise the user would have to manually X-close the window.