### PR TITLE
Fixes line ending problems with horizons vector files on linux

### DIFF
--- a/modules/space/horizonsfile.cpp
+++ b/modules/space/horizonsfile.cpp
@@ -504,8 +504,9 @@ HorizonsResult readHorizonsFile(std::filesystem::path file) {
     // " Before data starts, Observer table doesn't
     std::string line;
     std::getline(fileStream, line);
+    const std::string vectorTabHeader = "JDTDB";
     while (line[0] != '$') {
-        if (line == "JDTDB") {
+        if (line.substr(0, vectorTabHeader.size()) == vectorTabHeader) {
             fileStream.close();
             return readHorizonsVectorFile(file);
         }


### PR DESCRIPTION
This fix allows importing and rendering from horizons files in vector format by removing the former dependency on windows vs linux line endings.