### PR TITLE
Issue/2647

### DIFF
--- a/data/assets/examples/joystickProperty.asset
+++ b/data/assets/examples/joystickProperty.asset
@@ -5,10 +5,8 @@
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted

--- a/data/assets/examples/joystickProperty.asset
+++ b/data/assets/examples/joystickProperty.asset
@@ -18,7 +18,8 @@
 --       The axis values can either go back to 0 when the joystick is released or it can
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 
 -- Parameters for bindJoystickAxisProperty:
@@ -59,8 +60,6 @@ local freezeValue = function(name, axis, min, max)
   local isPropertyBound = true;
   if joystickType == "None" then
     isPropertyBound = false;
-  else
-    isPropertyBound = true;
   end
 
   if isPropertyBound then

--- a/data/assets/util/joysticks/joystick_helper.asset
+++ b/data/assets/util/joysticks/joystick_helper.asset
@@ -13,7 +13,7 @@ local bindLocalRoll = function(name, axis)
     end
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
     Joystick.State.IsInRollMode = true
   ]]
 end
@@ -27,7 +27,7 @@ local bindGlobalRoll = function(name, axis)
     end
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
     Joystick.State.IsInRollMode = true
   ]]
 end
@@ -38,7 +38,7 @@ local permaBindLocalRoll = function(name, axis)
     Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
   ]]
 end
 
@@ -48,7 +48,7 @@ local permaBindGlobalRoll = function(name, axis)
     Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
   ]]
 end
 

--- a/data/assets/util/joysticks/joystick_helper.asset
+++ b/data/assets/util/joysticks/joystick_helper.asset
@@ -9,11 +9,11 @@ local bindLocalRoll = function(name, axis)
     -- We only want to store the current state in the first mode that is enabled, otherwise we will overwrite the backup
     if not Joystick.State.IsInRollMode then
       -- Save current axis state
-      Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
+      Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
     end
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
     Joystick.State.IsInRollMode = true
   ]]
 end
@@ -23,11 +23,11 @@ local bindGlobalRoll = function(name, axis)
     -- We only want to store the current state in the first mode that is enabled, otherwise we will overwrite the backup
     if not Joystick.State.IsInRollMode then
       -- Save current axis state
-      Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
+      Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
     end
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
     Joystick.State.IsInRollMode = true
   ]]
 end
@@ -35,20 +35,20 @@ end
 local permaBindLocalRoll = function(name, axis)
   return [[
     -- Save current axis state
-    Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
+    Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
   ]]
 end
 
 local permaBindGlobalRoll = function(name, axis)
   return [[
     -- Save current axis state
-    Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
+    Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[);
 
     -- Set new axis state
-    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity);
+    openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll X", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
   ]]
 end
 
