### PR TITLE
Fix for preventing adding property from scriptlog if already in add mode

### DIFF
--- a/apps/OpenSpace/ext/launcher/include/profile/propertiesdialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/propertiesdialog.h
@@ -83,7 +83,7 @@ private:
     QPushButton* _addButton = nullptr;
     QPushButton* _removeButton = nullptr;
 
-    QPushButton* _fillFromScriptLog = nullptr;
+    QPushButton* _addFromScriptLog = nullptr;
     QLabel* _commandLabel = nullptr;
     QComboBox* _commandCombo = nullptr;
     QLabel* _propertyLabel = nullptr;

--- a/apps/OpenSpace/ext/launcher/src/profile/propertiesdialog.cpp
+++ b/apps/OpenSpace/ext/launcher/src/profile/propertiesdialog.cpp
@@ -93,12 +93,12 @@ void PropertiesDialog::createWidgets() {
 
         box->addStretch();
 
-        _fillFromScriptLog = new QPushButton("Fill from ScriptLog");
+        _addFromScriptLog = new QPushButton("Add from ScriptLog");
         connect(
-            _fillFromScriptLog, &QPushButton::clicked,
+            _addFromScriptLog, &QPushButton::clicked,
             this, &PropertiesDialog::selectLineFromScriptLog
         );
-        box->addWidget(_fillFromScriptLog);
+        box->addWidget(_addFromScriptLog);
 
         layout->addLayout(box);
     }
@@ -316,6 +316,7 @@ void PropertiesDialog::transitionToEditMode() {
     _saveButton->setDisabled(true);
     _cancelButton->setDisabled(true);
     _buttonBox->setDisabled(true);
+    _addFromScriptLog->setDisabled(true);
 
     _commandLabel->setText("<font color='black'>Property Set Command</font>");
     _propertyLabel->setText("<font color='black'>Property</font>");
@@ -331,6 +332,7 @@ void PropertiesDialog::transitionFromEditMode() {
     _saveButton->setDisabled(false);
     _cancelButton->setDisabled(false);
     _buttonBox->setDisabled(false);
+    _addFromScriptLog->setDisabled(false);
 
     _commandLabel->setText("<font color='light gray'>Property Set Command</font>");
     _propertyLabel->setText("<font color='light gray'>Property</font>");


### PR DESCRIPTION
The profile editor's property dialog now has two ways of adding a property: manual or fill-from-scriptlog. This change prevents user from being able to select the scriptlog fill option if the editor is currently in edit mode (adding or changing a property).