### PR TITLE
Fixes #2540 by correctly showing all points, including the proper end point

### DIFF
--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -253,8 +253,9 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
         }
         ++_sweepIteration;
 
+        // Full sweep is complete here.
         // Adds the last point in time to the _vertexArray so that we
-        // ensure that points for _start and _end always exists.
+        // ensure that points for _start and _end always exists
         if (stopIndex == _numberOfVertices) {
             const glm::vec3 p = _translation->position({
                 {},
@@ -262,9 +263,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
                 Time(0.0)
             });
             _vertexArray[stopIndex] = { p.x, p.y, p.z };
-        }
 
-        if (stopIndex == _numberOfVertices) {
             _sweepIteration = 0;
             setBoundingSphere(glm::distance(_maxVertex, _minVertex) / 2.f);
         }

--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -218,15 +218,15 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             // Cap _numberOfVertices in order to prevent overflow and extreme performance
             // degredation/RAM usage
             _numberOfVertices = std::min(
-                static_cast<unsigned int>(timespan / _totalSampleInterval),
+                static_cast<unsigned int>(std::ceil(timespan / _totalSampleInterval)),
                 maxNumberOfVertices
             );
 
             // We need to recalcuate the _totalSampleInterval if _numberOfVertices eqals
             // maxNumberOfVertices. If we don't do this the position for each vertex
             // will not be correct for the number of vertices we are doing along the trail
-            _totalSampleInterval = (_numberOfVertices == maxNumberOfVertices) ?
-                (timespan / _numberOfVertices) : _totalSampleInterval;
+            _totalSampleInterval = std::max(1.0, (_numberOfVertices == maxNumberOfVertices) ?
+                (timespan / _numberOfVertices) : _totalSampleInterval);
 
             // Make space for the vertices
             _vertexArray.clear();
@@ -311,7 +311,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             (data.time.j2000Seconds() - _start) / (_end - _start)
         );
         if (data.time.j2000Seconds() < _end) {
-            _primaryRenderInformation.count = static_cast<GLsizei>(_vertexArray.size() * t);
+            _primaryRenderInformation.count = static_cast<GLsizei>(std::max(1.0,_vertexArray.size() * t));
         }
         else {
             _primaryRenderInformation.count = static_cast<GLsizei>(_vertexArray.size());

--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -225,8 +225,9 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             // We need to recalcuate the _totalSampleInterval if _numberOfVertices eqals
             // maxNumberOfVertices. If we don't do this the position for each vertex
             // will not be correct for the number of vertices we are doing along the trail
-            _totalSampleInterval = std::max(1.0, (_numberOfVertices == maxNumberOfVertices) ?
-                (timespan / _numberOfVertices) : _totalSampleInterval);
+            _totalSampleInterval = (_numberOfVertices == maxNumberOfVertices) ?
+                (timespan / _numberOfVertices) : _totalSampleInterval;
+            _totalSampleInterval = std::max(1.0, _totalSampleInterval);
 
             // Make space for the vertices
             _vertexArray.clear();

--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -310,7 +310,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             (data.time.j2000Seconds() - _start) / (_end - _start)
         );
         if (data.time.j2000Seconds() < _end) {
-            _primaryRenderInformation.count = static_cast<GLsizei>(std::max(1.0,_vertexArray.size() * t));
+            _primaryRenderInformation.count = static_cast<GLsizei>(std::max(1.0, _vertexArray.size() * t));
         }
         else {
             _primaryRenderInformation.count = static_cast<GLsizei>(_vertexArray.size());

--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -230,7 +230,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
 
             // Make space for the vertices
             _vertexArray.clear();
-            _vertexArray.resize(_numberOfVertices);
+            _vertexArray.resize(_numberOfVertices + 1);
         }
 
         // Calculate sweeping range for this iteration
@@ -252,6 +252,17 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             _minVertex = glm::min(_minVertex, p);
         }
         ++_sweepIteration;
+
+        // Adds the last point in time to the _vertexArray so that we
+        // ensure that points for _start and _end always exists.
+        if (stopIndex == _numberOfVertices) {
+            const glm::vec3 p = _translation->position({
+                {},
+                Time(_end),
+                Time(0.0)
+            });
+            _vertexArray[stopIndex] = { p.x, p.y, p.z };
+        }
 
         if (stopIndex == _numberOfVertices) {
             _sweepIteration = 0;
@@ -299,10 +310,13 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
             0.0,
             (data.time.j2000Seconds() - _start) / (_end - _start)
         );
-        _primaryRenderInformation.count = std::min(
-            static_cast<GLsizei>(ceil(_vertexArray.size() * t)),
-            static_cast<GLsizei>(_vertexArray.size() - 1)
-        );
+        if (data.time.j2000Seconds() < _end) {
+            _primaryRenderInformation.count = static_cast<GLsizei>(_vertexArray.size() * t);
+        }
+        else {
+            _primaryRenderInformation.count = static_cast<GLsizei>(_vertexArray.size());
+        }
+
     }
 
     // If we are inside the valid time, we additionally want to draw a line from the last


### PR DESCRIPTION
### 1. RenderableTrailTrajectory now includes proper end points

#### Before:
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/572a573a-37b8-43c7-a870-7aa402eb8dda)

#### After:
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/22a146b7-859c-467e-ae3b-230409a94701)

____________________________________

### 2. RenderableTrajectory now renders proper amount of points based on `_numberOfVertices`

#### Before:
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/fdcd6a6b-2e8e-4c6d-bddd-b12da3890d64)

##### After:
**Note**: the end point is added afterwards and is not included in this variable
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/6f545874-cce7-44a4-b478-7379ebc8ccd4)
