### PR TITLE
Issue/2682

### DIFF
--- a/modules/globebrowsing/src/basictypes.h
+++ b/modules/globebrowsing/src/basictypes.h
@@ -104,6 +104,7 @@ struct TileMetaData {
     std::array<float, 4> maxValues;
     std::array<float, 4> minValues;
     std::array<bool, 4> hasMissingData;
+    bool allMissingData = false;
     uint8_t nValues = 0;
 };
 

--- a/modules/globebrowsing/src/rawtiledatareader.cpp
+++ b/modules/globebrowsing/src/rawtiledatareader.cpp
@@ -977,9 +977,7 @@ TileMetaData RawTileDataReader::tileMetaData(RawTile& rawTile,
         }
     }
 
-    if (allIsMissing) {
-        rawTile.error = RawTile::ReadError::Failure;
-    }
+    ppData.allMissingData = allIsMissing;
 
     return ppData;
 }

--- a/modules/globebrowsing/src/tileprovider/defaulttileprovider.cpp
+++ b/modules/globebrowsing/src/tileprovider/defaulttileprovider.cpp
@@ -251,9 +251,16 @@ Tile::Status DefaultTileProvider::tileStatus(const TileIndex& index) {
         .tileIndex = index,
         .providerID = uniqueIdentifier
     };
+    
     cache::MemoryAwareTileCache* tileCache =
         global::moduleEngine->module<GlobeBrowsingModule>()->tileCache();
-    return tileCache->get(key).status;
+
+    Tile t = tileCache->get(key);
+    if (t.metaData.has_value() && t.metaData->allMissingData) {
+        return Tile::Status::OutOfRange;
+    }
+
+    return t.status;
 }
 
 TileDepthTransform DefaultTileProvider::depthTransform() {


### PR DESCRIPTION
Tile with only "noDataValue" no longer reports as status Failure.
Due to this change Tiles with only "noDataValue" won't get re-added into the job queue forever. 
Solves issue where height data did not display for underlaying heightmaps (#2682)