### PR TITLE
Switch to std::list for adding & removing assets in deterministic order

### DIFF
--- a/include/openspace/scene/assetmanager.h
+++ b/include/openspace/scene/assetmanager.h
@@ -29,7 +29,7 @@
 #include <filesystem>
 #include <optional>
 #include <unordered_map>
-#include <unordered_set>
+#include <list>
 
 namespace openspace {
 
@@ -164,10 +164,10 @@ private:
 
     /// This list contains all of the assets that are queued to be loading in the next
     /// update call
-    std::unordered_set<std::string> _assetAddQueue;
+    std::list<std::string> _assetAddQueue;
 
     /// The list contains all of the assets that should be removed in the next update call
-    std::unordered_set<std::string> _assetRemoveQueue;
+    std::list<std::string> _assetRemoveQueue;
 
     /// This list contains all assets that need to be initialized in the next update call
     std::vector<Asset*> _toBeInitialized;

--- a/src/scene/assetmanager.cpp
+++ b/src/scene/assetmanager.cpp
@@ -300,24 +300,23 @@ void AssetManager::update() {
 void AssetManager::add(const std::string& path) {
     ghoul_precondition(!path.empty(), "Path must not be empty");
     // First check if the path is already in the remove queue. If so, remove it from there
-    const auto it = _assetRemoveQueue.find(path);
-    if (it != _assetRemoveQueue.end()) {
-        _assetRemoveQueue.erase(it);
-    }
-
-    _assetAddQueue.insert(path);
+    _assetRemoveQueue.remove_if(
+        [&path](const std::string& value) {
+            return (path == value);
+        }
+    );
+    _assetAddQueue.push_back(path);
 }
 
 void AssetManager::remove(const std::string& path) {
     ghoul_precondition(!path.empty(), "Path must not be empty");
-
     // First check if the path is already in the add queue. If so, remove it from there
-    const auto it = _assetAddQueue.find(path);
-    if (it != _assetAddQueue.end()) {
-        _assetAddQueue.erase(it);
-    }
-
-    _assetRemoveQueue.insert(path);
+    _assetAddQueue.remove_if(
+        [&path](const std::string& value) {
+            return (path == value);
+        }
+    );
+    _assetRemoveQueue.push_back(path);
 }
 
 std::vector<const Asset*> AssetManager::allAssets() const {

--- a/src/scene/assetmanager.cpp
+++ b/src/scene/assetmanager.cpp
@@ -300,22 +300,14 @@ void AssetManager::update() {
 void AssetManager::add(const std::string& path) {
     ghoul_precondition(!path.empty(), "Path must not be empty");
     // First check if the path is already in the remove queue. If so, remove it from there
-    _assetRemoveQueue.remove_if(
-        [&path](const std::string& value) {
-            return (path == value);
-        }
-    );
+    _assetRemoveQueue.remove(path);
     _assetAddQueue.push_back(path);
 }
 
 void AssetManager::remove(const std::string& path) {
     ghoul_precondition(!path.empty(), "Path must not be empty");
     // First check if the path is already in the add queue. If so, remove it from there
-    _assetAddQueue.remove_if(
-        [&path](const std::string& value) {
-            return (path == value);
-        }
-    );
+    _assetAddQueue.remove(path);
     _assetRemoveQueue.push_back(path);
 }
 


### PR DESCRIPTION
See issue #2513 for the problem of non-deterministic asset add/removal, with an example of a problem caused by it. This change of containers for assets to be added/removed seems to avoid the problem.
This change was run on the linux image test server. Results were positive but with a few possible artifacts due to this change. Needs some additional testing.