### PR TITLE
Issue/2227 - Option to just specify a scene graph node in profile editor camera dialog

### DIFF
--- a/apps/OpenSpace/ext/launcher/include/profile/cameradialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/cameradialog.h
@@ -54,6 +54,7 @@ private:
     void createWidgets();
     QWidget* createNavStateWidget();
     QWidget* createGeoWidget();
+    QWidget* createNodeWidget();
 
     void addErrorMsg(QString errorDescription);
     bool areRequiredFormsFilledAndValid();
@@ -80,6 +81,10 @@ private:
         QLineEdit* longitude = nullptr;
         QLineEdit* altitude = nullptr;
     } _geoState;
+
+    struct {
+        QLineEdit* anchor = nullptr;
+    } _nodeState;
 
     QLabel* _errorMsg = nullptr;
 };

--- a/apps/OpenSpace/ext/launcher/include/profile/cameradialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/cameradialog.h
@@ -52,15 +52,20 @@ private slots:
 
 private:
     void createWidgets();
+    QWidget* createNodeWidget();
     QWidget* createNavStateWidget();
     QWidget* createGeoWidget();
-    QWidget* createNodeWidget();
 
     void addErrorMsg(QString errorDescription);
     bool areRequiredFormsFilledAndValid();
 
     std::optional<openspace::Profile::CameraType>* _camera = nullptr;
     QTabWidget* _tabWidget = nullptr;
+
+    struct {
+        QLineEdit* anchor = nullptr;
+    } _nodeState;
+
     struct {
         QLineEdit* anchor = nullptr;
         QLineEdit* aim = nullptr;
@@ -81,10 +86,6 @@ private:
         QLineEdit* longitude = nullptr;
         QLineEdit* altitude = nullptr;
     } _geoState;
-
-    struct {
-        QLineEdit* anchor = nullptr;
-    } _nodeState;
 
     QLabel* _errorMsg = nullptr;
 };

--- a/apps/OpenSpace/ext/launcher/include/profile/cameradialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/cameradialog.h
@@ -64,6 +64,7 @@ private:
 
     struct {
         QLineEdit* anchor = nullptr;
+        QLineEdit* height = nullptr;
     } _nodeState;
 
     struct {

--- a/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
+++ b/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
@@ -153,6 +153,7 @@ CameraDialog  QLabel#camera-description {
   color:rgb(96, 96, 96);
   margin: 1em;
   margin-top: 0.2em;
+  margin-bottom: 0.4em;
 }
 
 /*

--- a/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
+++ b/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
@@ -149,6 +149,12 @@ CameraDialog  QLabel#error-message {
   min-width: 10em;
 }
 
+CameraDialog  QLabel#camera-description {
+  color:rgb(96, 96, 96);
+  margin: 1em;
+  margin-top: 0.2em;
+}
+
 /*
  * ScriptlogDialog
  */

