### PR TITLE
Offset sample coordinate by 0.5 when estimating height values

### DIFF
--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1441,7 +1441,6 @@ void RenderableGlobe::renderChunkLocally(const Chunk& chunk, const RenderData& d
     const glm::dmat4 viewTransform = data.camera.combinedViewMatrix();
     const glm::dmat4 modelViewTransform = viewTransform * _cachedModelTransform;
 
-
     std::array<glm::dvec3, 4> cornersCameraSpace;
     std::array<glm::dvec3, 4> cornersModelSpace;
     for (int i = 0; i < 4; ++i) {
@@ -1997,7 +1996,7 @@ float RenderableGlobe::getHeight(const glm::dvec3& position) const {
 
         const glm::uvec3 dimensions = tileTexture->dimensions();
 
-        const glm::vec2 samplePos = transformedUv * glm::vec2(dimensions);
+        const glm::vec2 samplePos = transformedUv * glm::vec2(dimensions) - glm::vec2(0.5f);
         glm::uvec2 samplePos00 = samplePos;
         samplePos00 = glm::clamp(
             samplePos00,

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1996,7 +1996,12 @@ float RenderableGlobe::getHeight(const glm::dvec3& position) const {
 
         const glm::uvec3 dimensions = tileTexture->dimensions();
 
-        const glm::vec2 samplePos = transformedUv * glm::vec2(dimensions) - glm::vec2(0.5f);
+        glm::vec2 samplePos = transformedUv * glm::vec2(dimensions);
+        // @TODO (emmbr, 2023-06-14) This 0.5f offset was added as a bandaid for issue
+        // #2696. It seems to imrpve the behavior, but I am not certain of why. And the
+        // underlying problem is still there and should at some point be looked at again
+        samplePos -= glm::vec2(0.5f);
+
         glm::uvec2 samplePos00 = samplePos;
         samplePos00 = glm::clamp(
             samplePos00,

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1998,7 +1998,7 @@ float RenderableGlobe::getHeight(const glm::dvec3& position) const {
 
         glm::vec2 samplePos = transformedUv * glm::vec2(dimensions);
         // @TODO (emmbr, 2023-06-14) This 0.5f offset was added as a bandaid for issue
-        // #2696. It seems to imrpve the behavior, but I am not certain of why. And the
+        // #2696. It seems to improve the behavior, but I am not certain of why. And the
         // underlying problem is still there and should at some point be looked at again
         samplePos -= glm::vec2(0.5f);
 


### PR DESCRIPTION
This is really this PR: https://github.com/OpenSpace/OpenSpace/pull/2756

But I accidentally closed it when fxing a naming mistake in the branch name... 

The conclusion was that the offset seems to greatly remedy the behavior of the issue https://github.com/OpenSpace/OpenSpace/issues/2696, but it only fixes the symptom, not the underlying cause. Before the height tiles are fully loaded, it is still possible to intersect the planetary surface. 

Only affect the estimation of height values based on the camera position