### PR TITLE
Rename Lua function to bring them more in line with the function naming in C++

### DIFF
--- a/data/assets/actions/planets/planet_lighting.asset
+++ b/data/assets/actions/planets/planet_lighting.asset
@@ -6,7 +6,7 @@ local function illuminationCommand(node, global)
   if (global) then
     commandString = commandString .. [[
 if (openspace.hasProperty("Scene."..node..".Renderable.UseAccurateNormals")) then
-  local list = openspace.getProperty("Scene." .. node .. ".Renderable.Layers.NightLayers.*.Enabled")
+  local list = openspace.property("Scene." .. node .. ".Renderable.Layers.NightLayers.*.Enabled")
   if (#list > 0) then
     openspace.setPropertyValue("Scene." .. node .. ".Renderable.Layers.NightLayers.*.Enabled", false)
   else
@@ -24,7 +24,7 @@ end]]
   else
     --todo @micahnyc this 40 wont do once we have more rings
     commandString = commandString .. [[if (openspace.hasProperty("Scene."..node..".Renderable.UseAccurateNormals")) then
-local list = openspace.getProperty("Scene." .. node .. ".Renderable.Layers.NightLayers.*.Enabled")
+local list = openspace.property("Scene." .. node .. ".Renderable.Layers.NightLayers.*.Enabled")
 if (#list > 0) then
   openspace.setPropertyValue(list[1], true)
 else

--- a/data/assets/actions/planets/scale_planets_and_moons.asset
+++ b/data/assets/actions/planets/scale_planets_and_moons.asset
@@ -29,12 +29,12 @@ local function toggleScaleAction(identifier, scale, name, speedup, speeddown)
     Identifier = "os.toggle_" .. string.gsub(name, "%s+", "") .. "_scale",
     Name = "Toggle " .. name .. " scale",
     Command = [[
-local list = openspace.getProperty("]] .. identifier .. [[.Scale.Scale")
+local list = openspace.property("]] .. identifier .. [[.Scale.Scale")
 if #list == 0 then
   openspace.printWarning("No planets to resize")
 else
   local prop = list[1]
-  local currentScale = openspace.getPropertyValue(prop)
+  local currentScale = openspace.propertyValue(prop)
   local newScale = 1
   if (currentScale == 1) then
     ]] .. scaleCommand(identifier, scale, speedup) .. [[

--- a/data/assets/actions/trails/on_off_all_minor_moons.asset
+++ b/data/assets/actions/trails/on_off_all_minor_moons.asset
@@ -2,11 +2,11 @@ local MinorMoonsOn = {
   Identifier = "os.MinorMoonsOn",
   Name = "Turn on minor moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -27,11 +27,11 @@ local MinorMoonsOff = {
   Identifier = "os.MinorMoonsOff",
   Name = "Turn off minor moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/actions/trails/toggle_all_dwarf_planet_trails.asset
+++ b/data/assets/actions/trails/toggle_all_dwarf_planet_trails.asset
@@ -2,9 +2,9 @@ local ToggleDwarfPlanetTrails = {
   Identifier = "os.ToggleDwarfPlanetTrails",
   Name = "Toggle dwarf planet trails",
   Command = [[
-    local list = openspace.getProperty("{planetTrail_dwarf}.Renderable.Enabled")
+    local list = openspace.property("{planetTrail_dwarf}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle on/off trails for all dwarf planets in the solar system",

--- a/data/assets/actions/trails/toggle_all_minor_moon_trails.asset
+++ b/data/assets/actions/trails/toggle_all_minor_moon_trails.asset
@@ -2,9 +2,9 @@ local ToggleMinorMoonTrails = {
   Identifier = "os.ToggleMinorMoonTrails",
   Name = "Toggle minor moon trails",
   Command = [[
-    local list = openspace.getProperty("{moonTrail_minor}.Renderable.Enabled")
+    local list = openspace.property("{moonTrail_minor}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle on/off minor moon trails for all planets in the solar system",

--- a/data/assets/actions/trails/toggle_all_trails.asset
+++ b/data/assets/actions/trails/toggle_all_trails.asset
@@ -2,11 +2,11 @@ local FadeUpTrails = {
   Identifier = "os.FadeUpTrails",
   Name = "Show all trails",
   Command = [[
-    local capList = openspace.getProperty("Scene.*Trail.Renderable.Fade")
+    local capList = openspace.property("Scene.*Trail.Renderable.Fade")
     for _,v in ipairs(capList) do
       openspace.setPropertyValueSingle(v, 1, 2)
     end
-    local list = openspace.getProperty("Scene.*trail.Renderable.Fade")
+    local list = openspace.property("Scene.*trail.Renderable.Fade")
     for _,v in ipairs(list) do
       openspace.setPropertyValueSingle(v, 1, 2)
     end
@@ -20,11 +20,11 @@ local FadeDownTrails = {
   Identifier = "os.FadeDownTrails",
   Name = "Hide all trails",
   Command = [[
-    local capList = openspace.getProperty("Scene.*Trail.Renderable.Fade")
+    local capList = openspace.property("Scene.*Trail.Renderable.Fade")
     for _,v in ipairs(capList) do
       openspace.setPropertyValueSingle(v, 0, 2)
     end
-    local list = openspace.getProperty("Scene.*trail.Renderable.Fade")
+    local list = openspace.property("Scene.*trail.Renderable.Fade")
     for _,v in ipairs(list) do
       openspace.setPropertyValueSingle(v, 0, 2)
     end
@@ -38,8 +38,8 @@ local ToggleTrails = {
   Identifier = "os.ToggleTrails",
   Name = "Toggle all trails",
   Command = [[
-    local capList = openspace.getProperty("*Trail.Renderable.Fade")
-    local list = openspace.getProperty("*trail.Renderable.Fade")
+    local capList = openspace.property("*Trail.Renderable.Fade")
+    local list = openspace.property("*trail.Renderable.Fade")
     if (#capList == 0) and (#list == 0) then
       openspace.printWarning("No trails to toggle")
     else
@@ -49,7 +49,7 @@ local ToggleTrails = {
       else
         prop = list[1]
       end
-      local currentFade = openspace.getPropertyValue(prop)
+      local currentFade = openspace.propertyValue(prop)
       local newFade = 0
       if currentFade < 1 then
         newFade = 1

--- a/data/assets/actions/trails/toggle_all_trails_planets_moons_instant.asset
+++ b/data/assets/actions/trails/toggle_all_trails_planets_moons_instant.asset
@@ -2,14 +2,14 @@ local ToggleTrailsInstant = {
   Identifier = "os.ToggleTrailsInstant",
   Name = "Toggle planet and moon trails (instant)",
   Command = [[
-    local list = openspace.getProperty("{planetTrail_solarSystem}.Renderable.Enabled")
+    local list = openspace.property("{planetTrail_solarSystem}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
 
-    local moonlist = openspace.getProperty("{moonTrail_solarSystem}.Renderable.Enabled")
+    local moonlist = openspace.property("{moonTrail_solarSystem}.Renderable.Enabled")
     for _,v in pairs(moonlist) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggles the visibility of planet and moon trails",

--- a/data/assets/actions/trails/toggle_trail.asset
+++ b/data/assets/actions/trails/toggle_trail.asset
@@ -29,7 +29,7 @@ local ToggleTrail = {
         return
       end
     else
-      visibility = not openspace.getPropertyValue("Scene." .. trail .. ".Renderable.Enabled")
+      visibility = not openspace.propertyValue("Scene." .. trail .. ".Renderable.Enabled")
     end
 
     if visibility then

--- a/data/assets/actions/trails/toggle_trails_planets_moons.asset
+++ b/data/assets/actions/trails/toggle_trails_planets_moons.asset
@@ -26,8 +26,8 @@ local ToggleTrails = {
   Identifier = "os.planetsmoons.ToggleTrails",
   Name = "Toggle planet and moon trails",
   Command = [[
-    local capList = openspace.getProperty("{planetTrail_solarSystem}.Renderable.Fade")
-    local list = openspace.getProperty("{moonTrail_solarSystem}.Renderable.Fade")
+    local capList = openspace.property("{planetTrail_solarSystem}.Renderable.Fade")
+    local list = openspace.property("{moonTrail_solarSystem}.Renderable.Fade")
     if (#capList == 0) and (#list == 0) then
       openspace.printWarning("No trails to toggle")
     else
@@ -37,7 +37,7 @@ local ToggleTrails = {
       else
         prop = list[1]
       end
-      local currentFade = openspace.getPropertyValue(prop)
+      local currentFade = openspace.propertyValue(prop)
       local newFade = 0
       if currentFade < 1 then
         newFade = 1

--- a/data/assets/actions/trails/trail_appearance.asset
+++ b/data/assets/actions/trails/trail_appearance.asset
@@ -29,12 +29,12 @@ local function toggleHighlightAction(identifierString, value, nameString)
     Identifier = "os.toggle_" .. identifierString .. "_trail_highlight",
     Name = "Toggle " .. nameString .. " trail highlight",
     Command = [[
-local list = openspace.getProperty("]] .. identifierString .. [[.Renderable.Appearance.Fade")
+local list = openspace.property("]] .. identifierString .. [[.Renderable.Appearance.Fade")
 if #list == 0 then
   openspace.printWarning("No planets to resize")
 else
   local prop = list[1]
-  local fadeValue = openspace.getPropertyValue(prop)
+  local fadeValue = openspace.propertyValue(prop)
   if fadeValue > 1 then
     ]] .. highlightCommand(identifierString, 1, nameString) .. "\n" .. [[
   else
@@ -76,8 +76,8 @@ local ToggleTrailFading = {
   Identifier = "os.ToggleTrailFading",
   Name = "Toggle trail fading",
   Command = [[
-    local capList = openspace.getProperty("*Trail.Renderable.Appearance.EnableFade")
-    local list = openspace.getProperty("*trail.Renderable.Appearance.EnableFade")
+    local capList = openspace.property("*Trail.Renderable.Appearance.EnableFade")
+    local list = openspace.property("*trail.Renderable.Appearance.EnableFade")
     if (#capList == 0) and (#list == 0) then
       openspace.printWarning("No trails to toggle")
     else
@@ -87,7 +87,7 @@ local ToggleTrailFading = {
       else
         prop = list[1]
       end
-      local currentFade = openspace.getPropertyValue(prop)
+      local currentFade = openspace.propertyValue(prop)
       local newFade = not currentFade
       openspace.setPropertyValue("Scene.*Trail.Renderable.Appearance.EnableFade", newFade)
       openspace.setPropertyValue("Scene.*trail.Renderable.Appearance.EnableFade", newFade)

--- a/data/assets/base_keybindings.asset
+++ b/data/assets/base_keybindings.asset
@@ -7,9 +7,9 @@ local TogglePlanetLabels = {
   Identifier = "os_default.TogglePlanetLabels",
   Name = "Toggle planet labels",
   Command = [[
-    local list = openspace.getProperty("{solarsystem_labels}.Renderable.Enabled")
+    local list = openspace.property("{solarsystem_labels}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Turns on visibility for all solar system labels",

--- a/data/assets/customization/gui.asset
+++ b/data/assets/customization/gui.asset
@@ -1,4 +1,4 @@
-asset.export("webguiDevelopmentMode", true)
+asset.export("webguiDevelopmentMode", false)
 
 -- To make changes to the webgui:
 

--- a/data/assets/customization/gui.asset
+++ b/data/assets/customization/gui.asset
@@ -1,4 +1,4 @@
-asset.export("webguiDevelopmentMode", false)
+asset.export("webguiDevelopmentMode", true)
 
 -- To make changes to the webgui:
 

--- a/data/assets/default_keybindings.asset
+++ b/data/assets/default_keybindings.asset
@@ -78,7 +78,7 @@ local FadeToBlack = {
   Identifier = "os.FadeToBlack",
   Name = "Fade to/from black",
   Command = [[
-    if openspace.getPropertyValue("RenderEngine.BlackoutFactor") > 0.5 then
+    if openspace.propertyValue("RenderEngine.BlackoutFactor") > 0.5 then
       openspace.setPropertyValueSingle("RenderEngine.BlackoutFactor", 0.0, 3)
     else
       openspace.setPropertyValueSingle("RenderEngine.BlackoutFactor", 1.0, 3)
@@ -102,7 +102,7 @@ local ToggleOverlays = {
   Identifier = "os.ToggleOverlays",
   Name = "Toggle dashboard and overlays",
   Command = [[
-    local isEnabled = openspace.getPropertyValue("Dashboard.IsEnabled")
+    local isEnabled = openspace.propertyValue("Dashboard.IsEnabled")
     openspace.setPropertyValueSingle("Dashboard.IsEnabled", not isEnabled)
     openspace.setPropertyValueSingle("RenderEngine.ShowLog", not isEnabled)
     openspace.setPropertyValueSingle("RenderEngine.ShowVersion", not isEnabled)

--- a/data/assets/events/toggle_sun.asset
+++ b/data/assets/events/toggle_sun.asset
@@ -7,7 +7,7 @@ local ToggleSun = {
       return
     end
 
-    if not openspace.getPropertyValue("Scene.Sun.Renderable.Enabled") then
+    if not openspace.propertyValue("Scene.Sun.Renderable.Enabled") then
       openspace.setPropertyValueSingle("Scene.Sun.Renderable.Enabled", true)
     end
 

--- a/data/assets/modules/exoplanets/exoplanets_data.asset
+++ b/data/assets/modules/exoplanets/exoplanets_data.asset
@@ -17,12 +17,12 @@ asset.onInitialize(function()
   -- Set the default data files used for the exoplanet system creation
   -- (Check if already set, to not override value set in another file)
   local p1 = "Modules.Exoplanets.DataFolder"
-  if (openspace.getPropertyValue(p1) == "") then
+  if (openspace.propertyValue(p1) == "") then
     openspace.setPropertyValueSingle(p1, dataPath)
   end
 
   local p2 = "Modules.Exoplanets.BvColormap"
-  if (openspace.getPropertyValue(p2) == "") then
+  if (openspace.propertyValue(p2) == "") then
     openspace.setPropertyValueSingle(p2, colormaps .. "colorbv.cmap")
   end
 end)

--- a/data/assets/modules/exoplanets/exoplanets_textures.asset
+++ b/data/assets/modules/exoplanets/exoplanets_textures.asset
@@ -31,27 +31,27 @@ asset.onInitialize(function()
   -- Set the default textures used for the exoplanet system creation
   -- (Check if already set, to not override value set in another file)
   local p1 = "Modules.Exoplanets.StarTexture"
-  if (openspace.getPropertyValue(p1) == "") then
+  if (openspace.propertyValue(p1) == "") then
     openspace.setPropertyValueSingle(p1, starTexture)
   end
 
   local p2 = "Modules.Exoplanets.StarGlareTexture"
-  if (openspace.getPropertyValue(p2) == "") then
+  if (openspace.propertyValue(p2) == "") then
     openspace.setPropertyValueSingle(p2, starGlareTexture)
   end
 
   local p3 = "Modules.Exoplanets.NoDataTexture"
-  if (openspace.getPropertyValue(p3) == "") then
+  if (openspace.propertyValue(p3) == "") then
     openspace.setPropertyValueSingle(p3, noDataTexture)
   end
 
   local p4 = "Modules.Exoplanets.OrbitDiscTexture"
-  if (openspace.getPropertyValue(p4) == "") then
+  if (openspace.propertyValue(p4) == "") then
     openspace.setPropertyValueSingle(p4, discTexture)
   end
 
   local p5 = "Modules.Exoplanets.HabitableZoneTexture"
-  if (openspace.getPropertyValue(p5) == "") then
+  if (openspace.propertyValue(p5) == "") then
     openspace.setPropertyValueSingle(p5, hzTexture)
   end
 end)

--- a/data/assets/nightsky/planets.asset
+++ b/data/assets/nightsky/planets.asset
@@ -156,7 +156,7 @@ local ToggleNightSkyPlanets = {
     openspace.toggleFade("Scene.NightSkyMars.Renderable")
     openspace.toggleFade("Scene.NightSkyJupiter.Renderable")
     openspace.toggleFade("Scene.NightSkySaturn.Renderable")
-    local scale = openspace.getPropertyValue("Scene.Moon.Scale.Scale")
+    local scale = openspace.propertyValue("Scene.Moon.Scale.Scale")
     if (scale > 1) then
       openspace.setPropertyValueSingle("Scene.Moon.Scale.Scale", 1.0)
     else

--- a/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
+++ b/data/assets/scene/solarsystem/heliosphere/2012/sun_earth_2012_fieldlines_pfss.asset
@@ -23,7 +23,7 @@ local DarkSun = {
   Name = "Dark sun",
   Command = [[
     local property = "Scene.Sun.Renderable.Layers.ColorLayers.Texture.Settings.Multiplier"
-    local textureMultiplier = openspace.getPropertyValue(property)
+    local textureMultiplier = openspace.propertyValue(property)
     if (textureMultiplier < 0.01) then
       openspace.setPropertyValueSingle(property, 1.0, 1)
     else

--- a/data/assets/scene/solarsystem/heliosphere/bastille_day/density_volume.asset
+++ b/data/assets/scene/solarsystem/heliosphere/bastille_day/density_volume.asset
@@ -56,11 +56,11 @@ local ToggleVolume = {
   Identifier = "os.bastilleday.densityvolume.ToggleVolume",
   Name = "Toggle volume",
   Command = [[
-    if openspace.getPropertyValue("Scene.MAS-MHD-Density-bastille-day-2000.Renderable.Enabled") then
+    if openspace.propertyValue("Scene.MAS-MHD-Density-bastille-day-2000.Renderable.Enabled") then
       openspace.setPropertyValueSingle(
         "Scene.MAS-MHD-Density-bastille-day-2000.Renderable.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("Scene.MAS-MHD-Density-bastille-day-2000.Renderable.Enabled", false)'
       )
@@ -69,7 +69,7 @@ local ToggleVolume = {
       openspace.setPropertyValueSingle(
         "Scene.MAS-MHD-Density-bastille-day-2000.Renderable.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end

--- a/data/assets/scene/solarsystem/heliosphere/bastille_day/fieldlines.asset
+++ b/data/assets/scene/solarsystem/heliosphere/bastille_day/fieldlines.asset
@@ -55,11 +55,11 @@ local ToggleFieldlines = {
   Identifier = "os.bastilleday.fieldlines.ToggleFieldlines",
   Name = "Toggle fieldlines",
   Command = [[
-    if openspace.getPropertyValue("Scene.MAS-MHD-Fieldlines-bastille-day-2000.Renderable.Enabled") then
+    if openspace.propertyValue("Scene.MAS-MHD-Fieldlines-bastille-day-2000.Renderable.Enabled") then
       openspace.setPropertyValueSingle(
         "Scene.MAS-MHD-Fieldlines-bastille-day-2000.Renderable.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("Scene.MAS-MHD-Fieldlines-bastille-day-2000.Renderable.Enabled", false)'
       )
@@ -68,7 +68,7 @@ local ToggleFieldlines = {
       openspace.setPropertyValueSingle(
         "Scene.MAS-MHD-Fieldlines-bastille-day-2000.Renderable.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end

--- a/data/assets/scene/solarsystem/heliosphere/bastille_day/fluxnodes.asset
+++ b/data/assets/scene/solarsystem/heliosphere/bastille_day/fluxnodes.asset
@@ -40,11 +40,11 @@ local ToggleFluxnodes = {
   Identifier = "os.bastilleday.fluxnodes.ToggleFluxnodes",
   Name = "Toggle flux nodes",
   Command = [[
-    if openspace.getPropertyValue("Scene.MAS-MHD-FluxNodes-bastille-day-2000.Renderable.Enabled") then
+    if openspace.propertyValue("Scene.MAS-MHD-FluxNodes-bastille-day-2000.Renderable.Enabled") then
       openspace.setPropertyValueSingle(
         "Scene.MAS-MHD-FluxNodes-bastille-day-2000.Renderable.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("Scene.MAS-MHD-FluxNodes-bastille-day-2000.Renderable.Enabled", false)'
       )
@@ -53,7 +53,7 @@ local ToggleFluxnodes = {
       openspace.setPropertyValueSingle(
         "Scene.MAS-MHD-FluxNodes-bastille-day-2000.Renderable.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end

--- a/data/assets/scene/solarsystem/heliosphere/bastille_day/fluxnodescutplane.asset
+++ b/data/assets/scene/solarsystem/heliosphere/bastille_day/fluxnodescutplane.asset
@@ -78,11 +78,11 @@ local ToggleEquatorial = {
   Identifier = "os.bastilleday.fluxnodescutplane.ToggleEquatorial",
   Name = "Toggle equatorial cutplane",
   Command = [[
-    if openspace.getPropertyValue("Scene.EquatorialCutplane-bastille-day-2000.Renderable.Enabled") then
+    if openspace.propertyValue("Scene.EquatorialCutplane-bastille-day-2000.Renderable.Enabled") then
       openspace.setPropertyValueSingle(
         "Scene.EquatorialCutplane-bastille-day-2000.Renderable.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("Scene.EquatorialCutplane-bastille-day-2000.Renderable.Enabled", false)'
       )
@@ -91,7 +91,7 @@ local ToggleEquatorial = {
       openspace.setPropertyValueSingle(
         "Scene.EquatorialCutplane-bastille-day-2000.Renderable.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end
@@ -104,11 +104,11 @@ local ToggleMeridial = {
   Identifier = "os.bastilleday.fluxnodescutplane.ToggleMeridial",
   Name = "Toggle meridial cutplane",
   Command = [[
-    if openspace.getPropertyValue("Scene.MeridialCutplane-bastille-day-2000.Renderable.Enabled") then
+    if openspace.propertyValue("Scene.MeridialCutplane-bastille-day-2000.Renderable.Enabled") then
       openspace.setPropertyValueSingle(
         "Scene.MeridialCutplane-bastille-day-2000.Renderable.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("Scene.MeridialCutplane-bastille-day-2000.Renderable.Enabled", false)'
       )
@@ -117,7 +117,7 @@ local ToggleMeridial = {
       openspace.setPropertyValueSingle(
         "Scene.MeridialCutplane-bastille-day-2000.Renderable.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end

--- a/data/assets/scene/solarsystem/heliosphere/bastille_day/fluxnodeslegend.asset
+++ b/data/assets/scene/solarsystem/heliosphere/bastille_day/fluxnodeslegend.asset
@@ -23,11 +23,11 @@ local ToggleLegend = {
   Identifier = "os.bastilleday.fluxnodelegend.ToggleLegend",
   Name = "Toggle the legend image",
   Command = [[
-    if openspace.getPropertyValue("ScreenSpace.LegendFluxNodes-bastille-day-2000.Enabled") then
+    if openspace.propertyValue("ScreenSpace.LegendFluxNodes-bastille-day-2000.Enabled") then
       openspace.setPropertyValueSingle(
         "ScreenSpace.LegendFluxNodes-bastille-day-2000.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("ScreenSpace.LegendFluxNodes-bastille-day-2000.Enabled", false)'
       )
@@ -36,7 +36,7 @@ local ToggleLegend = {
       openspace.setPropertyValueSingle(
         "ScreenSpace.LegendFluxNodes-bastille-day-2000.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end
@@ -53,7 +53,7 @@ local HideLegend = {
     openspace.setPropertyValueSingle(
       "ScreenSpace.LegendFluxNodes-bastille-day-2000.Fade",
       0.0,
-      openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+      openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
       "Linear",
       'openspace.setPropertyValueSingle("ScreenSpace.LegendFluxNodes-bastille-day-2000.Enabled", false)'
     )

--- a/data/assets/scene/solarsystem/missions/apollo/actions.asset
+++ b/data/assets/scene/solarsystem/missions/apollo/actions.asset
@@ -4,7 +4,7 @@ local ToggleMoonShading = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.Moon.Renderable.PerformShading",
-      not openspace.getPropertyValue("Scene.Moon.Renderable.PerformShading")
+      not openspace.propertyValue("Scene.Moon.Renderable.PerformShading")
     )
   ]],
   Documentation = "Toggles the shading of the Moon",

--- a/data/assets/scene/solarsystem/missions/apollo/apollo_globebrowsing.asset
+++ b/data/assets/scene/solarsystem/missions/apollo/apollo_globebrowsing.asset
@@ -40,7 +40,7 @@ local ToggleKaguyaLayer = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.Moon.Renderable.Layers.ColorLayers.Kaguya_Utah.Enabled",
-      not openspace.getPropertyValue("Scene.Moon.Renderable.Layers.ColorLayers.Kaguya_Utah.Enabled")
+      not openspace.propertyValue("Scene.Moon.Renderable.Layers.ColorLayers.Kaguya_Utah.Enabled")
     )
   ]],
   Documentation = "Toggles Moon Kaguya color layer",

--- a/data/assets/scene/solarsystem/missions/artemis/toggle_trail.asset
+++ b/data/assets/scene/solarsystem/missions/artemis/toggle_trail.asset
@@ -27,8 +27,8 @@ local ToggleTrail = {
       end
     else
       visibility = not (
-        (openspace.getPropertyValue("Scene." .. earthTrail .. ".Renderable.Fade") == 1) or
-        (openspace.getPropertyValue("Scene." .. moonTrail .. ".Renderable.Fade") == 1)
+        (openspace.propertyValue("Scene." .. earthTrail .. ".Renderable.Fade") == 1) or
+        (openspace.propertyValue("Scene." .. moonTrail .. ".Renderable.Fade") == 1)
       )
     end
 

--- a/data/assets/scene/solarsystem/missions/newhorizons/actions.asset
+++ b/data/assets/scene/solarsystem/missions/newhorizons/actions.asset
@@ -54,7 +54,7 @@ local ToggleImageProjection = {
   Identifier = "os.newhorizons.ToggleImageProjection",
   Name = "Toggle NH image projection",
   Command = [[
-    local enabled = openspace.getPropertyValue("Scene.PlutoProjection.Renderable.ProjectionComponent.PerformProjection")
+    local enabled = openspace.propertyValue("Scene.PlutoProjection.Renderable.ProjectionComponent.PerformProjection")
     openspace.setPropertyValue("Scene.PlutoProjection.Renderable.ProjectionComponent.PerformProjection", not enabled)
     openspace.setPropertyValue("Scene.CharonProjection.Renderable.ProjectionComponent.PerformProjection", not enabled)
   ]],
@@ -94,7 +94,7 @@ local IncreaseHeightmapPluto = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.PlutoProjection.Renderable.HeightExaggeration",
-      openspace.getPropertyValue("Scene.PlutoProjection.Renderable.HeightExaggeration") + 5000
+      openspace.propertyValue("Scene.PlutoProjection.Renderable.HeightExaggeration") + 5000
     )
   ]],
   Documentation = "Increases the height map exaggeration on Pluto",
@@ -108,7 +108,7 @@ local DecreaseHeightmapPluto = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.PlutoProjection.Renderable.HeightExaggeration",
-      openspace.getPropertyValue("Scene.PlutoProjection.Renderable.HeightExaggeration") - 5000
+      openspace.propertyValue("Scene.PlutoProjection.Renderable.HeightExaggeration") - 5000
     )
   ]],
   Documentation = "Decreases the height map exaggeration on Pluto",
@@ -122,7 +122,7 @@ local IncreaseHeightmapCharon = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.CharonProjection.Renderable.HeightExaggeration",
-      openspace.getPropertyValue("Scene.CharonProjection.Renderable.HeightExaggeration") + 5000
+      openspace.propertyValue("Scene.CharonProjection.Renderable.HeightExaggeration") + 5000
     )
   ]],
   Documentation = "Increases the height map exaggeration on Charon",
@@ -136,7 +136,7 @@ local DecreaseHeightmapCharon = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.CharonProjection.Renderable.HeightExaggeration",
-      openspace.getPropertyValue("Scene.CharonProjection.Renderable.HeightExaggeration") - 5000
+      openspace.propertyValue("Scene.CharonProjection.Renderable.HeightExaggeration") - 5000
     )
   ]],
   Documentation = "Decreases the height map exaggeration on Charon",
@@ -150,7 +150,7 @@ local TogglePlutoTrail = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.PlutoBarycentricTrail.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.PlutoBarycentricTrail.Renderable.Enabled")
+      not openspace.propertyValue("Scene.PlutoBarycentricTrail.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the visibility of the trail behind Pluto",
@@ -164,27 +164,27 @@ local TogglePlutoLabels = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.PlutoText.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.PlutoText.Renderable.Enabled")
+      not openspace.propertyValue("Scene.PlutoText.Renderable.Enabled")
     )
     openspace.setPropertyValueSingle(
       "Scene.CharonText.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.CharonText.Renderable.Enabled")
+      not openspace.propertyValue("Scene.CharonText.Renderable.Enabled")
     )
     openspace.setPropertyValueSingle(
       "Scene.HydraText.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.HydraText.Renderable.Enabled")
+      not openspace.propertyValue("Scene.HydraText.Renderable.Enabled")
     )
     openspace.setPropertyValueSingle(
       "Scene.NixText.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.NixText.Renderable.Enabled")
+      not openspace.propertyValue("Scene.NixText.Renderable.Enabled")
     )
     openspace.setPropertyValueSingle(
       "Scene.KerberosText.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.KerberosText.Renderable.Enabled")
+      not openspace.propertyValue("Scene.KerberosText.Renderable.Enabled")
     )
     openspace.setPropertyValueSingle(
       "Scene.StyxText.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.StyxText.Renderable.Enabled")
+      not openspace.propertyValue("Scene.StyxText.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the visibility of the text labels of Pluto, Charon, Hydra, Nix, Kerberos, and Styx",
@@ -196,7 +196,7 @@ local ToggleNewHorizonsLabels = {
   Identifier = "os.newhorizons.ToggleNewHorizonsLabels",
   Name = "Toggle New Horizons labels",
   Command = [[
-    local v = openspace.getPropertyValue("Scene.Labels.Renderable.Opacity")
+    local v = openspace.propertyValue("Scene.Labels.Renderable.Opacity")
     if v <= 0.5 then
       openspace.setPropertyValueSingle("Scene.Labels.Renderable.Opacity", 1.0, 2.0)
     else
@@ -214,11 +214,11 @@ local ToggleShadows = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.PlutoShadow.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.PlutoShadow.Renderable.Enabled")
+      not openspace.propertyValue("Scene.PlutoShadow.Renderable.Enabled")
     )
     openspace.setPropertyValueSingle(
       "Scene.CharonShadow.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.CharonShadow.Renderable.Enabled")
+      not openspace.propertyValue("Scene.CharonShadow.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the visibility of the shadow visualization of Pluto and Charon",
@@ -232,7 +232,7 @@ local ToggleNewHorizonsTrail = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.NewHorizonsTrailPluto.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.NewHorizonsTrailPluto.Renderable.Enabled")
+      not openspace.propertyValue("Scene.NewHorizonsTrailPluto.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the trail of New Horizons",

--- a/data/assets/scene/solarsystem/missions/osirisrex/actions.asset
+++ b/data/assets/scene/solarsystem/missions/osirisrex/actions.asset
@@ -78,7 +78,7 @@ local ToggleSunMarker = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.SunMarker.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.SunMarker.Renderable.Enabled")
+      not openspace.propertyValue("Scene.SunMarker.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the visibility of the text marking the location of the Sun",

--- a/data/assets/scene/solarsystem/missions/rosetta/67p.asset
+++ b/data/assets/scene/solarsystem/missions/rosetta/67p.asset
@@ -161,7 +161,7 @@ local Toggle67pProjection = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.67P.Renderable.ProjectionComponent.PerformProjection",
-      not openspace.getPropertyValue("Scene.67P.Renderable.ProjectionComponent.PerformProjection")
+      not openspace.propertyValue("Scene.67P.Renderable.ProjectionComponent.PerformProjection")
     )
   ]],
   Documentation = "Enables or disables the image projection on 67P",

--- a/data/assets/scene/solarsystem/missions/rosetta/actions.asset
+++ b/data/assets/scene/solarsystem/missions/rosetta/actions.asset
@@ -2,9 +2,9 @@ local ToggleOuterPlanetaryTrails = {
   Identifier = "os.rosetta.ToggleOuterPlanetaryTrails",
   Name = "Toggle outer planetary trails",
   Command = [[
-    local list = openspace.getProperty("{planetTrail_giants}.Renderable.Enabled")
+    local list = openspace.property("{planetTrail_giants}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggles the visibility of all trails further from the Sun than 67P",

--- a/data/assets/scene/solarsystem/missions/rosetta/rosetta.asset
+++ b/data/assets/scene/solarsystem/missions/rosetta/rosetta.asset
@@ -298,7 +298,7 @@ local ToggleImagePlane = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.ImagePlaneRosetta.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.ImagePlaneRosetta.Renderable.Enabled")
+      not openspace.propertyValue("Scene.ImagePlaneRosetta.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the visibility of the free floating image plane",
@@ -312,7 +312,7 @@ local TogglePhilaeTrail = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.PhilaeTrail.Renderable.Enabled",
-      not openspace.getPropertyValue("Scene.PhilaeTrail.Renderable.Enabled")
+      not openspace.propertyValue("Scene.PhilaeTrail.Renderable.Enabled")
     )
   ]],
   Documentation = "Toggles the visibility of Philae's trail",

--- a/data/assets/scene/solarsystem/missions/voyager/actions.asset
+++ b/data/assets/scene/solarsystem/missions/voyager/actions.asset
@@ -50,9 +50,9 @@ local ToggleMinorMoonTrails = {
   Identifier = "os.voyager.ToggleMinorMoonTrails",
   Name = "Toggle minor trails",
   Command = [[
-    local list = openspace.getProperty("{moonTrail_minor}.Renderable.Enabled")
+    local list = openspace.property("{moonTrail_minor}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggles the trails of the minor moons",

--- a/data/assets/scene/solarsystem/planets/earth/earth.asset
+++ b/data/assets/scene/solarsystem/planets/earth/earth.asset
@@ -93,9 +93,9 @@ local ToggleSatelliteTrails = {
   Identifier = "os.solarsystem.ToggleSatelliteTrails",
   Name = "Toggle satellite trails",
   Command = [[
-    local list = openspace.getProperty("{earth_satellites}.Renderable.Enabled")
+    local list = openspace.property("{earth_satellites}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle trails on or off for satellites around Earth",

--- a/data/assets/scene/solarsystem/planets/earth/moon/moon.asset
+++ b/data/assets/scene/solarsystem/planets/earth/moon/moon.asset
@@ -103,7 +103,7 @@ local ToggleMoonShading = {
   Command = [[
     openspace.setPropertyValueSingle(
       "Scene.Moon.Renderable.PerformShading",
-      not openspace.getPropertyValue("Scene.Moon.Renderable.PerformShading")
+      not openspace.propertyValue("Scene.Moon.Renderable.PerformShading")
     )
   ]],
   Documentation = "Toggles the shading of the Moon",

--- a/data/assets/scene/solarsystem/planets/jupiter/major_moons.asset
+++ b/data/assets/scene/solarsystem/planets/jupiter/major_moons.asset
@@ -9,11 +9,11 @@ local JupiterMajorMoonsOn = {
   Identifier = "os.solarsystem.JupiterMajorMoonsOn",
   Name = "Turn ON major moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_jupiter}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_jupiter}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_jupiter}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_jupiter}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_jupiter}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_jupiter}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_jupiter}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_jupiter}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -34,11 +34,11 @@ local JupiterMajorMoonsOff = {
   Identifier = "os.solarsystem.JupiterMajorMoonsOff",
   Name = "Turn OFF majors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_jupiter}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_jupiter}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_jupiter}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_jupiter}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_jupiter}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_jupiter}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_jupiter}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_jupiter}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/jupiter/minor_moons.asset
+++ b/data/assets/scene/solarsystem/planets/jupiter/minor_moons.asset
@@ -13,11 +13,11 @@ local JupiterMinorMoonsOn = {
   Identifier = "os.solarsystem.JupiterMinorMoonsOn",
   Name = "Turn ON minor moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_jupiter}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_jupiter}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_jupiter}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_jupiter}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_jupiter}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_jupiter}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_jupiter}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_jupiter}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -38,11 +38,11 @@ local JupiterMinorMoonsOff = {
   Identifier = "os.solarsystem.JupiterMinorMoonsOff",
   Name = "Turn OFF minors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_jupiter}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_jupiter}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_jupiter}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_jupiter}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_jupiter}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_jupiter}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_jupiter}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_jupiter}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/neptune/major_moons.asset
+++ b/data/assets/scene/solarsystem/planets/neptune/major_moons.asset
@@ -8,11 +8,11 @@ local NeptuneMajorMoonsOn = {
   Identifier = "os.solarsystem.NeptuneMajorMoonsOn",
   Name = "Turn on major moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_neptune}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_neptune}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_neptune}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_neptune}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_neptune}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_neptune}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_neptune}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_neptune}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -33,11 +33,11 @@ local NeptuneMajorMoonsOff = {
   Identifier = "os.solarsystem.NeptuneMajorMoonsOff",
   Name = "Turn off majors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_neptune}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_neptune}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_neptune}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_neptune}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_neptune}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_neptune}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_neptune}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_neptune}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/neptune/minor_moons.asset
+++ b/data/assets/scene/solarsystem/planets/neptune/minor_moons.asset
@@ -7,11 +7,11 @@ local NeptuneMinorMoonsOn = {
   Identifier = "os.solarsystem.NeptuneMinorMoonsOn",
   Name = "Turn on minor moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_neptune}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_neptune}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_neptune}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_neptune}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_neptune}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_neptune}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_neptune}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_neptune}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -32,11 +32,11 @@ local NeptuneMinorMoonsOff = {
   Identifier = "os.solarsystem.NeptuneMinorMoonsOff",
   Name = "Turn off minors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_neptune}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_neptune}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_neptune}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_neptune}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_neptune}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_neptune}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_neptune}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_neptune}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/saturn/major_moons.asset
+++ b/data/assets/scene/solarsystem/planets/saturn/major_moons.asset
@@ -14,11 +14,11 @@ local SaturnMajorMoonsOn = {
   Identifier = "os.solarsystem.SaturnMajorMoonsOn",
   Name = "Turn ON major moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_saturn}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_saturn}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_saturn}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_saturn}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_saturn}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_saturn}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_saturn}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_saturn}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -39,11 +39,11 @@ local SaturnMajorMoonsOff = {
   Identifier = "os.solarsystem.SaturnMajorMoonsOff",
   Name = "Turn OFF majors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_saturn}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_saturn}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_saturn}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_saturn}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_saturn}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_saturn}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_saturn}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_saturn}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/saturn/minor_moons.asset
+++ b/data/assets/scene/solarsystem/planets/saturn/minor_moons.asset
@@ -10,11 +10,11 @@ local SaturnMinorMoonsOn = {
   Identifier = "os.solarsystem.SaturnMinorMoonsOn",
   Name = "Turn ON minor moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_saturn}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_saturn}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_saturn}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_saturn}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_saturn}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_saturn}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_saturn}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_saturn}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -35,11 +35,11 @@ local SaturnMinorMoonsOff = {
   Identifier = "os.solarsystem.SaturnMinorMoonsOff",
   Name = "Turn OFF minors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_saturn}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_saturn}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_saturn}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_saturn}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_saturn}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_saturn}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_saturn}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_saturn}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/uranus/major_moons.asset
+++ b/data/assets/scene/solarsystem/planets/uranus/major_moons.asset
@@ -353,11 +353,11 @@ local UranusMajorMoonsOn = {
   Identifier = "os.solarsystem.UranusMajorMoonsOn",
   Name = "Turn ON major moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_uranus}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_uranus}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_uranus}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_uranus}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_uranus}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_uranus}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_uranus}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_uranus}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -378,11 +378,11 @@ local UranusMajorMoonsOff = {
   Identifier = "os.solarsystem.UranusMajorMoonsOff",
   Name = "Turn OFF majors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_major_uranus}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_major_uranus}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_major_uranus}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_major_uranus}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_major_uranus}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_major_uranus}.Renderable.Fade")
+    local moons = openspace.property("{moon_major_uranus}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_major_uranus}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/planets/uranus/minor_moons.asset
+++ b/data/assets/scene/solarsystem/planets/uranus/minor_moons.asset
@@ -8,11 +8,11 @@ local UranusMinorMoonsOn = {
   Identifier = "os.solarsystem.UranusMinorMoonsOn",
   Name = "Turn ON minor moons and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_uranus}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_uranus}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_uranus}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_uranus}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_uranus}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_uranus}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_uranus}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_uranus}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(trails[i], true)
@@ -33,11 +33,11 @@ local UranusMinorMoonsOff = {
   Identifier = "os.solarsystem.UranusMinorMoonsOff",
   Name = "Turn OFF minors moon and trails",
   Command = [[
-    local trails = openspace.getProperty("{moonTrail_minor_uranus}.Renderable.Enabled")
-    local trails_fade = openspace.getProperty("{moonTrail_minor_uranus}.Renderable.Fade")
+    local trails = openspace.property("{moonTrail_minor_uranus}.Renderable.Enabled")
+    local trails_fade = openspace.property("{moonTrail_minor_uranus}.Renderable.Fade")
 
-    local moons = openspace.getProperty("{moon_minor_uranus}.Renderable.Enabled")
-    local moons_fade = openspace.getProperty("{moon_minor_uranus}.Renderable.Fade")
+    local moons = openspace.property("{moon_minor_uranus}.Renderable.Enabled")
+    local moons_fade = openspace.property("{moon_minor_uranus}.Renderable.Fade")
 
     for i, v in pairs(trails_fade) do
       openspace.setPropertyValueSingle(

--- a/data/assets/scene/solarsystem/sun/EUV_layer.asset
+++ b/data/assets/scene/solarsystem/sun/EUV_layer.asset
@@ -38,11 +38,11 @@ local ToggleEuv = {
   Identifier = "os.solarsystem.ToggleEuv",
   Name = "Toggle EUV layer",
   Command = [[
-    if openspace.getPropertyValue("Scene.EUV-Layer-bastille-day-2000.Renderable.Enabled") then
+    if openspace.propertyValue("Scene.EUV-Layer-bastille-day-2000.Renderable.Enabled") then
       openspace.setPropertyValueSingle(
         "Scene.EUV-Layer-bastille-day-2000.Renderable.Fade",
         0.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear",
         'openspace.setPropertyValueSingle("Scene.EUV-Layer-bastille-day-2000.Renderable.Enabled", false)'
       )
@@ -51,7 +51,7 @@ local ToggleEuv = {
       openspace.setPropertyValueSingle(
         "Scene.EUV-Layer-bastille-day-2000.Renderable.Fade",
         1.0,
-        openspace.getPropertyValue("OpenSpaceEngine.FadeDuration"),
+        openspace.propertyValue("OpenSpaceEngine.FadeDuration"),
         "Linear"
       )
     end

--- a/data/assets/scene/solarsystem/telescopes/jwst/actions.asset
+++ b/data/assets/scene/solarsystem/telescopes/jwst/actions.asset
@@ -2,9 +2,9 @@ local ToggleLagrangianPoints = {
   Identifier = "os.jwst.ToggleLagrangianPoints",
   Name = "Toggle Lagrangian points",
   Command = [[
-    local list = openspace.getProperty("{lagrange_points_earth}.Renderable.Enabled")
+    local list = openspace.property("{lagrange_points_earth}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle points and labels for the Lagrangian points for Earth Sun system",
@@ -16,9 +16,9 @@ local ToggleHudf = {
   Identifier = "os.jwst.ToggleHudf",
   Name = "Toggle Hubble Ultra Deep Field",
   Command = [[
-    local list = openspace.getProperty("{mission_jwst_hudf}.*.Enabled")
+    local list = openspace.property("{mission_jwst_hudf}.*.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle Hubble Ultra Deep Field image and line towards its coordinate",
@@ -30,9 +30,9 @@ local ToggleL2 = {
   Identifier = "os.jwst.ToggleL2",
   Name = "Toggle L2 line and small L2 label",
   Command = [[
-    local list = openspace.getProperty("{lagrange_points_earth_l2_small}.*.Enabled")
+    local list = openspace.property("{lagrange_points_earth_l2_small}.*.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle L2 label, point and line",
@@ -44,9 +44,9 @@ local ToggleFov = {
   Identifier = "os.jwst.ToggleFov",
   Name = "Toggle JWST field of view and view band",
   Command = [[
-    local list = openspace.getProperty("{mission_jwst_fov}.*.Enabled")
+    local list = openspace.property("{mission_jwst_fov}.*.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle James Webb Space Telecope field of view and view band",
@@ -82,7 +82,7 @@ local ToggleSunTrail = {
   Identifier = "os.jwst.ToggleSunTrail",
   Name = "Toggle JWST Sun trail",
   Command = [[
-    local value = openspace.getPropertyValue("Scene.JWSTSunTrail.Renderable.Enabled")
+    local value = openspace.propertyValue("Scene.JWSTSunTrail.Renderable.Enabled")
     openspace.setPropertyValueSingle("Scene.JWSTSunTrail.Renderable.Enabled", not value)
   ]],
   Documentation = "Toggle JWST trail relative to the Sun",
@@ -94,13 +94,13 @@ local ToggleTrailsExceptMoon = {
   Identifier = "os.jwst.ToggleTrailsExceptMoon",
   Name = "Toggle trails (except Moon)",
   Command = [[
-    local list = openspace.getProperty("{planetTrail_solarSystem}.Renderable.Enabled")
+    local list = openspace.property("{planetTrail_solarSystem}.Renderable.Enabled")
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
-    local moonlist = openspace.getProperty("{moonTrail_solarSystem}.Renderable.Enabled")
+    local moonlist = openspace.property("{moonTrail_solarSystem}.Renderable.Enabled")
     for _,v in pairs(moonlist) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
     openspace.setPropertyValueSingle("Scene.MoonTrail.Renderable.Enabled", true)
   ]],
@@ -119,7 +119,7 @@ local ToggleJwstTrails = {
       "Scene.JWSTTrailCoRevOrbit.Renderable.Enabled"
     }
     for _,v in pairs(list) do
-      openspace.setPropertyValueSingle(v, not openspace.getPropertyValue(v))
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
   Documentation = "Toggle JWST launch, cruise and L2 co-revolving orbit trails, not the Sun trail",

--- a/data/assets/scene/solarsystem/telescopes/jwst/timelapse.asset
+++ b/data/assets/scene/solarsystem/telescopes/jwst/timelapse.asset
@@ -604,7 +604,7 @@ asset.onInitialize(function()
       end
 
       -- Update the dashboard text
-      local text = openspace.getPropertyValue("Dashboard.JWSTStateText.Text")
+      local text = openspace.propertyValue("Dashboard.JWSTStateText.Text")
       if string.len(text) > 14 then
         local newText = ""
         if text:sub(13, 13) == "-" then

--- a/data/assets/scene/solarsystem/telescopes/jwst/toggle_trail.asset
+++ b/data/assets/scene/solarsystem/telescopes/jwst/toggle_trail.asset
@@ -29,9 +29,9 @@ local ToggleTrail = {
       end
     else
       visibility = not (
-        openspace.getPropertyValue("Scene." .. launchTrail .. ".Renderable.Enabled") or
-        openspace.getPropertyValue("Scene." .. cruiseTrail .. ".Renderable.Enabled") or
-        openspace.getPropertyValue("Scene." .. coRevOrbitTrail .. ".Renderable.Enabled")
+        openspace.propertyValue("Scene." .. launchTrail .. ".Renderable.Enabled") or
+        openspace.propertyValue("Scene." .. cruiseTrail .. ".Renderable.Enabled") or
+        openspace.propertyValue("Scene." .. coRevOrbitTrail .. ".Renderable.Enabled")
       )
     end
 

--- a/data/assets/util/dpiscaling.asset
+++ b/data/assets/util/dpiscaling.asset
@@ -6,19 +6,19 @@ asset.onInitialize(function()
   if openspace.modules.isLoaded("CefWebGui") then
     openspace.setPropertyValueSingle(
       "Modules.CefWebGui.GuiScale",
-      openspace.getPropertyValue("Modules.CefWebGui.GuiScale") * scale
+      openspace.propertyValue("Modules.CefWebGui.GuiScale") * scale
     )
   end
 
-  local dashboards = openspace.getProperty("Dashboard.*.FontSize")
+  local dashboards = openspace.property("Dashboard.*.FontSize")
   for _, v in ipairs(dashboards) do
     openspace.setPropertyValueSingle(
       v,
-      openspace.getPropertyValue(v) * scale
+      openspace.propertyValue(v) * scale
     )
   end
 
-  local offset = openspace.getPropertyValue("Dashboard.StartPositionOffset")
+  local offset = openspace.propertyValue("Dashboard.StartPositionOffset")
   openspace.setPropertyValueSingle(
     "Dashboard.StartPositionOffset",
     { offset[1] * scale, offset[2] * scale }

--- a/data/assets/util/property_helper.asset
+++ b/data/assets/util/property_helper.asset
@@ -1,14 +1,14 @@
 -- Function that returns the string that inverts the fully qualified boolean property 'property'
 function invert(prop)
   local escaped_property = [["]] .. prop .. [["]]
-  return "openspace.setPropertyValueSingle(" .. escaped_property .. ", not openspace.getPropertyValue(" .. escaped_property .. "))"
+  return "openspace.setPropertyValueSingle(" .. escaped_property .. ", not openspace.propertyValue(" .. escaped_property .. "))"
 end
 
 -- Function that returns the string that increments the 'property' by the 'value'
 function increment(prop, value)
   local v = value or 1
   local escaped_property = [["]] .. prop .. [["]]
-  return "openspace.setPropertyValueSingle(" .. escaped_property .. ", openspace.getPropertyValue(" .. escaped_property .. ") + " .. v .. ")"
+  return "openspace.setPropertyValueSingle(" .. escaped_property .. ", openspace.propertyValue(" .. escaped_property .. ") + " .. v .. ")"
 end
 
 -- Function that returns the string that decrements the 'property' by the 'value'
@@ -38,7 +38,7 @@ function fadeInOut(prop, duration)
 
   local escaped_property = [["]] .. prop .. [["]]
   -- If the value is > 0.5 fade out, otherwise fade in
-  return "local v = openspace.getPropertyValue(" .. escaped_property .. ") if v <= 0.5 then " .. fadeIn(prop, duration) .. " else " .. fadeOut(prop, duration) .. " end"
+  return "local v = openspace.propertyValue(" .. escaped_property .. ") if v <= 0.5 then " .. fadeIn(prop, duration) .. " else " .. fadeOut(prop, duration) .. " end"
 end
 
 asset.export("invert", invert)

--- a/data/assets/util/screenshots_endpoint.asset
+++ b/data/assets/util/screenshots_endpoint.asset
@@ -5,10 +5,10 @@ asset.onInitialize(function()
   -- remove automatic restart on each property change, since frequent restarting seems to
   -- be unstable on MacOS.
 
-  local enabled = openspace.getPropertyValue("Modules.WebGui.ServerProcessEnabled")
+  local enabled = openspace.propertyValue("Modules.WebGui.ServerProcessEnabled")
   openspace.setPropertyValueSingle("Modules.WebGui.ServerProcessEnabled", false)
 
-  local directories = openspace.getPropertyValue("Modules.WebGui.Directories")
+  local directories = openspace.propertyValue("Modules.WebGui.Directories")
   directories[#directories + 1] = "screenshots"
   directories[#directories + 1] = "${SCREENSHOTS}"
   openspace.setPropertyValueSingle("Modules.WebGui.Directories", directories)

--- a/modules/exoplanets/exoplanetsmodule.cpp
+++ b/modules/exoplanets/exoplanetsmodule.cpp
@@ -346,7 +346,8 @@ scripting::LuaLibrary ExoplanetsModule::luaLibrary() const {
         {
             codegen::lua::AddExoplanetSystem,
             codegen::lua::RemoveExoplanetSystem,
-            codegen::lua::GetListOfExoplanets,
+            codegen::lua::ListOfExoplanets,
+            codegen::lua::ListOfExoplanetsDeprecated,
             codegen::lua::ListAvailableExoplanetSystems
         }
     };

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -639,9 +639,23 @@ std::vector<std::string> hostStarsWithSufficientData() {
     );
 }
 
-[[codegen::luawrap]] std::vector<std::string> getListOfExoplanets() {
+[[codegen::luawrap]] std::vector<std::string> listOfExoplanets() {
     std::vector<std::string> names = hostStarsWithSufficientData();
     return names;
+}
+
+/**
+ * Deprecated in favor of 'listOfExoplanets'
+ */
+[[codegen::luawrap("getListOfExoplanets")]] std::vector<std::string>
+listOfExoplanetsDeprecated()
+{
+    LWARNINGC(
+        "Deprecation",
+        "'getListOfExoplanets' function is deprecated and should be replaced with "
+        "'listOfExoplanets'"
+    );
+    return listOfExoplanets();
 }
 
 [[codegen::luawrap]] void listAvailableExoplanetSystems() {

--- a/modules/globebrowsing/globebrowsingmodule.cpp
+++ b/modules/globebrowsing/globebrowsingmodule.cpp
@@ -692,15 +692,18 @@ scripting::LuaLibrary GlobeBrowsingModule::luaLibrary() const {
         .functions = {
             codegen::lua::AddLayer,
             codegen::lua::DeleteLayer,
-            codegen::lua::GetLayers,
+            codegen::lua::Layers,
+            codegen::lua::LayersDeprecated,
             codegen::lua::MoveLayer,
             codegen::lua::GoToChunk,
             codegen::lua::GoToGeo,
             // @TODO (2021-06-23, emmbr) Combine with the above function when the camera
             // paths work really well close to surfaces
             codegen::lua::FlyToGeo,
-            codegen::lua::GetLocalPositionFromGeo,
-            codegen::lua::GetGeoPositionForCamera,
+            codegen::lua::LocalPositionFromGeo,
+            codegen::lua::LocalPositionFromGeoDeprecated,
+            codegen::lua::GeoPositionForCamera,
+            codegen::lua::GeoPositionForCameraDeprecated,
             codegen::lua::LoadWMSCapabilities,
             codegen::lua::RemoveWMSServer,
             codegen::lua::CapabilitiesWMS,

--- a/modules/globebrowsing/globebrowsingmodule_lua.inl
+++ b/modules/globebrowsing/globebrowsingmodule_lua.inl
@@ -118,8 +118,8 @@ namespace {
  * Returns the list of layers for the scene graph node specified in the first parameter.
  * The second parameter specifies which layer type should be queried.
  */
-[[codegen::luawrap]] std::vector<std::string> getLayers(std::string globeIdentifier,
-                                                        std::string layer)
+[[codegen::luawrap]] std::vector<std::string> layers(std::string globeIdentifier,
+                                                     std::string layer)
 {
     using namespace openspace;
     using namespace globebrowsing;
@@ -148,6 +148,23 @@ namespace {
         res.push_back(l->identifier());
     }
     return res;
+}
+
+/**
+ * Returns the list of layers for the scene graph node specified in the first parameter.
+ * The second parameter specifies which layer type should be queried. Deprecated in favor
+ * of 'layers'.
+ */
+[[codegen::luawrap("getLayers")]] std::vector<std::string> layersDeprecated(
+                                                              std::string globeIdentifier,
+                                                                        std::string layer)
+{
+    LWARNINGC(
+        "Deprecation",
+        "'getLayers' function is deprecated and should be replaced with 'layers'"
+    );
+
+    return layers(std::move(globeIdentifier), std::move(layer));
 }
 
 /**
@@ -398,8 +415,8 @@ namespace {
  */
 [[codegen::luawrap]]
 std::tuple<double, double, double>
-getLocalPositionFromGeo(std::string globeIdentifier, double latitude, double longitude,
-                        double altitude)
+localPositionFromGeo(std::string globeIdentifier, double latitude, double longitude,
+                     double altitude)
 {
     using namespace openspace;
     using namespace globebrowsing;
@@ -419,12 +436,38 @@ getLocalPositionFromGeo(std::string globeIdentifier, double latitude, double lon
 }
 
 /**
+ * Returns a position in the local Cartesian coordinate system of the globe identified by
+ * the first argument, that corresponds to the given geographic coordinates: latitude,
+ * longitude and altitude (in degrees and meters). In the local coordinate system, the
+ * position (0,0,0) corresponds to the globe's center. Deprecated in favor of
+ * 'localPositionFromGeo'.
+ */
+[[codegen::luawrap("getLocalPositionFromGeo")]]
+std::tuple<double, double, double>
+localPositionFromGeoDeprecated(std::string globeIdentifier, double latitude,
+                               double longitude, double altitude)
+{
+    LWARNINGC(
+        "Deprecation",
+        "'getLocalPositionFromGeo' function is deprecated and should be replaced with "
+        "'localPositionFromGeo'"
+    );
+
+    return localPositionFromGeo(
+        std::move(globeIdentifier),
+        latitude,
+        longitude,
+        altitude
+    );
+}
+
+/**
  * Get geographic coordinates of the camera position in latitude, longitude, and altitude
  * (degrees and meters). If the optional bool paramater is specified, the camera
  * eye postion will be used instead
  */
-[[codegen::luawrap]] std::tuple<double, double, double>
-getGeoPositionForCamera(bool useEyePosition = false)
+[[codegen::luawrap]] std::tuple<double, double, double> geoPositionForCamera(
+                                                              bool useEyePosition = false)
 {
     using namespace openspace;
     using namespace globebrowsing;
@@ -475,6 +518,24 @@ getGeoPositionForCamera(bool useEyePosition = false)
     );
 
     return { glm::degrees(geo2.lat), glm::degrees(geo2.lon), altitude };
+}
+
+/**
+ * Get geographic coordinates of the camera position in latitude, longitude, and altitude
+ * (degrees and meters). If the optional bool paramater is specified, the camera
+ * eye postion will be used instead. Deprecated in favor of 'geoPositionForCamera'.
+ */
+[[codegen::luawrap("getGeoPositionForCamera")]]
+std::tuple<double, double, double>
+geoPositionForCameraDeprecated(bool useEyePosition = false)
+{
+    LWARNINGC(
+        "Deprecation",
+        "'getGeoPositionForCamera' function is deprecated and should be replaced with "
+        "'geoPositionForCamera'"
+    );
+
+    return geoPositionForCamera(useEyePosition);
 }
 
 /**

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -835,14 +835,25 @@ scripting::LuaLibrary Scene::luaLibrary() {
             },
             {
                 "getPropertyValue",
+                &luascriptfunctions::propertyGetValueDeprecated,
+                {},
+                "",
+                "Returns the value the property, identified by the provided URI. "
+                "Deprecated in favor of the 'propertyValue' function",
+                {}
+            },
+            {
+                "propertyValue",
                 &luascriptfunctions::propertyGetValue,
                 {},
                 "",
-                "Returns the value the property, identified by the provided URI",
+                "Returns the value the property, identified by the provided URI. "
+                "Deprecated in favor of the 'propertyValue' function",
                 {}
             },
             codegen::lua::HasProperty,
-            codegen::lua::GetProperty,
+            codegen::lua::PropertyDeprecated,
+            codegen::lua::Property,
             codegen::lua::AddCustomProperty,
             codegen::lua::RemoveCustomProperty,
             codegen::lua::AddSceneGraphNode,

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -470,6 +470,16 @@ int propertyGetValue(lua_State* L) {
     return 1;
 }
 
+int propertyGetValueDeprecated(lua_State* L) {
+    LWARNINGC(
+        "Deprecation",
+        "'getPropertyValue' function is deprecated and should be replaced with "
+        "'propertyValue'"
+    );
+
+    return propertyGetValue(L);
+}
+
 }  // namespace openspace::luascriptfunctions
 
 namespace {
@@ -485,7 +495,7 @@ namespace {
 /**
  * Returns a list of property identifiers that match the passed regular expression
  */
-[[codegen::luawrap]] std::vector<std::string> getProperty(std::string regex) {
+[[codegen::luawrap]] std::vector<std::string> property(std::string regex) {
     using namespace openspace;
 
     std::string groupName;
@@ -589,6 +599,19 @@ namespace {
     }
 
     return res;
+}
+
+/**
+ * Returns a list of property identifiers that match the passed regular expression
+ */
+[[codegen::luawrap("getProperty")]] std::vector<std::string> propertyDeprecated(
+                                                                        std::string regex)
+{
+    LWARNINGC(
+        "Deprecation",
+        "'getProperty' function is deprecated and should be replaced with 'property'"
+    );
+    return property(std::move(regex));
 }
 
 /**


### PR DESCRIPTION
All of the Lua functions that had a `get` prefix now have the same version without the get.  The old prefixed version is still there, but prints a deprecation warning.  Since they might be used in user webpage code, it would be harsh to not give a version's worth of time to update.