--- a/apps/OpenSpace/ext/launcher/src/profile/cameradialog.cpp
+++ b/apps/OpenSpace/ext/launcher/src/profile/cameradialog.cpp
@@ -180,7 +180,7 @@ QWidget* CameraDialog::createNodeWidget() {
     QLabel* description = new QLabel;
     description->setWordWrap(true);
     description->setAlignment(Qt::AlignCenter);
-    description->setObjectName("description");
+    description->setObjectName("camera-description");
     description->setText(
         "Set the camera position based on a given scene graph node. \n \n "
         "Automatically computes a position that frames the object, and if possible, "
@@ -188,7 +188,6 @@ QWidget* CameraDialog::createNodeWidget() {
     );
 
     mainLayout->addWidget(description);
-    mainLayout->addSpacerItem(new QSpacerItem(0, 10));
 
     {
         QWidget* box = new QWidget;
@@ -217,14 +216,13 @@ QWidget* CameraDialog::createNavStateWidget() {
     QLabel* description = new QLabel;
     description->setWordWrap(true);
     description->setAlignment(Qt::AlignCenter);
-    description->setObjectName("camerdescription");
+    description->setObjectName("camera-description");
     description->setText(
         "Set the camera position from a navigation state. \n"
         "Allows for setting an exact view or camera position at start-up."
     );
 
     mainLayout->addWidget(description);
-    mainLayout->addSpacerItem(new QSpacerItem(0, 10));
 
     {
         QWidget* box = new QWidget;
@@ -330,13 +328,12 @@ QWidget* CameraDialog::createGeoWidget() {
     QLabel* description = new QLabel;
     description->setWordWrap(true);
     description->setAlignment(Qt::AlignCenter);
-    description->setObjectName("camerdescription");
+    description->setObjectName("camera-description");
     description->setText(
         "Sets the camera position from a geodetic position of a globe (e.g a planet/moon)."
     );
 
     mainLayout->addWidget(description);
-    mainLayout->addSpacerItem(new QSpacerItem(0, 10));
 
     {
 

--- a/apps/OpenSpace/ext/launcher/src/profile/cameradialog.cpp
+++ b/apps/OpenSpace/ext/launcher/src/profile/cameradialog.cpp
@@ -32,11 +32,12 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QKeyEvent>
-#include <QTabWidget> 
+#include <QTabWidget>
 
 namespace {
     constexpr int CameraTypeNav = 0;
     constexpr int CameraTypeGeo = 1;
+    constexpr int CameraTypeNode = 2;
 
     template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
     template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
@@ -110,6 +111,11 @@ CameraDialog::CameraDialog(QWidget* parent,
                     _geoState.altitude->clear();
                 }
                 tabSelect(CameraTypeGeo);
+            },
+            [this](const openspace::Profile::CameraGoToNode& node) {
+                _tabWidget->setCurrentIndex(CameraTypeNode);
+                _nodeState.anchor->setText(QString::fromStdString(node.anchor));
+                tabSelect(CameraTypeNode);
             }
         }, type);
     }
@@ -131,6 +137,8 @@ CameraDialog::CameraDialog(QWidget* parent,
         _geoState.latitude->clear();
         _geoState.longitude->clear();
         _geoState.altitude->clear();
+
+        _nodeState.anchor->clear();
     }
 }
 
@@ -140,6 +148,7 @@ void CameraDialog::createWidgets() {
     connect(_tabWidget, &QTabWidget::tabBarClicked, this, &CameraDialog::tabSelect);
     _tabWidget->addTab(createNavStateWidget(), "Navigation State");
     _tabWidget->addTab(createGeoWidget(), "Geo State");
+    _tabWidget->addTab(createNodeWidget(), "Scene Graph Node");
     layout->addWidget(_tabWidget);
 
     layout->addWidget(new Line);
@@ -287,6 +296,18 @@ QWidget* CameraDialog::createGeoWidget() {
     return box;
 }
 
+QWidget* CameraDialog::createNodeWidget() {
+    QWidget* box = new QWidget;
+    QGridLayout* layout = new QGridLayout(box);
+
+    layout->addWidget(new QLabel("Anchor:"), 0, 0);
+    _nodeState.anchor = new QLineEdit;
+    _nodeState.anchor->setToolTip("Anchor camera to this scene graph node");
+    layout->addWidget(_nodeState.anchor, 0, 1);
+
+    return box;
+}
+
 bool CameraDialog::areRequiredFormsFilledAndValid() {
     bool allFormsOk = true;
     _errorMsg->clear();
@@ -355,6 +376,14 @@ bool CameraDialog::areRequiredFormsFilledAndValid() {
             addErrorMsg("Longitude value is not in +/- 180.0 range");
         }
     }
+
+    if (_tabWidget->currentIndex() == CameraTypeNode) {
+        if (_nodeState.anchor->text().isEmpty()) {
+            allFormsOk = false;
+            addErrorMsg("Anchor is empty");
+        }
+    }
+
     return allFormsOk;
 }
 
@@ -418,6 +447,11 @@ void CameraDialog::approved() {
         }
         *_camera = std::move(geo);
     }
+    else if (_tabWidget->currentIndex() == CameraTypeNode) {
+        openspace::Profile::CameraGoToNode node;
+        node.anchor = _nodeState.anchor->text().toStdString();
+        *_camera = std::move(node);
+    }
 
     accept();
 }
@@ -425,11 +459,14 @@ void CameraDialog::approved() {
 void CameraDialog::tabSelect(int tabIndex) {
     _errorMsg->clear();
 
-    if (tabIndex == 0) {
+    if (tabIndex == CameraTypeNav) {
         _navState.anchor->setFocus(Qt::OtherFocusReason);
     }
-    else if (tabIndex == 1) {
+    else if (tabIndex == CameraTypeGeo) {
         _geoState.anchor->setFocus(Qt::OtherFocusReason);
+    }
+    else if (tabIndex == CameraTypeNode) {
+        _nodeState.anchor->setFocus(Qt::OtherFocusReason);
     }
     else {
         throw std::logic_error("Unknown tab index");

--- a/apps/OpenSpace/ext/launcher/src/profile/cameradialog.cpp
+++ b/apps/OpenSpace/ext/launcher/src/profile/cameradialog.cpp
@@ -55,6 +55,19 @@ namespace {
         }
         return true;
     }
+
+    bool isNumericalLargerThan(QLineEdit* le, float limit) {
+        QString s = le->text();
+        bool validConversion = false;
+        float value = s.toFloat(&validConversion);
+        if (!validConversion) {
+            return false;
+        }
+        if (value > limit) {
+            return true;
+        }
+        return false;
+    }
 } // namespace
 
 CameraDialog::CameraDialog(QWidget* parent,
@@ -397,6 +410,12 @@ bool CameraDialog::areRequiredFormsFilledAndValid() {
         if (_nodeState.anchor->text().isEmpty()) {
             allFormsOk = false;
             addErrorMsg("Anchor is empty");
+        }
+        if (!_nodeState.height->text().isEmpty()) {
+            if (!isNumericalLargerThan(_nodeState.height, 0.f)) {
+                allFormsOk = false;
+                addErrorMsg("Height must be larger than zero");
+            }
         }
     }
 

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -53,6 +53,7 @@ namespace openspace::interaction {
 
 struct JoystickInputStates;
 struct NavigationState;
+struct NodeCameraStateSpec;
 struct WebsocketInputStates;
 class KeyframeNavigator;
 class OrbitalNavigator;
@@ -145,8 +146,23 @@ public:
 
     void loadNavigationState(const std::string& filepath);
 
+    /**
+     * Set camera state from a provided navigation state next frame. The actual position
+     * will computed from the scene in the same frame as it is set.
+     *
+     * \param state the navigation state to compute a camera positon from
+     */
     void setNavigationStateNextFrame(const NavigationState& state);
-    void setCameraPoseNextFrame(CameraPose pose, std::string anchor);
+
+    /**
+     * Set camera state from a provided node based camera specification structure, next
+     * frame. The camera position will be computed to look at the node provided in the
+     * node info. The actual position will computed from the scene in the same frame as
+     * it is set.
+     *
+     * \param spec the node specification from which to compute the resulting camera pose
+     */
+    void setCameraFromNodeSpecNextFrame(NodeCameraStateSpec spec);
 
     /**
     * \return The Lua library that contains all Lua functions available to affect the
@@ -172,15 +188,7 @@ private:
     KeyframeNavigator _keyframeNavigator;
     PathNavigator _pathNavigator;
 
-    struct PendingPoseInfo {
-        std::string anchor;
-        CameraPose pose;
-    };
-
-    // The camera pose for navigation states can't be immediately evaluated on startup,
-    // as the required scene graph nodes are not initialized. So, we need to handle
-    // camera poses and navigation states differently...
-    std::optional<std::variant<PendingPoseInfo, NavigationState>> _pendingPose;
+    std::optional<std::variant<NodeCameraStateSpec, NavigationState>> _pendingState;
 
     properties::BoolProperty _disableKeybindings;
     properties::BoolProperty _disableMouseInputs;

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -171,7 +171,7 @@ public:
     static scripting::LuaLibrary luaLibrary();
 
 private:
-    void applyPendingPose();
+    void applyPendingState();
     void updateCameraTransitions();
     void clearGlobalJoystickStates();
 

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -174,11 +174,13 @@ private:
 
     struct PendingPoseInfo {
         std::string anchor;
-        std::string aim;
         CameraPose pose;
     };
 
-    std::optional<PendingPoseInfo> _pendingPose;
+    // The camera pose for navigation states can't be immediately evaluated on startup,
+    // as the required scene graph nodes are not initialized. So, we need to handle
+    // camera poses and navigation states differently...
+    std::optional<std::variant<PendingPoseInfo, NavigationState>> _pendingPose;
 
     properties::BoolProperty _disableKeybindings;
     properties::BoolProperty _disableMouseInputs;

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -145,7 +145,8 @@ public:
 
     void loadNavigationState(const std::string& filepath);
 
-    void setNavigationStateNextFrame(NavigationState state);
+    void setNavigationStateNextFrame(const NavigationState& state);
+    void setCameraPoseNextFrame(CameraPose pose, std::string anchor);
 
     /**
     * \return The Lua library that contains all Lua functions available to affect the
@@ -154,7 +155,7 @@ public:
     static scripting::LuaLibrary luaLibrary();
 
 private:
-    void applyNavigationState(const NavigationState& ns);
+    void applyPendingPose();
     void updateCameraTransitions();
     void clearGlobalJoystickStates();
 
@@ -171,7 +172,13 @@ private:
     KeyframeNavigator _keyframeNavigator;
     PathNavigator _pathNavigator;
 
-    std::optional<NavigationState> _pendingNavigationState;
+    struct PendingPoseInfo {
+        std::string anchor;
+        std::string aim;
+        CameraPose pose;
+    };
+
+    std::optional<PendingPoseInfo> _pendingPose;
 
     properties::BoolProperty _disableKeybindings;
     properties::BoolProperty _disableMouseInputs;

--- a/include/openspace/navigation/waypoint.h
+++ b/include/openspace/navigation/waypoint.h
@@ -63,7 +63,7 @@ private:
  */
 Waypoint waypointFromCamera();
 
-struct NodeInfo {
+struct NodeCameraStateSpec {
     std::string identifier;
     std::optional<glm::dvec3> position;
     std::optional<double> height;
@@ -73,19 +73,19 @@ struct NodeInfo {
 // @TODO (2023-05-16, emmbr) Allow different light sources, not only the 'Sun'
 /**
  * Compute a waypoint from information about a scene graph node and a previous waypoint,
- * where the camera is facing the given node. If there is a 'Sun' node in the scene, it
- * will possibly be used to compute a position on the lit side of the object.
+ * where the camera will be facing the given node. If there is a 'Sun' node in the scene,
+ * it will possibly be used to compute a position on the lit side of the object.
  *
- * \param info information about the node to create the wapoint from. Minimal
- *             information is the identifier of the node, but a position or height above
- *             the bounding sphere may also be given.
+ * \param spec details about the node and state to create the waypoint from. Minimal
+ *             information is the identifier of the node, but a position or height
+ *             above the bounding sphere may also be given.
  * \param startPoint an optional previous waypoint. If not specified, the current camera
  *                   position will be used.
  * \param userLinear if true, the new waypoint will be computed along a straight line
  *                   from the start waypoint to the scene graph node or position.
  * \return the computed WayPoint
  */
-Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
+Waypoint computeWaypointFromNodeInfo(const NodeCameraStateSpec& spec,
     std::optional<const Waypoint> startPoint = std::nullopt, bool useLinear = false);
 
 } // namespace openspace::interaction

--- a/include/openspace/navigation/waypoint.h
+++ b/include/openspace/navigation/waypoint.h
@@ -27,6 +27,7 @@
 
 #include <openspace/camera/camerapose.h>
 #include <ghoul/glm.h>
+#include <optional>
 #include <string>
 
 namespace openspace { class SceneGraphNode; }
@@ -51,9 +52,41 @@ public:
 private:
     CameraPose _pose;
     std::string _nodeIdentifier;
-    // to be able to handle nodes with faulty bounding spheres
+    // To be able to handle nodes with faulty bounding spheres
     double _validBoundingSphere = 0.0;
 };
+
+/**
+ * Compute a waypoint from the current camera position.
+ *
+ * \return the computed WayPoint
+ */
+Waypoint waypointFromCamera();
+
+struct NodeInfo {
+    std::string identifier;
+    std::optional<glm::dvec3> position;
+    std::optional<double> height;
+    bool useTargetUpDirection = false;
+};
+
+// @TODO (2023-05-16, emmbr) Allow different light sources, not only the 'Sun'
+/**
+ * Compute a waypoint from information about a scene graph node and a previous waypoint,
+ * where the camera is facing the given node. If there is a 'Sun' node in the scene, it
+ * will possibly be used to compute a position on the lit side of the object.
+ *
+ * \param info information about the node to create the wapoint from. Minimal
+ *             information is the identifier of the node, but a position or height above
+ *             the bounding sphere may also be given.
+ * \param startPoint an optional previous waypoint. If not specified, the current camera
+ *                   position will be used.
+ * \param userLinear if true, the new waypoint will be computed along a straight line
+ *                   from the start waypoint to the scene graph node or position.
+ * \return the computed WayPoint
+ */
+Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
+    std::optional<const Waypoint> startPoint = std::nullopt, bool useLinear = false);
 
 } // namespace openspace::interaction
 

--- a/include/openspace/navigation/waypoint.h
+++ b/include/openspace/navigation/waypoint.h
@@ -86,7 +86,7 @@ struct NodeCameraStateSpec {
  * \return the computed WayPoint
  */
 Waypoint computeWaypointFromNodeInfo(const NodeCameraStateSpec& spec,
-    std::optional<const Waypoint> startPoint = std::nullopt, bool useLinear = false);
+    std::optional<Waypoint> startPoint = std::nullopt, bool useLinear = false);
 
 } // namespace openspace::interaction
 

--- a/include/openspace/scene/profile.h
+++ b/include/openspace/scene/profile.h
@@ -106,6 +106,12 @@ public:
         bool startPaused = false;
     };
 
+    struct CameraGoToNode {
+        static constexpr std::string_view Type = "goToNode";
+
+        std::string anchor;
+    };
+
     struct CameraNavState {
         static constexpr std::string_view Type = "setNavigationState";
 
@@ -127,13 +133,7 @@ public:
         std::optional<double> altitude;
     };
 
-    struct CameraGoToNode {
-        static constexpr std::string_view Type = "goToNode";
-
-        std::string anchor;
-    };
-
-    using CameraType = std::variant<CameraNavState, CameraGoToGeo, CameraGoToNode>;
+    using CameraType = std::variant<CameraGoToNode, CameraNavState, CameraGoToGeo>;
 
     Profile() = default;
     explicit Profile(const std::string& content);

--- a/include/openspace/scene/profile.h
+++ b/include/openspace/scene/profile.h
@@ -110,6 +110,7 @@ public:
         static constexpr std::string_view Type = "goToNode";
 
         std::string anchor;
+        std::optional<double> height;
     };
 
     struct CameraNavState {

--- a/include/openspace/scene/profile.h
+++ b/include/openspace/scene/profile.h
@@ -154,7 +154,7 @@ public:
     /// Removes an asset unless the `ignoreUpdates` member is set to `true`
     void removeAsset(const std::string& path);
 
-    static constexpr Version CurrentVersion = Version{ 1, 2 };
+    static constexpr Version CurrentVersion = Version{ 1, 3 };
 
     Version version = CurrentVersion;
     std::vector<Module> modules;

--- a/include/openspace/scene/profile.h
+++ b/include/openspace/scene/profile.h
@@ -127,7 +127,13 @@ public:
         std::optional<double> altitude;
     };
 
-    using CameraType = std::variant<CameraNavState, CameraGoToGeo>;
+    struct CameraGoToNode {
+        static constexpr std::string_view Type = "goToNode";
+
+        std::string anchor;
+    };
+
+    using CameraType = std::variant<CameraNavState, CameraGoToGeo, CameraGoToNode>;
 
     Profile() = default;
     explicit Profile(const std::string& content);

--- a/modules/base/lightsource/scenegraphlightsource.cpp
+++ b/modules/base/lightsource/scenegraphlightsource.cpp
@@ -42,7 +42,7 @@ namespace {
         openspace::properties::Property::Visibility::NoviceUser
     };
 
-    constexpr openspace::properties::Property::PropertyInfo NodeInfo = {
+    constexpr openspace::properties::Property::PropertyInfo NodeCameraStateInfo = {
         "Node",
         "Node",
         "The identifier of the scene graph node to follow",
@@ -53,7 +53,7 @@ namespace {
         // [[codegen::verbatim(IntensityInfo.description)]]
         std::optional<float> intensity;
 
-        // [[codegen::verbatim(NodeInfo.description)]]
+        // [[codegen::verbatim(NodeCameraStateInfo.description)]]
         std::string node [[codegen::identifier()]];
     };
 #include "scenegraphlightsource_codegen.cpp"
@@ -67,7 +67,7 @@ documentation::Documentation SceneGraphLightSource::Documentation() {
 
 SceneGraphLightSource::SceneGraphLightSource()
     : _intensity(IntensityInfo, 1.f, 0.f, 1.f)
-    , _sceneGraphNodeReference(NodeInfo, "")
+    , _sceneGraphNodeReference(NodeCameraStateInfo, "")
 {
     addProperty(_intensity);
     _sceneGraphNodeReference.onChange([this]() {

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1055,17 +1055,17 @@ void OpenSpaceEngine::writeDocumentation() {
     nlohmann::json license = writer.generateJsonGroupedByLicense();
     nlohmann::json sceneProperties = settings.get();
     nlohmann::json sceneGraph = scene.get();
-    
+
     sceneProperties["name"] = "Settings";
     sceneGraph["name"] = "Scene";
-    
+
     // Add this here so that the generateJson function is the same as before to ensure
     // backwards compatibility
     nlohmann::json scriptingResult;
     scriptingResult["name"] = "Scripting API";
     scriptingResult["data"] = scripting;
 
-    nlohmann::json documentation = { 
+    nlohmann::json documentation = {
         sceneGraph, sceneProperties, keybindings, license, scriptingResult, factory
     };
 
@@ -1747,6 +1747,16 @@ void setCameraFromProfile(const Profile& p) {
                 geoScript += ")";
                 global::scriptEngine->queueScript(
                     geoScript,
+                    scripting::ScriptEngine::RemoteScripting::Yes
+                );
+            },
+            [](const Profile::CameraGoToNode& node) {
+                // @TODO set from core code directly instead
+                std::string goToScript = fmt::format(
+                    "openspace.pathnavigation.flyTo([[{}]], {})", node.anchor, 0.f
+                );
+                global::scriptEngine->queueScript(
+                    goToScript,
                     scripting::ScriptEngine::RemoteScripting::Yes
                 );
             }

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1753,15 +1753,11 @@ void setCameraFromProfile(const Profile& p) {
             },
             [](const Profile::CameraGoToNode& node) {
                 using namespace interaction;
-                NodeInfo info;
-                info.identifier = node.anchor;
-                info.useTargetUpDirection = true;
-                Waypoint wp = computeWaypointFromNodeInfo(info);
+                NodeCameraStateSpec spec;
+                spec.identifier = node.anchor;
+                spec.useTargetUpDirection = true;
 
-                global::navigationHandler->setCameraPoseNextFrame(
-                    wp.pose(),
-                    node.anchor
-                );
+                global::navigationHandler->setCameraFromNodeSpecNextFrame(spec);
             }
         },
         p.camera.value()

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1755,6 +1755,7 @@ void setCameraFromProfile(const Profile& p) {
                 using namespace interaction;
                 NodeCameraStateSpec spec;
                 spec.identifier = node.anchor;
+                spec.height = node.height;
                 spec.useTargetUpDirection = true;
 
                 global::navigationHandler->setCameraFromNodeSpecNextFrame(spec);

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1758,11 +1758,10 @@ void setCameraFromProfile(const Profile& p) {
                 info.useTargetUpDirection = true;
                 Waypoint wp = computeWaypointFromNodeInfo(info);
 
-                // @TODO do this after one frame
-                global::navigationHandler->orbitalNavigator().setAnchorNode(node.anchor);
-                global::navigationHandler->orbitalNavigator().setAimNode("");
-                global::navigationHandler->camera()->setPose(wp.pose());
-                global::navigationHandler->resetNavigationUpdateVariables();
+                global::navigationHandler->setCameraPoseNextFrame(
+                    wp.pose(),
+                    node.anchor
+                );
             }
         },
         p.camera.value()

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -182,7 +182,7 @@ void NavigationHandler::updateCamera(double deltaTime) {
 
     // If there is a state to set, do so immediately and then return
     if (_pendingState.has_value()) {
-        applyPendingPose();
+        applyPendingState();
         return;
     }
 
@@ -219,8 +219,8 @@ void NavigationHandler::updateCamera(double deltaTime) {
     _orbitalNavigator.updateCameraScalingFromAnchor(deltaTime);
 }
 
-void NavigationHandler::applyPendingPose() {
-    ghoul_assert(_pendingPose.has_value(), "Pending pose must have a value");
+void NavigationHandler::applyPendingState() {
+    ghoul_assert(_pendingState.has_value(), "Pending pose must have a value");
 
     std::variant<NodeCameraStateSpec, NavigationState> pending = *_pendingState;
     if (std::holds_alternative<NavigationState>(pending)) {

--- a/src/navigation/navigationstate.cpp
+++ b/src/navigation/navigationstate.cpp
@@ -115,6 +115,9 @@ CameraPose NavigationState::cameraPose() const {
 
     const glm::dmat3 referenceFrameTransform = referenceFrameNode->modelTransform();
 
+    // @TODO (2023-05-16, emmbr) This computation is wrong and has to be fixed! Only
+    // works if the reference frame is also the anchor node. I remember that fixing it
+    // was not as easy as using referenceFrameNode instead of anchor node though..
     resultingPose.position = anchorNode->worldPosition() +
         referenceFrameTransform * glm::dvec3(position);
 

--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -45,8 +45,6 @@ namespace {
     constexpr std::string_view _loggerCat = "Path";
     constexpr float LengthEpsilon = 1e-5f;
 
-    constexpr const char* SunIdentifier = "Sun";
-
     // TODO: where should this documentation be?
     // It's nice to have these to interpret the dictionary when creating the path, but
     // maybe it's not really necessary
@@ -458,138 +456,6 @@ double Path::speedAlongPath(double traveledDistance) const {
     return _speedFactorFromDuration * speed * dampeningFactor;
 }
 
-Waypoint waypointFromCamera() {
-    Camera* camera = global::navigationHandler->camera();
-    const glm::dvec3 pos = camera->positionVec3();
-    const glm::dquat rot = camera->rotationQuaternion();
-    const std::string node = global::navigationHandler->anchorNode()->identifier();
-    return Waypoint{ pos, rot, node };
-}
-
-// Compute a target position close to the specified target node, using knowledge of
-// the start point and a desired distance from the node's center
-glm::dvec3 computeGoodStepDirection(const SceneGraphNode* targetNode,
-                                    const Waypoint& startPoint)
-{
-    const glm::dvec3 nodePos = targetNode->worldPosition();
-    const SceneGraphNode* sun = sceneGraphNode(SunIdentifier);
-    const SceneGraphNode* closeNode = PathNavigator::findNodeNearTarget(targetNode);
-
-    // @TODO (2021-07-09, emmbr): Not nice to depend on a specific scene graph node,
-    // as it might not exist. Ideally, each SGN could know about their preferred
-    // direction to be viewed from (their "good side"), and then that could be queried
-    // and used instead.
-    if (closeNode) {
-        // If the node is close to another node in the scene, set the direction in a way
-        // that minimizes risk of collision
-        return glm::normalize(nodePos - closeNode->worldPosition());
-    }
-    else if (!sun) {
-        // Can't compute position from Sun position, so just use any direction. Z will do
-        return glm::dvec3(0.0, 0.0, 1.0);
-    }
-    else if (targetNode->identifier() == SunIdentifier) {
-        // Special case for when the target is the Sun, in which we want to avoid a zero
-        // vector. The Z axis is chosen to provide an overview of the solar system, and
-        // not stay in the orbital plane
-        return glm::dvec3(0.0, 0.0, 1.0);
-    }
-    else {
-        // Go to a point that is lit up by the sun, slightly offsetted from sun direction
-        const glm::dvec3 sunPos = sun->worldPosition();
-
-        const glm::dvec3 prevPos = startPoint.position();
-        const glm::dvec3 targetToPrev = prevPos - nodePos;
-        const glm::dvec3 targetToSun = sunPos - nodePos;
-
-        // Check against zero vectors, as this will lead to nan-values from cross product
-        if (glm::length(targetToSun) < LengthEpsilon ||
-            glm::length(targetToPrev) < LengthEpsilon)
-        {
-            // Same situation as if sun does not exist. Any direction will do
-            return glm::dvec3(0.0, 0.0, 1.0);
-        }
-
-        constexpr float defaultPositionOffsetAngle = -30.f; // degrees
-        constexpr float angle = glm::radians(defaultPositionOffsetAngle);
-        const glm::dvec3 axis = glm::normalize(glm::cross(targetToPrev, targetToSun));
-        const glm::dquat offsetRotation = angleAxis(static_cast<double>(angle), axis);
-
-        return glm::normalize(offsetRotation * targetToSun);
-    }
-}
-
-struct NodeInfo {
-    std::string identifier;
-    std::optional<glm::dvec3> position;
-    std::optional<double> height;
-    bool useTargetUpDirection;
-};
-
-Waypoint computeWaypointFromNodeInfo(const NodeInfo& info, const Waypoint& startPoint,
-                                     Path::Type type)
-{
-    const SceneGraphNode* targetNode = sceneGraphNode(info.identifier);
-    if (!targetNode) {
-        LERROR(fmt::format("Could not find target node '{}'", info.identifier));
-        return Waypoint();
-    }
-
-    glm::dvec3 stepDir;
-    glm::dvec3 targetPos;
-    if (info.position.has_value()) {
-        // The position in instruction is given in the targetNode's local coordinates.
-        // Convert to world coordinates
-        targetPos = glm::dvec3(
-            targetNode->modelTransform() * glm::dvec4(*info.position, 1.0)
-        );
-    }
-    else {
-        const PathNavigator& navigator = global::navigationHandler->pathNavigator();
-
-        const double radius = navigator.findValidBoundingSphere(targetNode);
-        const double defaultHeight = radius * navigator.arrivalDistanceFactor();
-        const double height = info.height.value_or(defaultHeight);
-        const double distanceFromNodeCenter = radius + height;
-
-        if (type == Path::Type::Linear) {
-            // If linear path, compute position along line form start to end point
-            glm::dvec3 endNodePos = targetNode->worldPosition();
-            stepDir = glm::normalize(startPoint.position() - endNodePos);
-        }
-        else {
-            stepDir = computeGoodStepDirection(targetNode, startPoint);
-        }
-
-        targetPos = targetNode->worldPosition() + stepDir * distanceFromNodeCenter;
-    }
-
-    glm::dvec3 up = global::navigationHandler->camera()->lookUpVectorWorldSpace();
-    if (info.useTargetUpDirection) {
-        // @TODO (emmbr 2020-11-17) For now, this is hardcoded to look good for Earth,
-        // which is where it matters the most. A better solution would be to make each
-        // sgn aware of its own 'up' and query
-        up = targetNode->worldRotationMatrix() * glm::dvec3(0.0, 0.0, 1.0);
-    }
-
-    // Compute rotation so the camera is looking at the targetted node
-    glm::dvec3 lookAtPos = targetNode->worldPosition();
-
-    // Check if we can distinguish between targetpos and lookAt pos. Otherwise, move it further away
-    const glm::dvec3 diff = targetPos - lookAtPos;
-    double distSquared = glm::dot(diff, diff);
-    if (std::isnan(distSquared) || distSquared < LengthEpsilon) {
-        double startToEndDist = glm::length(
-            startPoint.position() - targetNode->worldPosition()
-        );
-        lookAtPos = targetPos - stepDir * 0.1 * startToEndDist;
-    }
-
-    const glm::dquat targetRot = ghoul::lookAtQuaternion(targetPos, lookAtPos, up);
-
-    return Waypoint(targetPos, targetRot, info.identifier);
-}
-
 void checkVisibilityAndShowMessage(const SceneGraphNode* node) {
     auto isEnabled = [](const Renderable* r) {
         std::any propertyValueAny = r->property("Enabled")->get();
@@ -639,7 +505,7 @@ Path createPathFromDictionary(const ghoul::Dictionary& dictionary,
     bool hasStart = p.startState.has_value();
     const Waypoint startPoint = hasStart ?
         Waypoint(NavigationState(p.startState.value())) :
-        waypointFromCamera();
+        interaction::waypointFromCamera();
 
     std::vector<Waypoint> waypoints;
     switch (p.targetType) {
@@ -668,7 +534,7 @@ Path createPathFromDictionary(const ghoul::Dictionary& dictionary,
                 ));
             }
 
-            NodeInfo info {
+            interaction::NodeInfo info {
                 nodeIdentifier,
                 p.position,
                 p.height,
@@ -692,7 +558,8 @@ Path createPathFromDictionary(const ghoul::Dictionary& dictionary,
                 type = Path::Type::Linear;
             }
 
-            waypoints = { computeWaypointFromNodeInfo(info, startPoint, type) };
+            bool isLinear = type == Path::Type::Linear;
+            waypoints = { computeWaypointFromNodeInfo(info, startPoint, isLinear) };
             break;
         }
         default:

--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -534,7 +534,7 @@ Path createPathFromDictionary(const ghoul::Dictionary& dictionary,
                 ));
             }
 
-            interaction::NodeInfo info {
+            interaction::NodeCameraStateSpec info {
                 nodeIdentifier,
                 p.position,
                 p.height,

--- a/src/navigation/waypoint.cpp
+++ b/src/navigation/waypoint.cpp
@@ -157,13 +157,13 @@ glm::dvec3 computeGoodStepDirection(const SceneGraphNode* targetNode,
     }
 }
 
-Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
+Waypoint computeWaypointFromNodeInfo(const NodeCameraStateSpec& spec,
                                      std::optional<const Waypoint> startPoint,
                                      bool useLinear)
 {
-    const SceneGraphNode* targetNode = sceneGraphNode(info.identifier);
+    const SceneGraphNode* targetNode = sceneGraphNode(spec.identifier);
     if (!targetNode) {
-        LERROR(fmt::format("Could not find target node '{}'", info.identifier));
+        LERROR(fmt::format("Could not find target node '{}'", spec.identifier));
         return Waypoint();
     }
 
@@ -172,11 +172,11 @@ Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
 
     glm::dvec3 stepDir;
     glm::dvec3 targetPos;
-    if (info.position.has_value()) {
+    if (spec.position.has_value()) {
         // The position in instruction is given in the targetNode's local coordinates.
         // Convert to world coordinates
         targetPos = glm::dvec3(
-            targetNode->modelTransform() * glm::dvec4(*info.position, 1.0)
+            targetNode->modelTransform() * glm::dvec4(*spec.position, 1.0)
         );
     }
     else {
@@ -184,7 +184,7 @@ Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
 
         const double radius = navigator.findValidBoundingSphere(targetNode);
         const double defaultHeight = radius * navigator.arrivalDistanceFactor();
-        const double height = info.height.value_or(defaultHeight);
+        const double height = spec.height.value_or(defaultHeight);
         const double distanceFromNodeCenter = radius + height;
 
         if (useLinear) {
@@ -200,7 +200,7 @@ Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
     }
 
     glm::dvec3 up = global::navigationHandler->camera()->lookUpVectorWorldSpace();
-    if (info.useTargetUpDirection) {
+    if (spec.useTargetUpDirection) {
         // @TODO (emmbr 2020-11-17) For now, this is hardcoded to look good for Earth,
         // which is where it matters the most. A better solution would be to make each
         // sgn aware of its own 'up' and query
@@ -222,7 +222,7 @@ Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
 
     const glm::dquat targetRot = ghoul::lookAtQuaternion(targetPos, lookAtPos, up);
 
-    return Waypoint(targetPos, targetRot, info.identifier);
+    return Waypoint(targetPos, targetRot, spec.identifier);
 }
 
 } // namespace openspace::interaction

--- a/src/navigation/waypoint.cpp
+++ b/src/navigation/waypoint.cpp
@@ -24,6 +24,7 @@
 
 #include <openspace/navigation/waypoint.h>
 
+#include <openspace/camera/camera.h>
 #include <openspace/engine/globals.h>
 #include <openspace/engine/moduleengine.h>
 #include <openspace/navigation/navigationhandler.h>
@@ -35,6 +36,9 @@
 
 namespace {
     constexpr std::string_view _loggerCat = "Waypoint";
+
+    constexpr float LengthEpsilon = 1e-5f;
+    constexpr const char* SunIdentifier = "Sun";
 } // namespace
 
 namespace openspace::interaction {
@@ -90,6 +94,135 @@ std::string Waypoint::nodeIdentifier() const {
 
 double Waypoint::validBoundingSphere() const {
     return _validBoundingSphere;
+}
+
+Waypoint waypointFromCamera() {
+    Camera* camera = global::navigationHandler->camera();
+    const glm::dvec3 pos = camera->positionVec3();
+    const glm::dquat rot = camera->rotationQuaternion();
+    const std::string node = global::navigationHandler->anchorNode()->identifier();
+    return Waypoint{ pos, rot, node };
+}
+
+// Compute a target position close to the specified target node, using knowledge of
+// the start point and a desired distance from the node's center
+glm::dvec3 computeGoodStepDirection(const SceneGraphNode* targetNode,
+                                    const Waypoint& startPoint)
+{
+    const glm::dvec3 nodePos = targetNode->worldPosition();
+    const SceneGraphNode* sun = sceneGraphNode(SunIdentifier);
+    const SceneGraphNode* closeNode = PathNavigator::findNodeNearTarget(targetNode);
+
+    // @TODO (2021-07-09, emmbr): Not nice to depend on a specific scene graph node,
+    // as it might not exist. Ideally, each SGN could know about their preferred
+    // direction to be viewed from (their "good side"), and then that could be queried
+    // and used instead.
+    if (closeNode) {
+        // If the node is close to another node in the scene, set the direction in a way
+        // that minimizes risk of collision
+        return glm::normalize(nodePos - closeNode->worldPosition());
+    }
+    else if (!sun) {
+        // Can't compute position from Sun position, so just use any direction. Z will do
+        return glm::dvec3(0.0, 0.0, 1.0);
+    }
+    else if (targetNode->identifier() == SunIdentifier) {
+        // Special case for when the target is the Sun, in which we want to avoid a zero
+        // vector. The Z axis is chosen to provide an overview of the solar system, and
+        // not stay in the orbital plane
+        return glm::dvec3(0.0, 0.0, 1.0);
+    }
+    else {
+        // Go to a point that is lit up by the sun, slightly offsetted from sun direction
+        const glm::dvec3 sunPos = sun->worldPosition();
+
+        const glm::dvec3 prevPos = startPoint.position();
+        const glm::dvec3 targetToPrev = prevPos - nodePos;
+        const glm::dvec3 targetToSun = sunPos - nodePos;
+
+        // Check against zero vectors, as this will lead to nan-values from cross product
+        if (glm::length(targetToSun) < LengthEpsilon ||
+            glm::length(targetToPrev) < LengthEpsilon)
+        {
+            // Same situation as if sun does not exist. Any direction will do
+            return glm::dvec3(0.0, 0.0, 1.0);
+        }
+
+        constexpr float defaultPositionOffsetAngle = -30.f; // degrees
+        constexpr float angle = glm::radians(defaultPositionOffsetAngle);
+        const glm::dvec3 axis = glm::normalize(glm::cross(targetToPrev, targetToSun));
+        const glm::dquat offsetRotation = angleAxis(static_cast<double>(angle), axis);
+
+        return glm::normalize(offsetRotation * targetToSun);
+    }
+}
+
+Waypoint computeWaypointFromNodeInfo(const NodeInfo& info,
+                                     std::optional<const Waypoint> startPoint,
+                                     bool useLinear)
+{
+    const SceneGraphNode* targetNode = sceneGraphNode(info.identifier);
+    if (!targetNode) {
+        LERROR(fmt::format("Could not find target node '{}'", info.identifier));
+        return Waypoint();
+    }
+
+    // Use current camera position if no previous point was specified
+    Waypoint prevPoint = startPoint.value_or(waypointFromCamera());
+
+    glm::dvec3 stepDir;
+    glm::dvec3 targetPos;
+    if (info.position.has_value()) {
+        // The position in instruction is given in the targetNode's local coordinates.
+        // Convert to world coordinates
+        targetPos = glm::dvec3(
+            targetNode->modelTransform() * glm::dvec4(*info.position, 1.0)
+        );
+    }
+    else {
+        const PathNavigator& navigator = global::navigationHandler->pathNavigator();
+
+        const double radius = navigator.findValidBoundingSphere(targetNode);
+        const double defaultHeight = radius * navigator.arrivalDistanceFactor();
+        const double height = info.height.value_or(defaultHeight);
+        const double distanceFromNodeCenter = radius + height;
+
+        if (useLinear) {
+            // If linear path, compute position along line form start to end point
+            glm::dvec3 endNodePos = targetNode->worldPosition();
+            stepDir = glm::normalize(prevPoint.position() - endNodePos);
+        }
+        else {
+            stepDir = computeGoodStepDirection(targetNode, prevPoint);
+        }
+
+        targetPos = targetNode->worldPosition() + stepDir * distanceFromNodeCenter;
+    }
+
+    glm::dvec3 up = global::navigationHandler->camera()->lookUpVectorWorldSpace();
+    if (info.useTargetUpDirection) {
+        // @TODO (emmbr 2020-11-17) For now, this is hardcoded to look good for Earth,
+        // which is where it matters the most. A better solution would be to make each
+        // sgn aware of its own 'up' and query
+        up = targetNode->worldRotationMatrix() * glm::dvec3(0.0, 0.0, 1.0);
+    }
+
+    // Compute rotation so the camera is looking at the targetted node
+    glm::dvec3 lookAtPos = targetNode->worldPosition();
+
+    // Check if we can distinguish between targetpos and lookAt pos. Otherwise, move it further away
+    const glm::dvec3 diff = targetPos - lookAtPos;
+    double distSquared = glm::dot(diff, diff);
+    if (std::isnan(distSquared) || distSquared < LengthEpsilon) {
+        double startToEndDist = glm::length(
+            prevPoint.position() - targetNode->worldPosition()
+        );
+        lookAtPos = targetPos - stepDir * 0.1 * startToEndDist;
+    }
+
+    const glm::dquat targetRot = ghoul::lookAtQuaternion(targetPos, lookAtPos, up);
+
+    return Waypoint(targetPos, targetRot, info.identifier);
 }
 
 } // namespace openspace::interaction

--- a/src/navigation/waypoint.cpp
+++ b/src/navigation/waypoint.cpp
@@ -158,7 +158,7 @@ glm::dvec3 computeGoodStepDirection(const SceneGraphNode* targetNode,
 }
 
 Waypoint computeWaypointFromNodeInfo(const NodeCameraStateSpec& spec,
-                                     std::optional<const Waypoint> startPoint,
+                                     std::optional<Waypoint> startPoint,
                                      bool useLinear)
 {
     const SceneGraphNode* targetNode = sceneGraphNode(spec.identifier);

--- a/src/scene/profile.cpp
+++ b/src/scene/profile.cpp
@@ -349,6 +349,9 @@ void from_json(const nlohmann::json& j, Profile::Time& v) {
 void to_json(nlohmann::json& j, const Profile::CameraGoToNode& v) {
     j["type"] = Profile::CameraGoToNode::Type;
     j["anchor"] = v.anchor;
+    if (v.height.has_value()) {
+        j["height"] = *v.height;
+    }
 }
 
 void from_json(const nlohmann::json& j, Profile::CameraGoToNode& v) {
@@ -358,13 +361,17 @@ void from_json(const nlohmann::json& j, Profile::CameraGoToNode& v) {
     );
 
     checkValue(j, "anchor", &nlohmann::json::is_string, "camera", false);
+    checkValue(j, "height", &nlohmann::json::is_number, "camera", true);
     checkExtraKeys(
         j,
         "camera",
-        { "type", "anchor" }
+        { "type", "anchor", "height"}
     );
 
     j["anchor"].get_to(v.anchor);
+    if (j.find("height") != j.end()) {
+        v.height = j["height"].get<double>();
+    }
 }
 
 void to_json(nlohmann::json& j, const Profile::CameraNavState& v) {

--- a/src/scene/profile.cpp
+++ b/src/scene/profile.cpp
@@ -467,6 +467,27 @@ void from_json(const nlohmann::json& j, Profile::CameraGoToGeo& v) {
     }
 }
 
+void to_json(nlohmann::json& j, const Profile::CameraGoToNode& v) {
+    j["type"] = Profile::CameraGoToNode::Type;
+    j["anchor"] = v.anchor;
+}
+
+void from_json(const nlohmann::json& j, Profile::CameraGoToNode& v) {
+    ghoul_assert(
+        j.at("type").get<std::string>() == Profile::CameraGoToNode::Type,
+        "Wrong type for Camera"
+    );
+
+    checkValue(j, "anchor", &nlohmann::json::is_string, "camera", false);
+    checkExtraKeys(
+        j,
+        "camera",
+        { "type", "anchor" }
+    );
+
+    j["anchor"].get_to(v.anchor);
+}
+
 // In these namespaces we defined the structs as they used to be defined in the older
 // versions. That way, we can keep the from_json files as they were originally written too
 namespace version10 {
@@ -688,7 +709,8 @@ std::string Profile::serialize() const {
         r["camera"] = std::visit(
             overloaded {
                 [](const CameraNavState& c) { return nlohmann::json(c); },
-                [](const Profile::CameraGoToGeo& c) { return nlohmann::json(c); }
+                [](const Profile::CameraGoToGeo& c) { return nlohmann::json(c); },
+                [](const Profile::CameraGoToNode& c) { return nlohmann::json(c); }
             },
             *camera
         );
@@ -754,6 +776,9 @@ Profile::Profile(const std::string& content) {
             }
             else if (c["type"].get<std::string>() == CameraGoToGeo::Type) {
                 camera = c.get<CameraGoToGeo>();
+            }
+            else if (c["type"].get<std::string>() == CameraGoToNode::Type) {
+                camera = c.get<CameraGoToNode>();
             }
             else {
                 throw ParsingError(ParsingError::Severity::Error, "Unknown camera type");

--- a/src/scene/profile.cpp
+++ b/src/scene/profile.cpp
@@ -607,6 +607,14 @@ void convertVersion11to12(nlohmann::json& profile) {
 
 } // namespace version11
 
+namespace version12 {
+
+void convertVersion12to13(nlohmann::json& profile) {
+    // Version 1.3 introduced to GoToNode camera initial position
+    profile["version"] = Profile::Version{ 1, 3 };
+}
+
+} // namespace version12
 
 Profile::ParsingError::ParsingError(Severity severity_, std::string msg)
     : ghoul::RuntimeError(std::move(msg), "profile")
@@ -739,6 +747,11 @@ Profile::Profile(const std::string& content) {
 
         if (version.major == 1 && version.minor == 1) {
             version11::convertVersion11to12(profile);
+            profile["version"].get_to(version);
+        }
+
+        if (version.major == 1 && version.minor == 2) {
+            version12::convertVersion12to13(profile);
             profile["version"].get_to(version);
         }
 

--- a/tests/profile/basic/camera_gotonode.profile
+++ b/tests/profile/basic/camera_gotonode.profile
@@ -1,0 +1,7 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode",
+    "anchor": "anchor"
+  }
+}

--- a/tests/profile/basic/camera_gotonode_height.profile
+++ b/tests/profile/basic/camera_gotonode_height.profile
@@ -1,0 +1,8 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode",
+    "anchor": "anchor",
+    "height": 100.0
+  }
+}

--- a/tests/profile/error/camera/gotonode_invalidvalue_negative_height.profile
+++ b/tests/profile/error/camera/gotonode_invalidvalue_negative_height.profile
@@ -1,0 +1,8 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode",
+    "anchor": "anchor",
+    "height": -10.0
+  }
+}

--- a/tests/profile/error/camera/gotonode_invalidvalue_zero_height.profile
+++ b/tests/profile/error/camera/gotonode_invalidvalue_zero_height.profile
@@ -1,0 +1,8 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode",
+    "anchor": "anchor",
+    "height": 0.0
+  }
+}

--- a/tests/profile/error/camera/gotonode_missing_anchor.profile
+++ b/tests/profile/error/camera/gotonode_missing_anchor.profile
@@ -1,0 +1,6 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode"
+  }
+}

--- a/tests/profile/error/camera/gotonode_wrongtype_anchor.profile
+++ b/tests/profile/error/camera/gotonode_wrongtype_anchor.profile
@@ -1,0 +1,7 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode",
+    "anchor": 1.0
+  }
+}

--- a/tests/profile/error/camera/gotonode_wrongtype_height.profile
+++ b/tests/profile/error/camera/gotonode_wrongtype_height.profile
@@ -1,0 +1,8 @@
+{
+  "version": { "major": 1, "minor": 3 },
+  "camera": {
+    "type": "goToNode",
+    "anchor": "anchor",
+    "height": "0.0"
+  }
+}

--- a/tests/test_profile.cpp
+++ b/tests/test_profile.cpp
@@ -93,6 +93,12 @@ namespace openspace {
         return lhs.type == rhs.type && lhs.value == rhs.value;
     }
 
+    bool operator==(const openspace::Profile::CameraGoToNode& lhs,
+        const openspace::Profile::CameraGoToNode& rhs) noexcept
+    {
+        return lhs.anchor == rhs.anchor;
+    }
+
     bool operator==(const openspace::Profile::CameraNavState& lhs,
                     const openspace::Profile::CameraNavState& rhs) noexcept
     {

--- a/tests/test_profile.cpp
+++ b/tests/test_profile.cpp
@@ -96,7 +96,7 @@ namespace openspace {
     bool operator==(const openspace::Profile::CameraGoToNode& lhs,
         const openspace::Profile::CameraGoToNode& rhs) noexcept
     {
-        return lhs.anchor == rhs.anchor;
+        return lhs.anchor == rhs.anchor && lhs.height == rhs.height;
     }
 
     bool operator==(const openspace::Profile::CameraNavState& lhs,

--- a/tests/test_profile.cpp
+++ b/tests/test_profile.cpp
@@ -658,6 +658,37 @@ TEST_CASE("Basic Camera GoToGeo (with altitude)", "[profile]") {
     CHECK(profile == ref);
 }
 
+TEST_CASE("Basic Camera GoToNode", "[profile]") {
+    constexpr std::string_view File =
+        "${TESTDIR}/profile/basic/camera_gotonode.profile";
+    Profile profile = loadProfile(absPath(File));
+
+    Profile ref;
+    ref.version = Profile::CurrentVersion;
+
+    Profile::CameraGoToNode camera;
+    camera.anchor = "anchor";
+    ref.camera = camera;
+
+    CHECK(profile == ref);
+}
+
+TEST_CASE("Basic Camera GoToNode (with height)", "[profile]") {
+    constexpr std::string_view File =
+        "${TESTDIR}/profile/basic/camera_gotonode_height.profile";
+    Profile profile = loadProfile(absPath(File));
+
+    Profile ref;
+    ref.version = Profile::CurrentVersion;
+
+    Profile::CameraGoToNode camera;
+    camera.anchor = "anchor";
+    camera.height = 100.0;
+    ref.camera = camera;
+
+    CHECK(profile == ref);
+}
+
 TEST_CASE("Basic Mark Nodes", "[profile]") {
     constexpr std::string_view File = "${TESTDIR}/profile/basic/mark_nodes.profile";
     Profile profile = loadProfile(absPath(File));
@@ -1610,3 +1641,52 @@ TEST_CASE("(Error) Camera (GoToGeo): Wrong type 'altitude'", "[profile]") {
         Catch::Matchers::Equals("(profile) 'camera.altitude' must be a number")
     );
 }
+
+TEST_CASE("(Error) Camera (GoToNode): Wrong type 'anchor'", "[profile]") {
+    constexpr std::string_view TestFile =
+        "${TESTDIR}/profile/error/camera/gotonode_wrongtype_anchor.profile";
+    CHECK_THROWS_WITH(
+        loadProfile(absPath(TestFile)),
+        Catch::Matchers::Equals("(profile) 'camera.anchor' must be a string")
+    );
+}
+
+TEST_CASE("(Error) Camera (GoToNode): Wrong type 'height'", "[profile]") {
+    constexpr std::string_view TestFile =
+        "${TESTDIR}/profile/error/camera/gotonode_wrongtype_height.profile";
+    CHECK_THROWS_WITH(
+        loadProfile(absPath(TestFile)),
+        Catch::Matchers::Equals("(profile) 'camera.height' must be a number")
+    );
+}
+
+TEST_CASE("(Error) Camera (GoToNode): Missing value 'anchor'", "[profile]") {
+    constexpr std::string_view TestFile =
+        "${TESTDIR}/profile/error/camera/gotonode_missing_anchor.profile";
+    CHECK_THROWS_WITH(
+        loadProfile(absPath(TestFile)),
+        Catch::Matchers::Equals("(profile) 'camera.anchor' field is missing")
+    );
+}
+
+// @TODO (2023-05-17, emmbr) Seems like the profile loading actually do not validate
+// profile values to a larger degree than type and whether the value is missing, currently.
+// So this is left as future work
+//
+//TEST_CASE("(Error) Camera (GoToNode): Invalid value for 'height' - negative", "[profile]") {
+//    constexpr std::string_view TestFile =
+//        "${TESTDIR}/profile/error/camera/gotonode_invalidvalue_negative_height.profile";
+//    CHECK_THROWS_WITH(
+//        loadProfile(absPath(TestFile)),
+//        Catch::Matchers::Equals("(profile) 'camera.height' must be a larger than zero")
+//    );
+//}
+//
+//TEST_CASE("(Error) Camera (GoToNode): Invalid value for 'height' - zero", "[profile]") {
+//    constexpr std::string_view TestFile =
+//        "${TESTDIR}/profile/error/camera/gotonode_invalidvalue_zero_height.profile";
+//    CHECK_THROWS_WITH(
+//        loadProfile(absPath(TestFile)),
+//        Catch::Matchers::Equals("(profile) 'camera.height' must be a larger than zero")
+//    );
+//}

--- a/tests/test_profile.cpp
+++ b/tests/test_profile.cpp
@@ -172,8 +172,8 @@ TEST_CASE("Minimal", "[profile]") {
     Profile profile = loadProfile(absPath(File));
 
     Profile ref;
-    ref.version.major = 1;
-    ref.version.minor = 2;
+    ref.version = Profile::CurrentVersion;
+
     CHECK(profile == ref);
 }
 


### PR DESCRIPTION
Adds a tab for specifying a scene graph node (and makes that the default one)

Also added some descriptive text to each tab. Let me know what you think of them.

Used the already existing camera path waypoint creation code to compute the camera position, but unfortunately, the actual camera pose can't be computed until we reach the "first correct frame", so the code ended up being much uglier than I wanted it to be... (the check in navigationhandler.cpp). But it works, and that's what most important by now :) 

Do we also want to allow the user to set an optional height value? Since this is supported by the data structure used for the camera position, this might make sense