### PR TITLE
Optimization update for RenderableTrailTrajectory

### DIFF
--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -86,7 +86,8 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo SweepChunkSizeInfo = {
         "SweepChunkSize",
         "Sweep Chunk Size",
-        "The number of vertices that will be calculated each frame whenever the trail needs to be recalculated. "
+        "The number of vertices that will be calculated each frame whenever the trail "
+        "needs to be recalculated. "
         "A greater value will result in more calculations per frame."
     };
 
@@ -206,12 +207,18 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
 
             _totalSampleInterval = _sampleInterval / _timeStampSubsamplingFactor;
 
-            // Cap _numberOfVertices in order to prevent overflow and extreme performance degredation/RAM usage 
-            _numberOfVertices = std::min(static_cast<unsigned int>(timespan / _totalSampleInterval), maxNumberOfVertices);
+            // Cap _numberOfVertices in order to prevent overflow and extreme performance
+            // degredation/RAM usage 
+            _numberOfVertices = std::min(
+                static_cast<unsigned int>(timespan / _totalSampleInterval),
+                maxNumberOfVertices
+            );
 
-            // We need to recalcuate the _totalSampleInterval if _numberOfVertices eqals maxNumberOfVertices
-            // If we don't do this the position for each vertex will not be correct for the number of vertices we are doing along the trail.
-            _totalSampleInterval = (_numberOfVertices == maxNumberOfVertices) ? (timespan / _numberOfVertices) : _totalSampleInterval;
+            // We need to recalcuate the _totalSampleInterval if _numberOfVertices eqals
+            // maxNumberOfVertices. If we don't do this the position for each vertex 
+            // will not be correct for the number of vertices we are doing along the trail.
+            _totalSampleInterval = (_numberOfVertices == maxNumberOfVertices) ? 
+                (timespan / _numberOfVertices) : _totalSampleInterval;
 
             // Make space for the vertices
             _vertexArray.clear();
@@ -243,7 +250,8 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             setBoundingSphere(glm::distance(_maxVertex, _minVertex) / 2.f);
         }
         else { 
-            // Early return as we don't need to render if we are still doing full sweep calculations
+            // Early return as we don't need to render if we are still 
+            // doing full sweep calculations
             return;
         }
         

--- a/modules/base/rendering/renderabletrailtrajectory.h
+++ b/modules/base/rendering/renderabletrailtrajectory.h
@@ -65,7 +65,7 @@ private:
     void reset();
 
     /// The number of vertices that we do calculations for during each frame of the full sweep pass
-    static const int _sweepChunk = 200;
+    unsigned int _sweepChunkSize = 200;
 
     /// The start time of the trail
     properties::StringProperty _startTime;
@@ -96,7 +96,7 @@ private:
     int _sweepIteration = 0;
 
     /// How many values do we need to compute given the distance between the start and end date and the desired sample interval
-    int _nValues = 0;
+    unsigned int _numberOfVertices = 0;
 
     double _totalSampleInterval = 0.0;
 

--- a/modules/base/rendering/renderabletrailtrajectory.h
+++ b/modules/base/rendering/renderabletrailtrajectory.h
@@ -98,7 +98,7 @@ private:
     /// How many values do we need to compute given the distance between the start and end date and the desired sample interval
     int _nValues = 0;
 
-    int _totalSampleInterval = 0;
+    double _totalSampleInterval = 0.0;
 
     /// Max and min vertex used to calculate the bounding sphere
     glm::vec3 _maxVertex;

--- a/modules/base/rendering/renderabletrailtrajectory.h
+++ b/modules/base/rendering/renderabletrailtrajectory.h
@@ -60,6 +60,13 @@ public:
     static documentation::Documentation Documentation();
 
 private:
+    
+    /// Reset some variables to default state
+    void reset();
+
+    /// The number of vertices that we do calculations for during each frame of the full sweep pass
+    static const int _sweepChunk = 200;
+
     /// The start time of the trail
     properties::StringProperty _startTime;
     /// The end time of the trail
@@ -84,6 +91,21 @@ private:
     double _start = 0.0;
     /// The conversion of the _endTime into the internal time format
     double _end = 0.0;
+
+    //tracker for sweeping
+    int _sweepIteration = 0;
+
+    //flag for if the sweep is done or not
+    bool _sweeping = false;
+
+    /// How many values do we need to compute given the distance between the start and end date and the desired sample interval
+    int _nValues = 0;
+
+    int _totalSampleInterval = 0;
+
+    /// Max and min vertex used to calculate the bounding sphere
+    glm::vec3 _maxVertex;
+    glm::vec3 _minVertex;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/renderabletrailtrajectory.h
+++ b/modules/base/rendering/renderabletrailtrajectory.h
@@ -92,11 +92,8 @@ private:
     /// The conversion of the _endTime into the internal time format
     double _end = 0.0;
 
-    //tracker for sweeping
+    /// Keeps track of the sweep iteration and is used to calculate which vertices we work on each frame.
     int _sweepIteration = 0;
-
-    //flag for if the sweep is done or not
-    bool _sweeping = false;
 
     /// How many values do we need to compute given the distance between the start and end date and the desired sample interval
     int _nValues = 0;

--- a/modules/base/rendering/renderabletrailtrajectory.h
+++ b/modules/base/rendering/renderabletrailtrajectory.h
@@ -64,7 +64,7 @@ private:
     /// Reset some variables to default state
     void reset();
 
-    /// The number of vertices that we do calculations for during each frame of the full sweep pass
+    /// The number of vertices that we calculate during each frame of the full sweep pass
     unsigned int _sweepChunkSize = 200;
 
     /// The start time of the trail
@@ -92,10 +92,11 @@ private:
     /// The conversion of the _endTime into the internal time format
     double _end = 0.0;
 
-    /// Keeps track of the sweep iteration and is used to calculate which vertices we work on each frame.
+    /// Tracks sweep iteration, is used to calculate which vertices to work on per frame
     int _sweepIteration = 0;
 
-    /// How many values do we need to compute given the distance between the start and end date and the desired sample interval
+    /// How many points do we need to compute given the distance between the 
+    /// start and end date and the desired sample interval
     unsigned int _numberOfVertices = 0;
 
     double _totalSampleInterval = 0.0;


### PR DESCRIPTION
## Optimization for `RenderableTrailTrajectory::update` function.

### Key changes:
- Implemented iterative approach for calculating all vertex positions in the trail. Instead of doing all calculations at once, which takes time and locks the thread, we instead calculate a smaller portion (chunk) of the vertices each frame. Once all vertices are calculated we commit it for rendering.
- Moved the calculations for the bounding sphere into the "vertex calculation" loop in order to minimize unnecessary looping. Before we also calculated the bounding sphere each frame, but this is now changed to only be done after each full sweep.


### These changes have the following effect:
- Iterative approach: The program now runs without locking up when first loading large RenderableTrailTrajectories into the scene, albeit at a lower framerate.
- Bounding Sphere: Since bounding sphere calculations are only done when needed. 
Example, when using scene with both Voyager 1 and 2 trails, my setup went from 80-100 fps to 200-400 fps.

### Before:

https://user-images.githubusercontent.com/9076357/220638897-90bfc491-c3b2-4d94-a9d1-71a346a8637a.mp4

### After:

https://user-images.githubusercontent.com/9076357/220638961-d4176cd8-3db0-4f5e-ad2b-b7f0071834df.mp4

