### PR TITLE
Improve behavior for gui window and separate render window

### DIFF
--- a/apps/OpenSpace/ext/launcher/src/sgctedit/sgctedit.cpp
+++ b/apps/OpenSpace/ext/launcher/src/sgctedit/sgctedit.cpp
@@ -277,6 +277,11 @@ sgct::config::Cluster SgctEdit::generateConfiguration() const {
         window.tags.push_back("GUI");
         window.draw2D = true;
         window.draw3D = false;
+
+        //Disable 2D rendering on all non-GUI windows
+        for (unsigned int w = 1; w < node.windows.size(); ++w) {
+            node.windows[w].draw2D = false;
+        }
     }
 
     cluster.nodes.push_back(node);

--- a/apps/OpenSpace/ext/launcher/src/sgctedit/sgctedit.cpp
+++ b/apps/OpenSpace/ext/launcher/src/sgctedit/sgctedit.cpp
@@ -278,8 +278,8 @@ sgct::config::Cluster SgctEdit::generateConfiguration() const {
         window.draw2D = true;
         window.draw3D = false;
 
-        //Disable 2D rendering on all non-GUI windows
-        for (unsigned int w = 1; w < node.windows.size(); ++w) {
+        // Disable 2D rendering on all non-GUI windows
+        for (size_t w = 1; w < node.windows.size(); ++w) {
             node.windows[w].draw2D = false;
         }
     }

--- a/config/gui_projector.json
+++ b/config/gui_projector.json
@@ -30,11 +30,10 @@
         },
         {
           "fullscreen": true,
-          "monitor": 1,
           "name": "OpenSpace",
           "draw2d": false,
           "stereo": "none",
-          "pos": { "x": 0, "y": 0 },
+          "pos": { "x": 1920, "y": 1080 },
           "size": { "x": 1920, "y": 1080 },
           "viewports": [
             {


### PR DESCRIPTION
Removes our usage of "monitor" key in sgct config files, but does not remove that key in the sgct repository code.
Update of config/gui_projector.json to position non-gui window in 2nd monitor (dimensions will need to be customized to fit).
If option "show only user interface on the first window" is checked, then all subsequent windows will have 2D rendering disabled.