### PR TITLE
Fix for date format in sssb v2 asteroids files (issue 2649)

### DIFF
--- a/data/assets/scene/solarsystem/sssb/amor_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/amor_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Amor Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_amor_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/apollo_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/apollo_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Apollo Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_apollo_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/aten_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/aten_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Aten Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_aten_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/atira_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/atira_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Atira Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_atira_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/centaur_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/centaur_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Centaur Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_centaur_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/chiron-type_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/chiron-type_comet.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Chiron-type Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_chiron-type_comet",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/encke-type_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/encke-type_comet.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Encke-type Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_encke-type_comet",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/halley-type_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/halley-type_comet.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Halley-type Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_halley-type_comet",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/inner_main_belt_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/inner_main_belt_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Inner Main Belt Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_inner_main_belt_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/jupiter-family_comet.asset
+++ b/data/assets/scene/solarsystem/sssb/jupiter-family_comet.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Jupiter Family Comet)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_jupiter-family_comet",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/jupiter_trojan_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/jupiter_trojan_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Jupiter Trojan Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_jupiter_trojan_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/main_belt_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/main_belt_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Main Belt Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_main_belt_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/mars-crossing_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/mars-crossing_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Mars-Crossing Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_mars-crossing_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/outer_main_belt_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/outer_main_belt_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Outer Main Belt Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_outer_main_belt_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/pha.asset
+++ b/data/assets/scene/solarsystem/sssb/pha.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Potentially hazardous Asteroids)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_pha",
-  Version = 2
+  Version = 3
 })
 
 

--- a/data/assets/scene/solarsystem/sssb/transneptunian_object_asteroid.asset
+++ b/data/assets/scene/solarsystem/sssb/transneptunian_object_asteroid.asset
@@ -6,7 +6,7 @@ local sssb = asset.syncedResource({
   Name = "Small SolarSystem Body Data (Trans-Neptunian Object Asteroid)",
   Type = "HttpSynchronization",
   Identifier = "sssb_data_transneptunian_object_asteroid",
-  Version = 2
+  Version = 3
 })
 
 

--- a/modules/space/kepler.cpp
+++ b/modules/space/kepler.cpp
@@ -262,12 +262,9 @@ namespace {
         size_t nDashes = std::count_if(
             epoch.begin(),
             epoch.end(),
-            []( char c ) {return c =='-';}
+            [](char c) { return c == '-'; }
         );
-        std::string formatString = "{:4}{:2}{:2}{}";
-        if (nDashes == 2) {
-            formatString = "{:4}-{:2}-{:2}{}";
-        }
+        std::string formatString = (nDashes == 2) ? "{:4}-{:2}-{:2}{}" : "{:4}{:2}{:2}{}";
         auto [res, year, monthNum, dayOfMonthNum, fractionOfDay] =
             scn::scan_tuple<int, int, int, double>(e, formatString);
         if (!res) {

--- a/modules/space/kepler.cpp
+++ b/modules/space/kepler.cpp
@@ -239,8 +239,9 @@ namespace {
     }
 
     double epochFromYMDdSubstring(const std::string& epoch) {
-        // The epochString is in the form:
+        // The epochString can be in one of two forms:
         // YYYYMMDD.ddddddd
+        // YYYY-MM-DD.ddddddd
         // With YYYY as the year, MM the month (1 - 12), DD the day of month (1-31),
         // and dddd the fraction of that day.
 
@@ -258,8 +259,17 @@ namespace {
             e += ".0";
         }
         // 1, 2
+        size_t nDashes = std::count_if(
+            epoch.begin(),
+            epoch.end(),
+            []( char c ) {return c =='-';}
+        );
+        std::string formatString = "{:4}{:2}{:2}{}";
+        if (nDashes == 2) {
+            formatString = "{:4}-{:2}-{:2}{}";
+        }
         auto [res, year, monthNum, dayOfMonthNum, fractionOfDay] =
-            scn::scan_tuple<int, int, int, double>(e, "{:4}{:2}{:2}{}");
+            scn::scan_tuple<int, int, int, double>(e, formatString);
         if (!res) {
             throw ghoul::RuntimeError(fmt::format("Error parsing epoch '{}'", epoch));
         }

--- a/modules/space/kepler.cpp
+++ b/modules/space/kepler.cpp
@@ -613,7 +613,7 @@ std::vector<Parameters> readSbdbFile(std::filesystem::path file) {
     if (line != ExpectedHeader) {
         throw ghoul::RuntimeError(fmt::format(
             "Expected JPL SBDB file to start with '{}' but found '{}' instead",
-            ExpectedHeader, line
+            ExpectedHeader, line.substr(0, 100)
         ));
     }
 

--- a/modules/space/kepler.cpp
+++ b/modules/space/kepler.cpp
@@ -608,6 +608,8 @@ std::vector<Parameters> readSbdbFile(std::filesystem::path file) {
 
     std::string line;
     std::getline(f, line);
+    // Newer versions downloaded from the JPL SBDB website have " around variables
+    line.erase(remove(line.begin(), line.end(), '\"'), line.end());
     if (line != ExpectedHeader) {
         throw ghoul::RuntimeError(fmt::format(
             "Expected JPL SBDB file to start with '{}' but found '{}' instead",


### PR DESCRIPTION
The JPL SSSB site changed their date format from `YYYYMMDD` to `YYYY-MM-DD`. Our v1 asteroids files have the first date format, and our v2 files have the second.
This version will accept either of these two format, so that the older v1 files will still work.

**Important Note for Testing this PR:**
The crash mentioned in issue 2649 only occurs if OpenSpace was built in Debug mode.
In order to verify this fix, the following are required:

- Build & run OpenSpace in Debug mode
- Delete all cache folders that begin with _sssb_data__
- Delete all folders in sync/http that begin with _sssb_data__
- In openspace.cfg entry for `Sync{HttpSynchronizationRepositories}`, comment-out all other servers except for `http://openspace.sci.utah.edu/request`.