### PR TITLE
Double renderbins for renderables

### DIFF
--- a/include/openspace/rendering/renderable.h
+++ b/include/openspace/rendering/renderable.h
@@ -99,6 +99,8 @@ public:
     void setRenderBin(RenderBin bin);
     bool matchesRenderBinMask(int binMask);
 
+    bool matchesSecondaryRenderBin(int binMask);
+
     void setFade(float fade);
 
     bool isVisible() const;
@@ -128,6 +130,10 @@ protected:
     SceneGraphNode* _parent = nullptr;
     bool _shouldUpdateIfDisabled = false;
     RenderBin _renderBin = RenderBin::Opaque;
+
+    // An optional renderbin that renderables can use for certain components, in cases
+    // where all parts of the renderable should not be rendered in the same bin
+    std::optional<RenderBin>_secondaryRenderBin = std::nullopt;
 
 private:
     // We only want the SceneGraphNode to be able manipulate the parent, so we don't want

--- a/include/openspace/rendering/renderable.h
+++ b/include/openspace/rendering/renderable.h
@@ -82,8 +82,9 @@ public:
 
     std::string_view typeAsString() const;
 
-    virtual void render(const RenderData& data, RendererTasks& rendererTask);
     virtual void update(const UpdateData& data);
+    virtual void render(const RenderData& data, RendererTasks& rendererTask);
+    virtual void renderSecondary(const RenderData& data, RendererTasks& rendererTask);
 
     // The 'surface' in this case is the interaction sphere of this renderable. In some
     // cases (i.e., planets) this corresponds directly to the physical surface, but in

--- a/include/openspace/rendering/renderable.h
+++ b/include/openspace/rendering/renderable.h
@@ -98,9 +98,9 @@ public:
 
     RenderBin renderBin() const;
     void setRenderBin(RenderBin bin);
-    bool matchesRenderBinMask(int binMask);
+    bool matchesRenderBinMask(int binMask) const noexcept;
 
-    bool matchesSecondaryRenderBin(int binMask);
+    bool matchesSecondaryRenderBin(int binMask) const noexcept;
 
     void setFade(float fade);
 
@@ -134,7 +134,7 @@ protected:
 
     // An optional renderbin that renderables can use for certain components, in cases
     // where all parts of the renderable should not be rendered in the same bin
-    std::optional<RenderBin>_secondaryRenderBin = std::nullopt;
+    std::optional<RenderBin> _secondaryRenderBin;
 
 private:
     // We only want the SceneGraphNode to be able manipulate the parent, so we don't want

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -667,7 +667,7 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
 
     // Use a secondary renderbin for labels, and other things that we want to be able to
     // render with transparency, on top of the globe, after the atmosphere step
