### PR TITLE
Don't call update function unless layer has been initialized

### DIFF
--- a/modules/globebrowsing/src/layer.cpp
+++ b/modules/globebrowsing/src/layer.cpp
@@ -384,6 +384,7 @@ void Layer::initialize() {
     if (_tileProvider) {
         _tileProvider->initialize();
     }
+    _isInitialized = true;
 }
 
 void Layer::deinitialize() {

--- a/modules/globebrowsing/src/layer.cpp
+++ b/modules/globebrowsing/src/layer.cpp
@@ -438,6 +438,10 @@ bool Layer::enabled() const {
     return _enabled;
 }
 
+bool Layer::isInitialized() const {
+    return _isInitialized;
+}
+
 TileProvider* Layer::tileProvider() const {
     return _tileProvider.get();
 }

--- a/modules/globebrowsing/src/layer.h
+++ b/modules/globebrowsing/src/layer.h
@@ -58,6 +58,7 @@ public:
     TileDepthTransform depthTransform() const;
     void setEnabled(bool enabled);
     bool enabled() const;
+    bool isInitialized() const;
     TileProvider* tileProvider() const;
     glm::vec3 solidColor() const;
     const LayerRenderSettings& renderSettings() const;
@@ -99,6 +100,7 @@ private:
     const layers::Group::ID _layerGroupId;
 
     std::function<void(Layer*)> _onChangeCallback;
+    bool _isInitialized = false;
   };
 
 } // namespace openspace::globebrowsing

--- a/modules/globebrowsing/src/layergroup.cpp
+++ b/modules/globebrowsing/src/layergroup.cpp
@@ -91,7 +91,7 @@ void LayerGroup::update() {
     _activeLayers.clear();
 
     for (const std::unique_ptr<Layer>& layer : _layers) {
-        if (layer->enabled()) {
+        if (layer->enabled() && layer->isInitialized()) {
             layer->update();
             _activeLayers.push_back(layer.get());
         }


### PR DESCRIPTION
Added a simple check to see if the layer is initialized before calling the update function.