### PR TITLE
Updating assets that use updated Horizons data files

### DIFF
--- a/data/assets/scene/solarsystem/interstellar/c-2019_q4_borisov.asset
+++ b/data/assets/scene/solarsystem/interstellar/c-2019_q4_borisov.asset
@@ -4,7 +4,7 @@ local trajectory = asset.syncedResource({
   Name = "C-2019 Q4 Borisov Trajectory",
   Type = "HttpSynchronization",
   Identifier = "borisov_horizons",
-  Version = 2
+  Version = 3
 })
 
 local C2019Q4BorisovTrail = {

--- a/data/assets/scene/solarsystem/interstellar/oumuamua.asset
+++ b/data/assets/scene/solarsystem/interstellar/oumuamua.asset
@@ -4,7 +4,7 @@ local trajectory = asset.syncedResource({
   Name = "'Oumuamua Trajectory",
   Type = "HttpSynchronization",
   Identifier = "oumuamua_horizons",
-  Version = 2
+  Version = 3
 })
 
 local OumuamuaTrail = {

--- a/data/assets/scene/solarsystem/sssb/amor_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/amor_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Amor Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_amor_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/apollo_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/apollo_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Apollo Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_apollo_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/astraea.asset
+++ b/data/assets/scene/solarsystem/sssb/astraea.asset
@@ -4,7 +4,7 @@ local horizons = asset.syncedResource({
   Name = "5 Astraea Trajectory",
   Type = "HttpSynchronization",
   Identifier = "astraea_horizons",
-  Version = 1
+  Version = 2
 })
 
 local AstraeaTrail = {

--- a/data/assets/scene/solarsystem/sssb/aten_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/aten_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Aten Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_aten_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/atira_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/atira_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Atira Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_atira_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/c2019y4atlas.asset
+++ b/data/assets/scene/solarsystem/sssb/c2019y4atlas.asset
@@ -4,7 +4,7 @@ local orbit = asset.syncedResource({
   Name = "Comet C/2019 Y4 ATLAS",
   Type = "HttpSynchronization",
   Identifier = "horizons_c2019y4atlas",
-  Version = 2
+  Version = 3
 }) .. "c2019y4atlas.hrz"
 
 local C2019Y4AtlasTrail = {

--- a/data/assets/scene/solarsystem/sssb/centaur_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/centaur_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Centaur Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_centaur_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/chiron-type_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/chiron-type_comet.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Chiron-type Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_chiron-type_comet",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/encke-type_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/encke-type_comet.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Encke-type Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_encke-type_comet",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/halley-type_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/halley-type_comet.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Halley-type Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_halley-type_comet",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/inner_main_belt_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/inner_main_belt_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Inner Main Belt Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_inner_main_belt_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/itokawa.asset
+++ b/data/assets/scene/solarsystem/sssb/itokawa.asset
@@ -5,7 +5,7 @@ local orbit = asset.syncedResource({
   Name = "Itokawa Orbit",
   Type = "HttpSynchronization",
   Identifier = "itokawa_horizons",
-  Version = 1
+  Version = 2
 })
 
 local model = asset.syncedResource({

--- a/data/assets/scene/solarsystem/sssb/jupiter-family_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/jupiter-family_comet.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Jupiter Family Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_jupiter-family_comet",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/jupiter_trojan_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/jupiter_trojan_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Jupiter Trojan Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_jupiter_trojan_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/main_belt_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/main_belt_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Main Belt Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_main_belt_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/mars-crossing_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/mars-crossing_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Mars-Crossing Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_mars-crossing_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/outer_main_belt_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/outer_main_belt_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Outer Main Belt Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_outer_main_belt_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/pha.asset
+++ b/data/assets/scene/solarsystem/sssb/pha.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Potentially hazardous Asteroids)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_pha",
-  Version = 1
+  Version = 2
 })
 
 local object = {

--- a/data/assets/scene/solarsystem/sssb/swifttuttle.asset
+++ b/data/assets/scene/solarsystem/sssb/swifttuttle.asset
@@ -4,7 +4,7 @@ local sync = asset.syncedResource({
   Name = "Swift Tuttle Orbit",
   Type = "HttpSynchronization",
   Identifier = "swift_tuttle_horizons",
-  Version = 2
+  Version = 3
 })
 
 local SwiftTuttleTrail = {

--- a/data/assets/scene/solarsystem/sssb/transneptunian_object_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/transneptunian_object_asteroid.asset
@@ -4,7 +4,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Trans-Neptunian Object Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_transneptunian_object_asteroid",
-  Version = 1
+  Version = 2
 })
 
 local object = {


### PR DESCRIPTION
All assets that use Horizons ephemeris were checked recently for updated positions. For all files where the ephemeris had been updated, the new file was downloaded from JPL and added to the Utah data server with an updated version number.
For testing, it will be necessary to switch the openspace.cfg file's sync entry to:
`HttpSynchronizationRepositories = { "http://openspace.sci.utah.edu/request" }`
since data.openspaceproject.com does not yet have this data.