-    _secondaryRenderBin = RenderBin::PreDeferredTransparent;
+    _secondaryRenderBin = RenderBin::PostDeferredTransparent;
 }
 
 void RenderableGlobe::initializeGL() {
@@ -728,14 +728,6 @@ void RenderableGlobe::render(const RenderData& data, RendererTasks& rendererTask
         data.camera.positionVec3(),
         data.modelTransform.translation
     );
-
-    if (matchesSecondaryRenderBin(data.renderBinMask)) {
-        _globeLabelsComponent.draw(data);
-
-        if (*_secondaryRenderBin != _renderBin) {
-            return;
-        }
-    }
 
     // This distance will be enough to render the globe as one pixel if the field of
     // view is 'fov' radians and the screen resolution is 'res' pixels.
@@ -813,6 +805,10 @@ void RenderableGlobe::render(const RenderData& data, RendererTasks& rendererTask
     }
 
     _lastChangedLayer = nullptr;
+}
+
+void RenderableGlobe::renderSecondary(const RenderData& data, RendererTasks&) {
+    _globeLabelsComponent.draw(data);
 }
 
 void RenderableGlobe::update(const UpdateData& data) {

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -64,6 +64,8 @@ namespace std {
 #endif
 
 namespace {
+    constexpr std::string_view _loggerCat = "RenderableGlobe";
+
     // Global flags to modify the RenderableGlobe
     constexpr bool LimitLevelByAvailableData = true;
     constexpr bool PerformFrustumCulling = true;
@@ -808,7 +810,12 @@ void RenderableGlobe::render(const RenderData& data, RendererTasks& rendererTask
 }
 
 void RenderableGlobe::renderSecondary(const RenderData& data, RendererTasks&) {
-    _globeLabelsComponent.draw(data);
+    try {
+        _globeLabelsComponent.draw(data);
+    }
+    catch (const ghoul::opengl::TextureUnit::TextureUnitError& e) {
+        LERROR(fmt::format("Error on drawing globe labels: '{}'", e.message));
+    }
 }
 
 void RenderableGlobe::update(const UpdateData& data) {

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -665,7 +665,8 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     }
     _generalProperties.shadowMapping.onChange(notifyShaderRecompilation);
 
-    // Use a secondary renderbin for labels
+    // Use a secondary renderbin for labels, and other things that we want to be able to
+    // render with transparency, on top of the globe, after the atmosphere step
     _secondaryRenderBin = RenderBin::PreDeferredTransparent;
 }
 

--- a/modules/globebrowsing/src/renderableglobe.h
+++ b/modules/globebrowsing/src/renderableglobe.h
@@ -103,6 +103,7 @@ public:
     bool isReady() const override;
 
     void render(const RenderData& data, RendererTasks& rendererTask) override;
+    void renderSecondary(const RenderData& data, RendererTasks&) override;
     void update(const UpdateData& data) override;
 
     SurfacePositionHandle calculateSurfacePositionHandle(

--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -268,7 +268,16 @@ void Renderable::setRenderBin(RenderBin bin) {
 }
 
 bool Renderable::matchesRenderBinMask(int binMask) {
-    return binMask & static_cast<int>(renderBin());
+    bool matchesPrimary = binMask & static_cast<int>(_renderBin);
+    bool matchesSecondary = matchesSecondaryRenderBin(binMask);
+    return matchesPrimary || matchesSecondary;
+}
+
+bool Renderable::matchesSecondaryRenderBin(int binMask) {
+    if (!_secondaryRenderBin.has_value()) {
+        return false;
+    }
+    return binMask & static_cast<int>(*_secondaryRenderBin);
 }
 
 void Renderable::setFade(float fade) {

--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -224,6 +224,8 @@ void Renderable::update(const UpdateData&) {}
 
 void Renderable::render(const RenderData&, RendererTasks&) {}
 
+void Renderable::renderSecondary(const RenderData&, RendererTasks&) {}
+
 void Renderable::setBoundingSphere(double boundingSphere) {
     _boundingSphere = boundingSphere;
 }
@@ -268,9 +270,7 @@ void Renderable::setRenderBin(RenderBin bin) {
 }
 
 bool Renderable::matchesRenderBinMask(int binMask) {
-    bool matchesPrimary = binMask & static_cast<int>(_renderBin);
-    bool matchesSecondary = matchesSecondaryRenderBin(binMask);
-    return matchesPrimary || matchesSecondary;
+    return binMask & static_cast<int>(_renderBin);
 }
 
 bool Renderable::matchesSecondaryRenderBin(int binMask) {

--- a/src/rendering/renderable.cpp
+++ b/src/rendering/renderable.cpp
@@ -269,11 +269,11 @@ void Renderable::setRenderBin(RenderBin bin) {
     _renderBin = bin;
 }
 
-bool Renderable::matchesRenderBinMask(int binMask) {
+bool Renderable::matchesRenderBinMask(int binMask) const noexcept {
     return binMask & static_cast<int>(_renderBin);
 }
 
-bool Renderable::matchesSecondaryRenderBin(int binMask) {
+bool Renderable::matchesSecondaryRenderBin(int binMask) const noexcept {
     if (!_secondaryRenderBin.has_value()) {
         return false;
     }

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -759,7 +759,7 @@ void SceneGraphNode::render(const RenderData& data, RendererTasks& tasks) {
     };
 
     if (_renderable->matchesSecondaryRenderBin(data.renderBinMask)) {
-        TracyGpuZone("Render Secondary")
+        TracyGpuZone("Render Secondary Bin")
         _renderable->renderSecondary(newData, tasks);
     }
 

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -737,7 +737,7 @@ void SceneGraphNode::render(const RenderData& data, RendererTasks& tasks) {
     }
 
     const bool visible = _renderable && _renderable->isVisible() &&
-        _renderable->isReady() && _renderable->matchesRenderBinMask(data.renderBinMask);
+        _renderable->isReady();
 
     if (!visible) {
         return;
@@ -747,21 +747,31 @@ void SceneGraphNode::render(const RenderData& data, RendererTasks& tasks) {
         return;
     }
 
+    RenderData newData = {
+        .camera = data.camera,
+        .time = data.time,
+        .renderBinMask = data.renderBinMask,
+        .modelTransform = {
+            .translation = _worldPositionCached,
+            .rotation = _worldRotationCached,
+            .scale = _worldScaleCached
+        }
+    };
+
+    if (_renderable->matchesSecondaryRenderBin(data.renderBinMask)) {
+        TracyGpuZone("Render Secondary")
+        _renderable->renderSecondary(newData, tasks);
+    }
+
+    if (!_renderable->matchesRenderBinMask(data.renderBinMask)) {
+        return;
+    }
+
     {
         TracyGpuZone("Render")
 
-        RenderData newData = {
-            .camera = data.camera,
-            .time = data.time,
-            .renderBinMask = data.renderBinMask,
-            .modelTransform = {
-                .translation = _worldPositionCached,
-                .rotation = _worldRotationCached,
-                .scale = _worldScaleCached
-            }
-        };
-
         _renderable->render(newData, tasks);
+
         if (_computeScreenSpaceValues) {
             computeScreenSpaceData(newData);
         }


### PR DESCRIPTION
Fixes https://github.com/OpenSpace/OpenSpace/issues/1610 and fixes https://github.com/OpenSpace/OpenSpace/issues/1617 by rendering the globelabels after the atmosphere

Also fixes a problem with opacity not really working for globelabels on celestial bodies with an atmosphere

And allows for rendering the upcoming GeoJson component as part of the renderable globe