### PR TITLE
Switched multiple OpenGL calls to a single call for better efficiency

### DIFF
--- a/modules/space/rendering/renderableorbitalkepler.cpp
+++ b/modules/space/rendering/renderableorbitalkepler.cpp
@@ -290,14 +290,11 @@ void RenderableOrbitalKepler::render(const RenderData& data, RendererTasks&) {
 
     glLineWidth(_appearance.lineWidth);
 
-    const size_t nrOrbits = _segmentSize.size();
-    gl::GLint vertices = 0;
-
     //glDepthMask(false);
     //glBlendFunc(GL_SRC_ALPHA, GL_ONE)
 
-    GLint* _si = &_startIndex[0];
-    GLint* _ss = &_segmentSize[0];
+    GLint* _si = _startIndex.data();
+    GLint* _ss = _segmentSize.data();
 
     glBindVertexArray(_vertexArray);
     glMultiDrawArrays(GL_LINE_STRIP, _si, _ss, static_cast<GLsizei>(_startIndex.size()));

--- a/modules/space/rendering/renderableorbitalkepler.cpp
+++ b/modules/space/rendering/renderableorbitalkepler.cpp
@@ -296,11 +296,11 @@ void RenderableOrbitalKepler::render(const RenderData& data, RendererTasks&) {
     //glDepthMask(false);
     //glBlendFunc(GL_SRC_ALPHA, GL_ONE)
 
+    GLint* _si = &_startIndex[0];
+    GLint* _ss = &_segmentSize[0];
+
     glBindVertexArray(_vertexArray);
-    for (size_t i = 0; i < nrOrbits; ++i) {
-        glDrawArrays(GL_LINE_STRIP, vertices, static_cast<GLsizei>(_segmentSize[i] + 1));
-        vertices = vertices + static_cast<GLint>(_segmentSize[i]) + 1;
-    }
+    glMultiDrawArrays(GL_LINE_STRIP, _si, _ss, static_cast<GLsizei>(_startIndex.size()));
     glBindVertexArray(0);
 
     _programObject->deactivate();
@@ -363,12 +363,17 @@ void RenderableOrbitalKepler::updateBuffers() {
     }
 
     _segmentSize.clear();
-    for (const kepler::Parameters& p : parameters) {
+    _startIndex.clear();
+    _startIndex.push_back(0);
+    for (int i = 0; i < parameters.size(); ++i) {
         const double scale = static_cast<double>(_segmentQuality) * 10.0;
+        const kepler::Parameters& p = parameters[i];
         _segmentSize.push_back(
             static_cast<size_t>(scale + (scale / pow(1 - p.eccentricity, 1.2)))
         );
+        _startIndex.push_back(_startIndex[i] + static_cast<GLint>(_segmentSize[i]) + 1);
     }
+    _startIndex.pop_back();
 
     size_t nVerticesTotal = 0;
 

--- a/modules/space/rendering/renderableorbitalkepler.h
+++ b/modules/space/rendering/renderableorbitalkepler.h
@@ -58,7 +58,8 @@ private:
 
     bool _updateDataBuffersAtNextRender = false;
     std::streamoff _numObjects;
-    std::vector<size_t> _segmentSize;
+    std::vector<GLint> _segmentSize;
+    std::vector<GLint> _startIndex;
     properties::UIntProperty _segmentQuality;
     properties::UIntProperty _startRenderIdx;
     properties::UIntProperty _sizeRender;


### PR DESCRIPTION
Switched multiple OpenGL calls to single a call for better efficiency from `glDrawArrays` to `glMultiDrawArrays` .
This increases performance when rendering Main Asteroid Belt from 20 fps to 85 fps on my machine.

## Before
![mainbelt_before](https://github.com/OpenSpace/OpenSpace/assets/9076357/569048c1-d80b-4347-acc7-8507788ffb6d)

## After
![mainbelt_after](https://github.com/OpenSpace/OpenSpace/assets/9076357/582ae469-6572-440e-a1f7-1971cff0bc03)
