### PR TITLE
Add search text box and filtering capability to Launcher profile assets editor

### DIFF
--- a/apps/OpenSpace/ext/launcher/include/profile/assetsdialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/assetsdialog.h
@@ -26,8 +26,8 @@
 #define __OPENSPACE_UI_LAUNCHER___ASSETSDIALOG___H__
 
 #include <QDialog>
-#include <QSortFilterProxyModel>
 #include <QRegularExpression>
+#include <QSortFilterProxyModel>
 #include "assettreemodel.h"
 
 class QTextEdit;
@@ -41,7 +41,7 @@ public:
      *
      * \param parent The QObject* object that is the Qt parent of this object
      */
-    SearchProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
+    SearchProxyModel(QObject* parent = nullptr);
 
 public slots:
     /**
@@ -55,8 +55,9 @@ protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
 
 private:
-    QRegularExpression* _regExPattern = nullptr;
     bool acceptIndex(const QModelIndex& idx) const;
+
+    QRegularExpression* _regExPattern = nullptr;
 };
 
 class AssetsDialog final : public QDialog {

--- a/apps/OpenSpace/ext/launcher/include/profile/assetsdialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/assetsdialog.h
@@ -26,11 +26,35 @@
 #define __OPENSPACE_UI_LAUNCHER___ASSETSDIALOG___H__
 
 #include <QDialog>
-
+#include <QSortFilterProxyModel>
+#include <QRegExp>
 #include "assettreemodel.h"
 
 class QTextEdit;
 class QTreeView;
+
+class SearchProxyModel : public QSortFilterProxyModel {
+public:
+    /**
+     * Constructor for SearchProxyModel class
+     *
+     * \param parent The QObject* object that is the Qt parent of this object
+     */
+    SearchProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
+
+    /**
+     * Sets the regular expression pattern to apply to the filter
+     *
+     * \param pattern The QString reference containing the regex pattern
+     */
+    void setFilterRegExp(const QString& pattern);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
+
+private:
+    bool acceptIndex(const QModelIndex& idx) const;
+};
 
 class AssetsDialog final : public QDialog {
 Q_OBJECT
@@ -48,12 +72,14 @@ public:
     AssetsDialog(QWidget* parent, openspace::Profile* profile,
         const std::string& assetBasePath, const std::string& userAssetBasePath);
 
+private slots:
+    void searchTextChanged(const QString& text);
+
 private:
     void createWidgets();
-
+    void setViewToBaseModel();
     void parseSelections();
     void selected(const QModelIndex&);
-
     /// Creates a text summary of all assets and their paths
     QString createTextSummary();
     void openAssetEditor();
@@ -61,7 +87,10 @@ private:
     openspace::Profile* _profile = nullptr;
     AssetTreeModel _assetTreeModel;
     QTreeView* _assetTree = nullptr;
+    QLineEdit* _searchTextBox = nullptr;
     QTextEdit* _summary = nullptr;
+    QSortFilterProxyModel* _assetProxyModel = nullptr;
+    SearchProxyModel* _searchProxyModel = nullptr;
 };
 
 #endif // __OPENSPACE_UI_LAUNCHER___ASSETSDIALOG___H__

--- a/apps/OpenSpace/ext/launcher/include/profile/assetsdialog.h
+++ b/apps/OpenSpace/ext/launcher/include/profile/assetsdialog.h
@@ -27,13 +27,14 @@
 
 #include <QDialog>
 #include <QSortFilterProxyModel>
-#include <QRegExp>
+#include <QRegularExpression>
 #include "assettreemodel.h"
 
 class QTextEdit;
 class QTreeView;
 
 class SearchProxyModel : public QSortFilterProxyModel {
+Q_OBJECT
 public:
     /**
      * Constructor for SearchProxyModel class
@@ -42,17 +43,19 @@ public:
      */
     SearchProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
 
+public slots:
     /**
      * Sets the regular expression pattern to apply to the filter
      *
      * \param pattern The QString reference containing the regex pattern
      */
-    void setFilterRegExp(const QString& pattern);
+    void setFilterRegularExpression(const QString& pattern);
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
 
 private:
+    QRegularExpression* _regExPattern = nullptr;
     bool acceptIndex(const QModelIndex& idx) const;
 };
 


### PR DESCRIPTION
It can be hard to find an asset in the profile editor since there are many assets, and the tree view has collapsed branches by default for directories that don't contain any currently-selected assets.
This adds a text box above the tree view to allow for easy searching of the available asset files.