@@ -56,9 +56,9 @@ local unbindRoll = function(name, axis)
   return [[
     -- Reset previous state
     if (Joystick.State.Axis.Type == "Property") then
-      openspace.navigation.bindJoystickAxisProperty("]] .. name .. "\", " .. axis .. [[, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.Inverted, Joystick.State.Axis.IsRemote);
+      openspace.navigation.bindJoystickAxisProperty("]] .. name .. "\", " .. axis .. [[, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.Inverted, Joystick.State.Axis.Flip, Joystick.State.Axis.IsRemote);
     else
-      openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Sensitivity);
+      openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity);
     end
   ]]
 end

--- a/data/assets/util/joysticks/ps4.asset
+++ b/data/assets/util/joysticks/ps4.asset
@@ -21,7 +21,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       The axis values can either go back to 0 when the joystick is released or it can
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local PS4Controller = {
   LeftThumbStick = { 0 , 1 },

--- a/data/assets/util/joysticks/ps4.asset
+++ b/data/assets/util/joysticks/ps4.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted

--- a/data/assets/util/joysticks/space-mouse-compact-wireless.asset
+++ b/data/assets/util/joysticks/space-mouse-compact-wireless.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted
@@ -43,7 +41,7 @@ asset.onInitialize(function()
   openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true, "JoystickLike", true, false, 40.0);
   openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y", false, "JoystickLike", true, false, 35.0);
   openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom", false, "JoystickLike", true, false, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X", false, "JoystickLike", true, false, 35.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll", false, "JoystickLike", true, false, 35.0);
 
   openspace.navigation.bindJoystickButton(
     name,

--- a/data/assets/util/joysticks/space-mouse-compact-wireless.asset
+++ b/data/assets/util/joysticks/space-mouse-compact-wireless.asset
@@ -22,7 +22,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
 --       This version of the SpaceMouse IS Sticky.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local SpaceMouse = {
   Push = {0, 1, 2}, -- left/right, back/forth, up/down
@@ -37,12 +38,12 @@ asset.onInitialize(function()
   local controller = SpaceMouse;
   local name = "3Dconnexion Universal Receiver";
 
-  openspace.navigation.bindJoystickAxis(name, controller.Push[1], "Orbit X", false, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Push[2], "Orbit Y", false, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y", false, "JoystickLike", true, 35.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom", false, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X", false, "JoystickLike", true, 35.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Push[1], "Orbit X", false, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Push[2], "Orbit Y", false, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y", false, "JoystickLike", true, false, 35.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom", false, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X", false, "JoystickLike", true, false, 35.0);
 
   openspace.navigation.bindJoystickButton(
     name,

--- a/data/assets/util/joysticks/space-mouse-compact.asset
+++ b/data/assets/util/joysticks/space-mouse-compact.asset
@@ -22,7 +22,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
 --       This version of the SpaceMouse IS Sticky.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local SpaceMouse = {
   Push = {0, 1, 2}, -- left/right, back/forth, up/down
@@ -37,12 +38,12 @@ asset.onInitialize(function()
   local controller = SpaceMouse;
   local name = "SpaceNavigator";
 
-  openspace.navigation.bindJoystickAxis(name, controller.Push[1], "Orbit X", false, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Push[2], "Orbit Y", false, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y", false, "JoystickLike", true, 35.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom", false, "JoystickLike", true, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X", false, "JoystickLike", true, 35.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Push[1], "Orbit X", false, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Push[2], "Orbit Y", false, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y", false, "JoystickLike", true, false, 35.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom", false, "JoystickLike", true, false, 40.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X", false, "JoystickLike", true, false, 35.0);
 
   openspace.navigation.bindJoystickButton(
     name,

--- a/data/assets/util/joysticks/space-mouse-compact.asset
+++ b/data/assets/util/joysticks/space-mouse-compact.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted
@@ -43,7 +41,7 @@ asset.onInitialize(function()
   openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true, "JoystickLike", true, false, 40.0);
   openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y", false, "JoystickLike", true, false, 35.0);
   openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom", false, "JoystickLike", true, false, 40.0);
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X", false, "JoystickLike", true, false, 35.0);
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll", false, "JoystickLike", true, false, 35.0);
 
   openspace.navigation.bindJoystickButton(
     name,

--- a/data/assets/util/joysticks/space-mouse-enterprise-wireless.asset
+++ b/data/assets/util/joysticks/space-mouse-enterprise-wireless.asset
@@ -22,7 +22,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
 --       This version of the SpaceMouse is NOT Sticky.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local SpaceMouse = {
   Push = {0, 1, 2}, -- left/right, back/forth, up/down

--- a/data/assets/util/joysticks/space-mouse-enterprise-wireless.asset
+++ b/data/assets/util/joysticks/space-mouse-enterprise-wireless.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted
@@ -51,5 +49,5 @@ asset.onInitialize(function()
   openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true);
   openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y");
   openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom");
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X");
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll");
 end)

--- a/data/assets/util/joysticks/space-mouse-enterprise.asset
+++ b/data/assets/util/joysticks/space-mouse-enterprise.asset
@@ -22,7 +22,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
 --       This version of the SpaceMouse is NOT Sticky.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local SpaceMouse = {
   Push = {0, 1, 2}, -- left/right, back/forth, up/down

--- a/data/assets/util/joysticks/space-mouse-enterprise.asset
+++ b/data/assets/util/joysticks/space-mouse-enterprise.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted
@@ -51,5 +49,5 @@ asset.onInitialize(function()
   openspace.navigation.bindJoystickAxis(name, controller.Twist[1], "Pan X", true);
   openspace.navigation.bindJoystickAxis(name, controller.Tilt[2], "Pan Y");
   openspace.navigation.bindJoystickAxis(name, controller.Push[3], "Zoom");
-  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll X");
+  openspace.navigation.bindJoystickAxis(name, controller.Tilt[1], "LocalRoll");
 end)

--- a/data/assets/util/joysticks/xbox-wireless.asset
+++ b/data/assets/util/joysticks/xbox-wireless.asset
@@ -21,7 +21,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       The axis values can either go back to 0 when the joystick is released or it can
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local XBoxController = {
   LeftThumbStick = { 0 , 1 },

--- a/data/assets/util/joysticks/xbox-wireless.asset
+++ b/data/assets/util/joysticks/xbox-wireless.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted

--- a/data/assets/util/joysticks/xbox.asset
+++ b/data/assets/util/joysticks/xbox.asset
@@ -21,7 +21,8 @@ local joystickHelper = asset.require("./joystick_helper")
 --       The axis values can either go back to 0 when the joystick is released or it can
 --       stay at the value it was before the joystick was released.
 --       The latter is called a sticky axis, when the values don't go back to 0.
--- Seventh parameter is the sensitivity for the axis
+-- Seventh parameter can be used to reverse the camera movement for the axis
+-- Eighth parameter is the sensitivity for the axis
 
 local XBoxController = {
   LeftThumbStick = { 0 , 1 },

--- a/data/assets/util/joysticks/xbox.asset
+++ b/data/assets/util/joysticks/xbox.asset
@@ -69,7 +69,7 @@ asset.onInitialize(function()
   openspace.navigation.bindJoystickButton(
     name,
     controller.DPad.Up,
-    joystickHelper.bindGlobalRoll(name, controller.RightThumbStick[1]) ..
+    joystickHelper.bindLocalRoll(name, controller.RightThumbStick[1]) ..
     "openspace.navigation.bindJoystickAxis('" .. name .. "', " .. controller.RightThumbStick[2] .. ", 'None');",
     "Switch to roll mode"
   )

--- a/data/assets/util/joysticks/xbox.asset
+++ b/data/assets/util/joysticks/xbox.asset
@@ -8,10 +8,8 @@ local joystickHelper = asset.require("./joystick_helper")
 -- "Zoom" -- both in and out
 -- "Zoom In"
 -- "Zoom Out"
--- "LocalRoll X"
--- "LocalRoll Y"
--- "GlobalRoll X"
--- "GlobalRoll Y"
+-- "LocalRoll"
+-- "GlobalRoll"
 -- "Pan X"
 -- "Pan Y"
 -- Fourth parameter determines whether the axis should be inverted
@@ -71,7 +69,7 @@ asset.onInitialize(function()
   openspace.navigation.bindJoystickButton(
     name,
     controller.DPad.Up,
-    joystickHelper.bindLocalRoll(name, controller.RightThumbStick[1]) ..
+    joystickHelper.bindGlobalRoll(name, controller.RightThumbStick[1]) ..
     "openspace.navigation.bindJoystickAxis('" .. name .. "', " .. controller.RightThumbStick[2] .. ", 'None');",
     "Switch to roll mode"
   )

--- a/include/openspace/interaction/joystickcamerastates.h
+++ b/include/openspace/interaction/joystickcamerastates.h
@@ -60,11 +60,13 @@ public:
 
     BooleanType(AxisInvert);
     BooleanType(ButtonCommandRemote);
+    BooleanType(AxisFlip);
 
     struct AxisInformation {
         AxisType type = AxisType::None;
         AxisInvert invert = AxisInvert::No;
         JoystickType joystickType = JoystickType::JoystickLike;
+        AxisFlip flip = AxisFlip::No;
 
         // The axis values can either go back to 0 when the joystick is released or it can
         // stay at the value it was before the joystick was released.
@@ -91,12 +93,14 @@ public:
     void setAxisMapping(std::string joystickName, int axis, AxisType mapping,
         AxisInvert shouldInvert = AxisInvert::No,
         JoystickType joystickType = JoystickType::JoystickLike,
-        bool isSticky = false, double sensitivity = 0.0
+        bool isSticky = false, AxisFlip shouldFlip = AxisFlip::No,
+        double sensitivity = 0.0
     );
 
     void setAxisMappingProperty(std::string joystickName, int axis,
         std::string propertyUri, float min = 0.f, float max = 1.f,
-        AxisInvert shouldInvert = AxisInvert::No, bool isRemote = true
+        AxisInvert shouldInvert = AxisInvert::No, AxisFlip shouldFlip = AxisFlip::No,
+        bool isRemote = true
     );
 
     AxisInformation axisMapping(const std::string& joystickName, int axis) const;

--- a/include/openspace/interaction/joystickcamerastates.h
+++ b/include/openspace/interaction/joystickcamerastates.h
@@ -99,8 +99,7 @@ public:
 
     void setAxisMappingProperty(std::string joystickName, int axis,
         std::string propertyUri, float min = 0.f, float max = 1.f,
-        AxisInvert shouldInvert = AxisInvert::No, AxisFlip shouldFlip = AxisFlip::No,
-        bool isRemote = true
+        AxisInvert shouldInvert = AxisInvert::No, bool isRemote = true
     );
 
     AxisInformation axisMapping(const std::string& joystickName, int axis) const;

--- a/include/openspace/interaction/joystickcamerastates.h
+++ b/include/openspace/interaction/joystickcamerastates.h
@@ -44,10 +44,8 @@ public:
         ZoomIn,
         ZoomOut,
         Zoom,
-        LocalRollX,
-        LocalRollY,
-        GlobalRollX,
-        GlobalRollY,
+        LocalRoll,
+        GlobalRoll,
         PanX,
         PanY,
         Property
@@ -171,10 +169,8 @@ inline std::string to_string(
         case T::ZoomIn:      return "Zoom In";
         case T::ZoomOut:     return "Zoom Out";
         case T::Zoom:        return "Zoom In and Out";
-        case T::LocalRollX:  return "LocalRoll X";
-        case T::LocalRollY:  return "LocalRoll Y";
-        case T::GlobalRollX: return "GlobalRoll X";
-        case T::GlobalRollY: return "GlobalRoll Y";
+        case T::LocalRoll:  return "LocalRoll";
+        case T::GlobalRoll: return "GlobalRoll";
         case T::PanX:        return "Pan X";
         case T::PanY:        return "Pan Y";
         case T::Property:    return "Property";
@@ -194,10 +190,8 @@ from_string(std::string_view string)
     if (string == "Zoom In") { return T::ZoomIn; }
     if (string == "Zoom Out") { return T::ZoomOut; }
     if (string == "Zoom") { return T::Zoom; }
-    if (string == "LocalRoll X") { return T::LocalRollX; }
-    if (string == "LocalRoll Y") { return T::LocalRollY; }
-    if (string == "GlobalRoll X") { return T::GlobalRollX; }
-    if (string == "GlobalRoll Y") { return T::GlobalRollY; }
+    if (string == "LocalRoll") { return T::LocalRoll; }
+    if (string == "GlobalRoll") { return T::GlobalRoll; }
     if (string == "Pan X") { return T::PanX; }
     if (string == "Pan Y") { return T::PanY; }
     if (string == "Property") { return T::Property; }

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -114,7 +114,6 @@ public:
         float min = 0.f, float max = 1.f,
         JoystickCameraStates::AxisInvert shouldInvert =
             JoystickCameraStates::AxisInvert::No,
-        JoystickCameraStates::AxisFlip shouldFlip = JoystickCameraStates::AxisFlip::No,
         bool isRemote = true);
 
     JoystickCameraStates::AxisInformation joystickAxisMapping(

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -105,15 +105,17 @@ public:
             JoystickCameraStates::AxisInvert::No,
         JoystickCameraStates::JoystickType joystickType =
             JoystickCameraStates::JoystickType::JoystickLike,
-        bool isSticky = false, double sensitivity = 0.0
-    );
+        bool isSticky = false,
+        JoystickCameraStates::AxisFlip shouldFlip = JoystickCameraStates::AxisFlip::No,
+        double sensitivity = 0.0);
 
     void setJoystickAxisMappingProperty(std::string joystickName,
         int axis, std::string propertyUri,
         float min = 0.f, float max = 1.f,
         JoystickCameraStates::AxisInvert shouldInvert =
-        JoystickCameraStates::AxisInvert::No, bool isRemote = true
-    );
+            JoystickCameraStates::AxisInvert::No,
+        JoystickCameraStates::AxisFlip shouldFlip = JoystickCameraStates::AxisFlip::No,
+        bool isRemote = true);
 
     JoystickCameraStates::AxisInformation joystickAxisMapping(
         const std::string& joystickName, int axis) const;

--- a/src/interaction/joystickcamerastates.cpp
+++ b/src/interaction/joystickcamerastates.cpp
@@ -276,7 +276,6 @@ void JoystickCameraStates::setAxisMappingProperty(std::string joystickName,
                                                   std::string propertyUri,
                                                   float min, float max,
                                                   AxisInvert shouldInvert,
-                                                  AxisFlip shouldFlip,
                                                   bool isRemote)
 {
     JoystickCameraState* joystickCameraState = findOrAddJoystickCameraState(joystickName);
@@ -292,7 +291,6 @@ void JoystickCameraStates::setAxisMappingProperty(std::string joystickName,
 
     joystickCameraState->axisMapping[axis].type = AxisType::Property;
     joystickCameraState->axisMapping[axis].invert = shouldInvert;
-    joystickCameraState->axisMapping[axis].flip = shouldFlip;
     joystickCameraState->axisMapping[axis].propertyUri = propertyUri;
     joystickCameraState->axisMapping[axis].minValue = min;
     joystickCameraState->axisMapping[axis].maxValue = max;

--- a/src/interaction/joystickcamerastates.cpp
+++ b/src/interaction/joystickcamerastates.cpp
@@ -121,6 +121,10 @@ void JoystickCameraStates::updateStateFromInput(
                 }
             }
 
+            if (t.flip) {
+                value = -value;
+            }
+
             switch (t.type) {
                 case AxisType::None:
                     break;
@@ -242,6 +246,7 @@ void JoystickCameraStates::setAxisMapping(std::string joystickName,
                                           AxisInvert shouldInvert,
                                           JoystickType joystickType,
                                           bool isSticky,
+                                          AxisFlip shouldFlip,
                                           double sensitivity)
 {
     JoystickCameraState* joystickCameraState = findOrAddJoystickCameraState(joystickName);
@@ -259,6 +264,7 @@ void JoystickCameraStates::setAxisMapping(std::string joystickName,
     joystickCameraState->axisMapping[axis].invert = shouldInvert;
     joystickCameraState->axisMapping[axis].joystickType = joystickType;
     joystickCameraState->axisMapping[axis].isSticky = isSticky;
+    joystickCameraState->axisMapping[axis].flip = shouldFlip;
     joystickCameraState->axisMapping[axis].sensitivity = sensitivity;
 
     joystickCameraState->prevAxisValues[axis] =
@@ -270,6 +276,7 @@ void JoystickCameraStates::setAxisMappingProperty(std::string joystickName,
                                                   std::string propertyUri,
                                                   float min, float max,
                                                   AxisInvert shouldInvert,
+                                                  AxisFlip shouldFlip,
                                                   bool isRemote)
 {
     JoystickCameraState* joystickCameraState = findOrAddJoystickCameraState(joystickName);
@@ -285,6 +292,7 @@ void JoystickCameraStates::setAxisMappingProperty(std::string joystickName,
 
     joystickCameraState->axisMapping[axis].type = AxisType::Property;
     joystickCameraState->axisMapping[axis].invert = shouldInvert;
+    joystickCameraState->axisMapping[axis].flip = shouldFlip;
     joystickCameraState->axisMapping[axis].propertyUri = propertyUri;
     joystickCameraState->axisMapping[axis].minValue = min;
     joystickCameraState->axisMapping[axis].maxValue = max;

--- a/src/interaction/joystickcamerastates.cpp
+++ b/src/interaction/joystickcamerastates.cpp
@@ -56,8 +56,8 @@ void JoystickCameraStates::updateStateFromInput(
 
     std::pair<bool, glm::dvec2> globalRotation = std::pair(false, glm::dvec2(0.0));
     std::pair<bool, double> zoom = std::pair(false, 0.0);
-    std::pair<bool, glm::dvec2> localRoll = std::pair(false, glm::dvec2(0.0));
-    std::pair<bool, glm::dvec2> globalRoll = std::pair(false, glm::dvec2(0.0));
+    std::pair<bool, double> localRoll = std::pair(false, 0.0);
+    std::pair<bool, double> globalRoll = std::pair(false, 0.0);
     std::pair<bool, glm::dvec2> localRotation = std::pair(false, glm::dvec2(0.0));
 
     for (const JoystickInputState& joystickInputState : joystickInputStates) {
@@ -145,21 +145,13 @@ void JoystickCameraStates::updateStateFromInput(
                     zoom.first = true;
                     zoom.second -= value;
                     break;
-                case AxisType::LocalRollX:
+                case AxisType::LocalRoll:
                     localRoll.first = true;
-                    localRoll.second.x += value;
+                    localRoll.second+= value;
                     break;
-                case AxisType::LocalRollY:
-                    localRoll.first = true;
-                    localRoll.second.y += value;
-                    break;
-                case AxisType::GlobalRollX:
+                case AxisType::GlobalRoll:
                     globalRoll.first = true;
-                    globalRoll.second.x += value;
-                    break;
-                case AxisType::GlobalRollY:
-                    globalRoll.first = true;
-                    globalRoll.second.y += value;
+                    globalRoll.second += value;
                     break;
                 case AxisType::PanX:
                     localRotation.first = true;
@@ -220,14 +212,14 @@ void JoystickCameraStates::updateStateFromInput(
     }
 
     if (localRoll.first) {
-        _localRollState.velocity.set(localRoll.second, deltaTime);
+        _localRollState.velocity.set(glm::dvec2(localRoll.second), deltaTime);
     }
     else {
         _localRollState.velocity.decelerate(deltaTime);
     }
 
     if (globalRoll.first) {
-        _globalRollState.velocity.set(globalRoll.second, deltaTime);
+        _globalRollState.velocity.set(glm::dvec2(globalRoll.second), deltaTime);
     }
     else {
         _globalRollState.velocity.decelerate(deltaTime);

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -544,7 +544,6 @@ void NavigationHandler::setJoystickAxisMappingProperty(std::string joystickName,
                                                        std::string propertyUri,
                                                        float min, float max,
                                             JoystickCameraStates::AxisInvert shouldInvert,
-                                                JoystickCameraStates::AxisFlip shouldFlip,
                                                        bool isRemote)
 {
     _orbitalNavigator.joystickStates().setAxisMappingProperty(
@@ -554,7 +553,6 @@ void NavigationHandler::setJoystickAxisMappingProperty(std::string joystickName,
         min,
         max,
         shouldInvert,
-        shouldFlip,
         isRemote
     );
 }

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -524,6 +524,7 @@ void NavigationHandler::setJoystickAxisMapping(std::string joystickName, int axi
                                             JoystickCameraStates::AxisInvert shouldInvert,
                                           JoystickCameraStates::JoystickType joystickType,
                                                bool isSticky,
+                                               JoystickCameraStates::AxisFlip shouldFlip,
                                                double sensitivity)
 {
     _orbitalNavigator.joystickStates().setAxisMapping(
@@ -533,6 +534,7 @@ void NavigationHandler::setJoystickAxisMapping(std::string joystickName, int axi
         shouldInvert,
         joystickType,
         isSticky,
+        shouldFlip,
         sensitivity
     );
 }
@@ -542,6 +544,7 @@ void NavigationHandler::setJoystickAxisMappingProperty(std::string joystickName,
                                                        std::string propertyUri,
                                                        float min, float max,
                                             JoystickCameraStates::AxisInvert shouldInvert,
+                                                JoystickCameraStates::AxisFlip shouldFlip,
                                                        bool isRemote)
 {
     _orbitalNavigator.joystickStates().setAxisMappingProperty(
@@ -551,6 +554,7 @@ void NavigationHandler::setJoystickAxisMappingProperty(std::string joystickName,
         min,
         max,
         shouldInvert,
+        shouldFlip,
         isRemote
     );
 }

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -169,12 +169,24 @@ namespace {
  * 'isSticky' is 'true', the value is calculated relative to the previous value. If
  * 'sensitivity' is given then that value will affect the sensitivity of the axis together
  * with the global sensitivity.
+ *
+ * \param joystickName the name for the joystick or game controller that should be bound
+ * \param axis the axis of the joystick that should be bound
+ * \param axisType the type of movement that the axis should be mapped to
+ * \param shouldInvert if the joystick movement should be inverted or not
+ * \param joystickType what type of joystick or axis this is. Either
+ *                     <code>"JoystickLike"</code> or <code>"TriggerLike"</code>.
+ * \param isSticky if true, the value is calculated relative to the previous value,
+ *                 if false the the value is used as is.
+ * \param shouldFlip reverses the movement of the camera that the joystick produces
+ * \param sensitivity sensitivity for this axis
  */
 [[codegen::luawrap]] void bindJoystickAxis(std::string joystickName, int axis,
                                            std::string axisType,
                                            bool shouldInvert = false,
                                            std::string joystickType = "JoystickLike",
                                            bool isSticky = false,
+                                           bool shouldFlip = false,
                                            double sensitivity = 0.0)
 {
     using namespace openspace;
@@ -186,6 +198,7 @@ namespace {
         JoystickCameraStates::AxisInvert(shouldInvert),
         ghoul::from_string<JoystickCameraStates::JoystickType>(joystickType),
         isSticky,
+        JoystickCameraStates::AxisFlip(shouldFlip),
         sensitivity
     );
 }
@@ -197,21 +210,34 @@ namespace {
  * value is rescaled from [-1, 1] to [min, max], default is [0, 1]. If 'isInverted' is
  * 'true', the axis value is inverted. The last argument determines whether the property
  * change is going to be executed locally or remotely, where the latter is the default.
+ *
+ * \param joystickName the name for the joystick or game controller that should be bound
+ * \param axis the axis of the joystick that should be bound
+ * \param propertyUri the property that this joystick axis should modify
+ * \param min the minimum value that this axis can set for the property
+ * \param max the maximum value that this axis can set for the property
+ * \param shouldInvert if the joystick movement should be inverted or not
+ * \param shouldFlip reverses the movement of the camera that the joystick produces
+ * \param isRemote if true, the property change will also be executed on connected nodes
+ *                 if false, the property change will only affect the master node
  */
 [[codegen::luawrap]] void bindJoystickAxisProperty(std::string joystickName, int axis,
                                                    std::string propertyUri,
                                                    float min = 0.f, float max = 1.f,
                                                    bool shouldInvert = false,
+                                                   bool shouldFlip = false,
                                                    bool isRemote = true)
 {
     using namespace openspace;
+    using JoystickCameraStates = interaction::JoystickCameraStates;
     global::navigationHandler->setJoystickAxisMappingProperty(
         std::move(joystickName),
         axis,
         std::move(propertyUri),
         min,
         max,
-        interaction::JoystickCameraStates::AxisInvert(shouldInvert),
+        JoystickCameraStates::AxisInvert(shouldInvert),
+        JoystickCameraStates::AxisFlip(shouldFlip),
         isRemote
     );
 }
@@ -226,7 +252,7 @@ namespace {
  * bool.
  */
 [[codegen::luawrap]]
-std::tuple<std::string, bool, std::string, bool, double, std::string, float, float, bool>
+std::tuple<std::string, bool, std::string, bool, bool, double, std::string, float, float, bool>
 joystickAxis(std::string joystickName, int axis)
 {
     using namespace openspace;
@@ -239,6 +265,7 @@ joystickAxis(std::string joystickName, int axis)
         info.invert,
         ghoul::to_string(info.joystickType),
         info.isSticky,
+        info.flip,
         info.sensitivity,
         info.propertyUri,
         info.minValue,

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -167,6 +167,7 @@ namespace {
  * 'isInverted' is 'true', the axis value is inverted. 'joystickType' is if the joystick
  * behaves more like a joystick or a trigger, where the first is the default. If
  * 'isSticky' is 'true', the value is calculated relative to the previous value. If
+ * 'shouldFlip' is true, then the camera movement for the axis is reversed. If
  * 'sensitivity' is given then that value will affect the sensitivity of the axis together
  * with the global sensitivity.
  *

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -217,7 +217,6 @@ namespace {
  * \param min the minimum value that this axis can set for the property
  * \param max the maximum value that this axis can set for the property
  * \param shouldInvert if the joystick movement should be inverted or not
- * \param shouldFlip reverses the movement of the camera that the joystick produces
  * \param isRemote if true, the property change will also be executed on connected nodes
  *                 if false, the property change will only affect the master node
  */
@@ -225,7 +224,6 @@ namespace {
                                                    std::string propertyUri,
                                                    float min = 0.f, float max = 1.f,
                                                    bool shouldInvert = false,
-                                                   bool shouldFlip = false,
                                                    bool isRemote = true)
 {
     using namespace openspace;
@@ -237,7 +235,6 @@ namespace {
         min,
         max,
         JoystickCameraStates::AxisInvert(shouldInvert),
-        JoystickCameraStates::AxisFlip(shouldFlip),
         isRemote
     );
 }


### PR DESCRIPTION
Closes #2647 and makes it possible to reverse a joystick axis movement. Worth mentioning is that this will also remove the Roll Y movement for the joysticks that were never used. So now only LoclaRoll and GlobalRoll exist.