### PR TITLE
Set pause directly instead of interpolating over 0 duration for setPause

### DIFF
--- a/src/util/timemanager.cpp
+++ b/src/util/timemanager.cpp
@@ -867,7 +867,7 @@ void TimeManager::interpolatePreviousDeltaTimeStep(double durationSeconds) {
 }
 
 void TimeManager::setPause(bool pause) {
-    interpolatePause(pause, 0);
+    _timePaused = pause;
 }
 
 void TimeManager::interpolatePause(bool pause, double interpolationDuration) {


### PR DESCRIPTION
Seems to solve problems in #2826 and #2510

Would be great if some people could try it out; it almost seems a bit too simple and I'm afraid it might cause problems in other scenarios (e.g. session recording?). Someone that has more experience with the time system or more ideas on what to test, please help me verify that it does not. 

There is still some weirdness when setting the time and interpolating the pause in the same frame, but perhaps that is to be expected. It does not quite make sense to do those two actions simultaneously, IMO