### PR TITLE
Add UI descriptions and asset metas to a bunch of assets

### DIFF
--- a/data/assets/educational/scale/arc_de_triomphe.asset
+++ b/data/assets/educational/scale/arc_de_triomphe.asset
@@ -40,6 +40,8 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Arc de Triomphe",
+    Description = [[The triumphal arch is 50 m (164 ft) tall and has a footprint of
+      45x22 m (148x72 ft).]],
     Path = "/Scale Objects"
   }
 }
@@ -83,3 +85,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Arc de Triomphe",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Arc de Triomphe. Per default it is placed at
+    its actual position in Paris, France. But the asset also includes actions to move it
+    to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/big_ben.asset
+++ b/data/assets/educational/scale/big_ben.asset
@@ -42,6 +42,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Big Ben",
+    Description = "The clock tower is 96 m (316 ft) tall.",
     Path = "/Scale Objects"
   }
 }
@@ -85,3 +86,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Big Ben",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Big Ben. Per default it is placed at its
+    actual position in London, England. But the asset also includes actions to move
+    it to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/burj_khalifa.asset
+++ b/data/assets/educational/scale/burj_khalifa.asset
@@ -43,6 +43,8 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Burj Khalifa",
+    Description = [[The skyscraper is 830 m (2,722 ft) tall, and the tallest in the
+      world as of 2009.]],
     Path = "/Scale Objects"
   }
 }
@@ -85,3 +87,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Burj Khalifa",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Burj Khalifa. Per default it is placed at its
+    actual position in Dubai. But the asset also includes actions to move it to a
+    position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/eiffeltower.asset
+++ b/data/assets/educational/scale/eiffeltower.asset
@@ -46,6 +46,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Eiffel Tower",
+    Description = "The tower is 330 m (1,083 ft) tall.",
     Path = "/Scale Objects"
   }
 }
@@ -89,3 +90,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Eiffel Tower",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Eiffel Tower. Per default it is placed at
+    its actual position in Paris, France. But the asset also includes actions to move it
+    to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/empire_state_building.asset
+++ b/data/assets/educational/scale/empire_state_building.asset
@@ -45,6 +45,8 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Empire State Building",
+    Description = [[The building is 443 m (1,454 ft) tall, including the spire, and has
+      102 floors. It has a footprint of 129x57 m (424x187 ft).]],
     Path = "/Scale Objects"
   }
 }
@@ -88,3 +90,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Empire State Building",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Empire State Building. Per default it is
+    placed at its actual position in New York City. But the asset also includes actions
+    to move it to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/gateway_arch.asset
+++ b/data/assets/educational/scale/gateway_arch.asset
@@ -46,6 +46,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Gateway Arch",
+    Description = "The arch monument is 192 m (630 ft) tall.",
     Path = "/Scale Objects"
   }
 }
@@ -89,3 +90,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Gateway Arch",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Gateway Arch. Per default it is placed at its
+    actual position in Saint Louis, Missouri. But the asset also includes actions to move
+    it to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/golden_gate_bridge.asset
+++ b/data/assets/educational/scale/golden_gate_bridge.asset
@@ -46,6 +46,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Golden Gate Bridge",
+    Description = "The bridge is 2,737 m (8,980 ft) long and 227 m (746 ft) high.",
     Path = "/Scale Objects"
   }
 }
@@ -89,3 +90,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Golden Gate Bridge",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Golden Gate Bridge. Per default it is placed
+    at its actual position in San Fransisco. But the asset also includes actions to move
+    it to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/kuala_lumpur_tower.asset
+++ b/data/assets/educational/scale/kuala_lumpur_tower.asset
@@ -40,6 +40,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Kuala Lumpur Tower",
+    Description = "The tower is 421 m (1,381 ft) tall",
     Path = "/Scale Objects"
   }
 }
@@ -83,3 +84,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Kuala Lumpur Tower",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Kuala Lumpur Tower. Per default it is placed
+    at its actual position in Kuala Lumpur. But the asset also includes actions to move
+    it to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/kuala_lumpur_tower.asset
+++ b/data/assets/educational/scale/kuala_lumpur_tower.asset
@@ -40,7 +40,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Kuala Lumpur Tower",
-    Description = "The tower is 421 m (1,381 ft) tall",
+    Description = "The tower is 421 m (1,381 ft) tall.",
     Path = "/Scale Objects"
   }
 }

--- a/data/assets/educational/scale/kuala_lumpur_tower.asset
+++ b/data/assets/educational/scale/kuala_lumpur_tower.asset
@@ -90,8 +90,8 @@ asset.meta = {
   Name = "Scale Model - Kuala Lumpur Tower",
   Version = "1.0",
   Description = [[A 1:1 scale model of the Kuala Lumpur Tower. Per default it is placed
-    at its actual position in Kuala Lumpur. But the asset also includes actions to move
-    it to a position under the camera, or back to its original position.]],
+    at its actual position in Kuala Lumpur, Malaysia. But the asset also includes actions
+    to move it to a position under the camera, or back to its original position.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/educational/scale/rose_bowl.asset
+++ b/data/assets/educational/scale/rose_bowl.asset
@@ -41,6 +41,10 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Rose Bowl",
+    Description = [[The stadium seats over 92,000 people, with 77 rows of seats. It
+      measures 880 feet (268 meters) from the north rim to the south rim, and 695 feet
+      (212 meters) from east to west. The turfed area is 79,156 square feet (7354
+      square meters).]],
     Path = "/Scale Objects"
   }
 }
@@ -84,3 +88,15 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Rose Bowl Stadium",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Rose Bowl Stadium. Per default it is placed
+    at its actual position in Pasadena, California. But the asset also includes actions
+    to move it to a position under the camera, or back to its original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/school_bus.asset
+++ b/data/assets/educational/scale/school_bus.asset
@@ -41,6 +41,8 @@ local ScaleModel = {
   },
   GUI = {
     Name = "School bus",
+    Desription = [[The average length of a full size US school bus is above 35 feet
+      (10.7 meters)]],
     Path = "/Scale Objects"
   }
 }
@@ -61,7 +63,7 @@ local ResetPositionAction = {
   Name = "Reset School bus position",
   Command = [[
     openspace.globebrowsing.setNodePosition("Scale_SchoolBus", "]] .. earthAsset.Earth.Identifier .. [[", ]] .. Location[1] .. "," .. Location[2] .. ")",
-  Documentation = "Resets the school bus back to its actual location",
+  Documentation = "Resets the school bus back to its start location",
   GuiPath = "/Scale Objects",
   IsLocal = false
 }
@@ -83,3 +85,14 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Eiffel Tower",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of a US school bus, with actions to move
+    it to a position under the camera, or back to its start position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/school_bus.asset
+++ b/data/assets/educational/scale/school_bus.asset
@@ -42,7 +42,7 @@ local ScaleModel = {
   GUI = {
     Name = "School bus",
     Desription = [[The average length of a full size US school bus is above 35 feet
-      (10.7 meters)]],
+      (10.7 meters).]],
     Path = "/Scale Objects"
   }
 }

--- a/data/assets/educational/scale/scientist.asset
+++ b/data/assets/educational/scale/scientist.asset
@@ -41,7 +41,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Scientist",
-    Description = [[The average height of a human is a bit under 170 cm (5'7")]],
+    Description = [[The average height of a human is a bit under 170 cm (5'7").]],
     Path = "/Scale Objects"
   }
 }

--- a/data/assets/educational/scale/scientist.asset
+++ b/data/assets/educational/scale/scientist.asset
@@ -41,6 +41,7 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Scientist",
+    Description = [[The average height of a human is a bit under 170 cm (5'7")]],
     Path = "/Scale Objects"
   }
 }
@@ -84,3 +85,14 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Eiffel Tower",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of a human scientist, with actions to move
+    it to a position under the camera, or back to its start position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/educational/scale/statue_of_liberty.asset
+++ b/data/assets/educational/scale/statue_of_liberty.asset
@@ -41,6 +41,8 @@ local ScaleModel = {
   },
   GUI = {
     Name = "Statue of Liberty",
+    Description = [[From ground level, the statue is 93 meters (305 feet) tall, up to the
+      torch.]],
     Path = "/Scale Objects"
   }
 }
@@ -84,3 +86,16 @@ end)
 asset.export(ScaleModel)
 asset.export("UpdatePositionAction", UpdatePositionAction.Identifier)
 asset.export("ResetPositionAction", ResetPositionAction.Identifier)
+
+
+asset.meta = {
+  Name = "Scale Model - Statue of Liberty",
+  Version = "1.0",
+  Description = [[A 1:1 scale model of the Statue of Liberty. Per default it is
+    placed at its actual position on Liberty Island in New York City. But the asset
+    also includes actions to move it to a position under the camera, or back to its
+    original position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/dashboarditems.asset
+++ b/data/assets/examples/dashboarditems.asset
@@ -100,3 +100,15 @@ asset.export(Mission)
 asset.export(PropertyValue)
 asset.export(ElapsedTime)
 asset.export(InputState)
+
+
+asset.meta = {
+  Name = "Dashboard Items Example",
+  Version = "1.0",
+  Description = [[Examples of different types of dashboard items.
+    These are dynamic information texts that wil be shown over the rendering
+    (per default in the top left corner, on flat screens)]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/dashboarditems.asset
+++ b/data/assets/examples/dashboarditems.asset
@@ -106,7 +106,7 @@ asset.meta = {
   Name = "Dashboard Items Example",
   Version = "1.0",
   Description = [[Examples of different types of dashboard items.
-    These are dynamic information texts that wil be shown over the rendering
+    These are dynamic information texts that will be shown over the rendering
     (per default in the top left corner, on flat screens)]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",

--- a/data/assets/examples/dashboarditems.asset
+++ b/data/assets/examples/dashboarditems.asset
@@ -105,9 +105,9 @@ asset.export(InputState)
 asset.meta = {
   Name = "Dashboard Items Example",
   Version = "1.0",
-  Description = [[Examples of different types of dashboard items.
-    These are dynamic information texts that will be shown over the rendering
-    (per default in the top left corner, on flat screens)]],
+  Description = [[Examples of different types of dashboard items. These are dynamic
+    information texts that will be shown over the rendering (per default in the top
+    left corner, on flat screens).]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/examples/debugcoordinateaxes.asset
+++ b/data/assets/examples/debugcoordinateaxes.asset
@@ -19,6 +19,7 @@ local EarthBarycenterAxes = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
+    Name = "Earth Barycenter Axes",
     Path = "/Other/Coordinate Systems"
   }
 }
@@ -36,6 +37,7 @@ local EarthInertialAxes = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
+    Name = "Earth Inertial Axes",
     Path = "/Other/Coordinate Systems"
   }
 }
@@ -53,6 +55,7 @@ local EarthIAUAxes = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
+    Name = "Earth IAU Axes",
     Path = "/Other/Coordinate Systems"
   }
 }
@@ -70,6 +73,7 @@ local SunIAUAxes = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
+    Name = "Sun IAU Axes",
     Path = "/Other/Coordinate Systems"
   }
 }
@@ -87,6 +91,7 @@ local SolarSystemBarycenterAxes = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
+    Name = "Solar System Barycenter Axes",
     Path = "/Other/Coordinate Systems"
   }
 }
@@ -114,3 +119,15 @@ asset.export(EarthInertialAxes)
 asset.export(EarthIAUAxes)
 asset.export(SunIAUAxes)
 asset.export(SolarSystemBarycenterAxes)
+
+
+asset.meta = {
+  Name = "Debug Coordinates",
+  Version = "1.0",
+  Description = [[A set of coordinate axes demonstrating different XYZ coordinate
+    reference frames that are useful for debugging, such as the Earth or Solar
+    System Barycenter.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/discs.asset
+++ b/data/assets/examples/discs.asset
@@ -56,7 +56,7 @@ asset.export(FullEllipticDisc)
 asset.meta = {
   Name = "Example Discs",
   Version = "1.0",
-  Description = [[Example of different types of rendered discs.]],
+  Description = [[Examples of different types of rendered discs.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/examples/discs.asset
+++ b/data/assets/examples/discs.asset
@@ -51,3 +51,13 @@ end)
 
 asset.export(BasicDisc)
 asset.export(FullEllipticDisc)
+
+
+asset.meta = {
+  Name = "Example Discs",
+  Version = "1.0",
+  Description = [[Example of different types of rendered discs.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/globerotation.asset
+++ b/data/assets/examples/globerotation.asset
@@ -55,3 +55,15 @@ asset.onDeinitialize(function()
 end)
 
 asset.export(ExampleGlobeRotation)
+
+
+asset.meta = {
+  Name = "Model Example",
+  Version = "1.0",
+  Description = [[An example that demonstrates how to load a 3D model from a geometry
+    file, together with some basic funcitonality. The model is placed on the surface
+    of a panet using a GlobeRotation and GlobeTranslation.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/globerotation.asset
+++ b/data/assets/examples/globerotation.asset
@@ -61,8 +61,8 @@ asset.meta = {
   Name = "Model Example",
   Version = "1.0",
   Description = [[An example that demonstrates how to load a 3D model from a geometry
-    file, together with some basic funcitonality. The model is placed on the surface
-    of a panet using a GlobeRotation and GlobeTranslation.]],
+    file, together with some basic functionality. The model is placed on the surface
+    of a planet using a GlobeRotation and GlobeTranslation.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/examples/globetranslation.asset
+++ b/data/assets/examples/globetranslation.asset
@@ -72,3 +72,15 @@ end)
 
 asset.export(ExampleFixedHeight)
 asset.export(ExampleAdaptiveHeight)
+
+
+asset.meta = {
+  Name = "GlobeTranslation Example",
+  Version = "1.0",
+  Description = [[An example that demonstrates how to place object on a planet surface
+    using the "GlobeTranslation" transform. For the altitude, a fixed height can be used,
+    or the height can be queried from the height map]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/globetranslation.asset
+++ b/data/assets/examples/globetranslation.asset
@@ -77,7 +77,7 @@ asset.export(ExampleAdaptiveHeight)
 asset.meta = {
   Name = "GlobeTranslation Example",
   Version = "1.0",
-  Description = [[An example that demonstrates how to place object on a planet surface
+  Description = [[An example that demonstrates how to place an object on a planet surface
     using the "GlobeTranslation" transform. For the altitude, a fixed height can be used,
     or the height can be queried from the height map]],
   Author = "OpenSpace Team",

--- a/data/assets/examples/grids.asset
+++ b/data/assets/examples/grids.asset
@@ -19,7 +19,7 @@ local RadialGrid = {
   },
   GUI = {
     Name = "Example Radial Grid",
-    Description = [[A circular 2D grid, with segments based on the radius and angle]],
+    Description = [[A circular 2D grid, with segments based on the radius and angle.]],
     Path = "/Examples/Grids"
   }
 }
@@ -44,7 +44,7 @@ local PlanarGrid = {
   },
   GUI = {
     Name = "Example Grid",
-    Description = [[A basic 2D grid, with a given size and number of segments]],
+    Description = [[A basic 2D grid, with a given size and number of segments.]],
     Path = "/Examples/Grids"
   }
 }
@@ -116,7 +116,7 @@ asset.export(BoxGrid)
 asset.meta = {
   Name = "Example Grids",
   Version = "1.0",
-  Description = [[Example of different types of rendered grids.]],
+  Description = [[Examples of different types of rendered grids.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/examples/grids.asset
+++ b/data/assets/examples/grids.asset
@@ -19,6 +19,7 @@ local RadialGrid = {
   },
   GUI = {
     Name = "Example Radial Grid",
+    Description = [[A circular 2D grid, with segments based on the radius and angle]],
     Path = "/Examples/Grids"
   }
 }
@@ -43,6 +44,7 @@ local PlanarGrid = {
   },
   GUI = {
     Name = "Example Grid",
+    Description = [[A basic 2D grid, with a given size and number of segments]],
     Path = "/Examples/Grids"
   }
 }
@@ -63,6 +65,7 @@ local SphericalGrid = {
   },
   GUI = {
     Name = "Example Spherical Grid",
+    Description = [[A grid in the form of a 3D sphere.]],
     Path = "/Examples/Grids"
   }
 }
@@ -84,6 +87,7 @@ local BoxGrid = {
   },
   GUI = {
     Name = "Example Box Grid",
+    Description = [[A grid in the form of a 3D box.]],
     Path = "/Examples/Grids"
   }
 }
@@ -107,3 +111,13 @@ asset.export(RadialGrid)
 asset.export(PlanarGrid)
 asset.export(SphericalGrid)
 asset.export(BoxGrid)
+
+
+asset.meta = {
+  Name = "Example Grids",
+  Version = "1.0",
+  Description = [[Example of different types of rendered grids.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/joystickproperty.asset
+++ b/data/assets/examples/joystickproperty.asset
@@ -99,7 +99,7 @@ end)
 asset.meta = {
   Name = "Joystick example",
   Version = "1.0",
-  Description = [[Exaple asset that binds a joystick to use for input and navigation.
+  Description = [[Example asset that binds a joystick to use for input and navigation.
     More info on the OpenSpace wiki page.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",

--- a/data/assets/examples/joystickproperty.asset
+++ b/data/assets/examples/joystickproperty.asset
@@ -94,3 +94,14 @@ asset.onInitialize(function()
     "Freeze current scale for Earth. Or release it to the trigger again."
   )
 end)
+
+
+asset.meta = {
+  Name = "Joystick example",
+  Version = "1.0",
+  Description = [[Exaple asset that binds a joystick to use for input and navigation.
+    More info on the OpenSpace wiki page.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/primitives.asset
+++ b/data/assets/examples/primitives.asset
@@ -57,3 +57,14 @@ end)
 
 asset.export(Circle)
 asset.export(Ellipse)
+
+
+asset.meta = {
+  Name = "Primitives Example",
+  Version = "1.0",
+  Description = [[Examples of different simple rendered primitives, such as circles
+    and ellipses.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/renderableplaneimageonline.asset
+++ b/data/assets/examples/renderableplaneimageonline.asset
@@ -13,6 +13,7 @@ local RenderablePlaneImageOnline = {
     URL = "http://data.openspaceproject.com/examples/renderableplaneimageonline.jpg"
   },
   GUI = {
+    Description = "A plane that loads a texture from the internet",
     Path = "/Examples"
   }
 }
@@ -27,3 +28,14 @@ asset.onDeinitialize(function()
 end)
 
 asset.export(RenderablePlaneImageOnline)
+
+
+asset.meta = {
+  Name = "RenderablePlaneImageOnline Example",
+  Version = "1.0",
+  Description = [[Example of how to create a textured plane in 3D space, where the
+    texture is loaded from a web URL]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/renderableplaneimageonline.asset
+++ b/data/assets/examples/renderableplaneimageonline.asset
@@ -13,7 +13,7 @@ local RenderablePlaneImageOnline = {
     URL = "http://data.openspaceproject.com/examples/renderableplaneimageonline.jpg"
   },
   GUI = {
-    Description = "A plane that loads a texture from the internet",
+    Description = "A plane that loads a texture from the internet.",
     Path = "/Examples"
   }
 }

--- a/data/assets/examples/screenspacebrowser.asset
+++ b/data/assets/examples/screenspacebrowser.asset
@@ -21,7 +21,7 @@ asset.meta = {
   Name = "ScreenSpaceBrowser Example",
   Version = "1.0",
   Description = [[Example of how to load and show a webpage in the rendering. The loaded
-    webpage is shown in screen space]],
+    webpage is shown in screen space.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/examples/screenspacebrowser.asset
+++ b/data/assets/examples/screenspacebrowser.asset
@@ -15,3 +15,14 @@ asset.onDeinitialize(function()
 end)
 
 asset.export(Browser)
+
+
+asset.meta = {
+  Name = "ScreenSpaceBrowser Example",
+  Version = "1.0",
+  Description = [[Example of how to load and show a webpage in the rendering. The loaded
+    webpage is shown in screen space]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/spheres.asset
+++ b/data/assets/examples/spheres.asset
@@ -49,3 +49,15 @@ end)
 for _, n in ipairs(spheres) do
   asset.export(n)
 end
+
+
+asset.meta = {
+  Name = "Spheres Example",
+  Version = "1.0",
+  Description = [[Example showing how to render textured spheres in 3D space. Some
+    coding logic is used to generate 9 spheres with different size and position.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}
+

--- a/data/assets/examples/statemachine.asset
+++ b/data/assets/examples/statemachine.asset
@@ -71,3 +71,14 @@ asset.onInitialize(function()
 
   openspace.statemachine.createStateMachine(States, Transitions, "Earth")
 end)
+
+
+asset.meta = {
+  Name = "State Machine",
+  Version = "1.0",
+  Description = [[Example of how to create a state machine in OpenSpace, where each
+    state and transition between states may trigger different behaviors.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/urlsynchronization.asset
+++ b/data/assets/examples/urlsynchronization.asset
@@ -47,7 +47,7 @@ asset.meta = {
   Name = "UrlSynchronization",
   Version = "1.0",
   Description = [[Example showing how to load resources (any type of data file) from
-    online sources, using the UrlSyncronization resouce type. These can then be used
+    online sources, using the UrlSynchronization resource type. These can then be used
     in other assets. See more information on resources on the OpenSpace wiki page.
   ]],
   Author = "OpenSpace Team",

--- a/data/assets/examples/urlsynchronization.asset
+++ b/data/assets/examples/urlsynchronization.asset
@@ -31,6 +31,9 @@ asset.syncedResource({
   Override = true
 })
 
+-- Load a resource without hashing, meaning that the bare directory name will be
+-- used for the downloaded file. If UseHash is true, the hash of the URL is appended
+-- to the directory name to produce a unique directory under all circumstances
 asset.syncedResource({
   Name = "Example No Hash",
   Type = "UrlSynchronization",
@@ -38,3 +41,16 @@ asset.syncedResource({
   Url = "http://wms.itn.liu.se/Mercury/Messenger_Mosaic/Messenger_Mosaic.wms",
   UseHash = false
 })
+
+
+asset.meta = {
+  Name = "UrlSynchronization",
+  Version = "1.0",
+  Description = [[Example showing how to load resources (any type of data file) from
+    online sources, using the UrlSyncronization resouce type. These can then be used
+    in other assets. See more information on resources on the OpenSpace wiki page.
+  ]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/examples/video/videoglobe.asset
+++ b/data/assets/examples/video/videoglobe.asset
@@ -1,4 +1,4 @@
--- To learn how you can include your own video, see the wiki 
+-- To learn how you can include your own video, see the wiki
 -- http://wiki.openspaceproject.com/docs/builders/assets/resources.html
 
 local earth = asset.require("scene/solarsystem/planets/earth/earth")
@@ -27,7 +27,7 @@ asset.export("layer", Layer)
 
 
 asset.meta = {
-  Name = "Video Player Test",
+  Name = "Video Player on Globe Example",
   Version = "1.0",
   Description = "An example asset that shows how to include a video on Earth",
   Author = "OpenSpace Team",

--- a/data/assets/examples/video/videoglobe.asset
+++ b/data/assets/examples/video/videoglobe.asset
@@ -29,7 +29,7 @@ asset.export("layer", Layer)
 asset.meta = {
   Name = "Video Player on Globe Example",
   Version = "1.0",
-  Description = "An example asset that shows how to include a video on Earth",
+  Description = "An example asset that shows how to include a video on Earth.",
   Author = "OpenSpace Team",
   URL = "https://openspaceproject.com",
   License = "MIT"

--- a/data/assets/examples/video/videoplane.asset
+++ b/data/assets/examples/video/videoplane.asset
@@ -1,4 +1,4 @@
--- To learn how you can include your own video, see the wiki 
+-- To learn how you can include your own video, see the wiki
 -- http://wiki.openspaceproject.com/docs/builders/assets/resources.html
 
 local transforms = asset.require("scene/solarsystem/planets/earth/transforms")
@@ -40,7 +40,7 @@ asset.export(Plane)
 
 
 asset.meta = {
-  Name = "Video Plane Test",
+  Name = "Video Plane Example",
   Version = "1.0",
   Description = "An example asset that shows how to include a video on a plane",
   Author = "OpenSpace Team",

--- a/data/assets/examples/video/videoplane.asset
+++ b/data/assets/examples/video/videoplane.asset
@@ -42,7 +42,7 @@ asset.export(Plane)
 asset.meta = {
   Name = "Video Plane Example",
   Version = "1.0",
-  Description = "An example asset that shows how to include a video on a plane",
+  Description = "An example asset that shows how to include a video on a plane.",
   Author = "OpenSpace Team",
   URL = "https://openspaceproject.com",
   License = "MIT"

--- a/data/assets/examples/video/videoscreenspace.asset
+++ b/data/assets/examples/video/videoscreenspace.asset
@@ -24,7 +24,7 @@ asset.export(ScreenSpace)
 asset.meta = {
   Name = "ScreenSpace Video Example",
   Version = "1.0",
-  Description = "An example asset that shows how to include a video in screen space",
+  Description = "An example asset that shows how to include a video in screen space.",
   Author = "OpenSpace Team",
   URL = "https://openspaceproject.com",
   License = "MIT"

--- a/data/assets/examples/video/videoscreenspace.asset
+++ b/data/assets/examples/video/videoscreenspace.asset
@@ -1,4 +1,4 @@
--- To learn how you can include your own video, see the wiki 
+-- To learn how you can include your own video, see the wiki
 -- http://wiki.openspaceproject.com/docs/builders/assets/resources.html
 
 local ScreenSpace = {
@@ -22,7 +22,7 @@ asset.export(ScreenSpace)
 
 
 asset.meta = {
-  Name = "Video ScreenSpace",
+  Name = "ScreenSpace Video Example",
   Version = "1.0",
   Description = "An example asset that shows how to include a video in screen space",
   Author = "OpenSpace Team",

--- a/data/assets/examples/video/videosphere.asset
+++ b/data/assets/examples/video/videosphere.asset
@@ -32,7 +32,7 @@ asset.export(Sphere)
 asset.meta = {
   Name = "Video Player on Sphere Example",
   Version = "1.0",
-  Description = "An example asset that shows how to include a video on a sphere",
+  Description = "An example asset that shows how to include a video on a sphere.",
   Author = "OpenSpace Team",
   URL = "https://openspaceproject.com",
   License = "MIT"

--- a/data/assets/examples/video/videosphere.asset
+++ b/data/assets/examples/video/videosphere.asset
@@ -1,4 +1,4 @@
--- To learn how you can include your own video, see the wiki 
+-- To learn how you can include your own video, see the wiki
 -- http://wiki.openspaceproject.com/docs/builders/assets/resources.html
 
 local Sphere = {
@@ -30,7 +30,7 @@ asset.export(Sphere)
 
 
 asset.meta = {
-  Name = "Video Player on Sphere",
+  Name = "Video Player on Sphere Example",
   Version = "1.0",
   Description = "An example asset that shows how to include a video on a sphere",
   Author = "OpenSpace Team",

--- a/data/assets/nightsky/altaz.asset
+++ b/data/assets/nightsky/altaz.asset
@@ -56,8 +56,8 @@ local AltAzGrid = {
     Name = "Altitude/Azimuth Grid",
     Description = [[A local Altitude/Azimuth grid centered around your position on a
     planetary surface. The grid can be toggled, hidden or shown using the accompanying
-    actiions in the actions panel, under "Night Sky". Use these actions to move it to
-    another planet. The default is Earth]],
+    actions in the actions panel, under "Night Sky". Use these actions to move it to
+    another planet. The default is Earth.]],
     Path = "/Other/Night Sky"
   }
 }
@@ -131,7 +131,7 @@ asset.meta = {
   Version = "1.0",
   Description = [[A local Altitude/Azimuth grid centered around your position on a
     planetary surface. The asset also includes some actions to toggle, hide or
-    show the grid]],
+    show the grid.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/nightsky/altaz.asset
+++ b/data/assets/nightsky/altaz.asset
@@ -26,7 +26,7 @@ local AltAzGridPosition = {
   },
   GUI = {
     Name = "Altitude/Azimuth Grid Position",
-    Path = "/Other/Grids",
+    Path = "/Other/Night Sky",
     Hidden = true
   }
 }
@@ -54,7 +54,11 @@ local AltAzGrid = {
   },
   GUI = {
     Name = "Altitude/Azimuth Grid",
-    Path = "/Other/Grids"
+    Description = [[A local Altitude/Azimuth grid centered around your position on a
+    planetary surface. The grid can be toggled, hidden or shown using the accompanying
+    actiions in the actions panel, under "Night Sky". Use these actions to move it to
+    another planet. The default is Earth]],
+    Path = "/Other/Night Sky"
   }
 }
 
@@ -120,3 +124,15 @@ asset.export(AltAzGrid)
 asset.export("ShowAltaz", ShowAltaz.Identifier)
 asset.export("HideAltaz", HideAltaz.Identifier)
 asset.export("ToggleAltaz", ToggleAltaz.Identifier)
+
+
+asset.meta = {
+  Name = "Altitude/Azimuth Grid",
+  Version = "1.0",
+  Description = [[A local Altitude/Azimuth grid centered around your position on a
+    planetary surface. The asset also includes some actions to toggle, hide or
+    show the grid]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/cardinal_directions.asset
+++ b/data/assets/nightsky/cardinal_directions.asset
@@ -60,7 +60,7 @@ local CardinalDirectionSphere = {
   },
   GUI = {
     Name = "Cardinal Directions",
-    Description = [[A textures sphere showing the cardinal directions.
+    Description = [[A textured sphere showing the cardinal directions.
       The sphere is placed on the planet surface and follows the camera's movements.
     ]],
     Path = "/Other/Night Sky"

--- a/data/assets/nightsky/cardinal_directions.asset
+++ b/data/assets/nightsky/cardinal_directions.asset
@@ -60,6 +60,9 @@ local CardinalDirectionSphere = {
   },
   GUI = {
     Name = "Cardinal Directions",
+    Description = [[A textures sphere showing the cardinal directions.
+      The sphere is placed on the planet surface and follows the camera's movements.
+    ]],
     Path = "/Other/Night Sky"
   }
 }
@@ -153,3 +156,16 @@ asset.export("ShowNeswBandSmall", ShowNeswBand.Identifier)
 asset.export("ShowNeswLetters", ShowNeswLetters.Identifier)
 asset.export("ShowNeswLettersSmall", ShowNeswLettersSmall.Identifier)
 asset.export("HideNesw", HideNesw.Identifier)
+
+
+asset.meta = {
+  Name = "Cardinal Directions",
+  Version = "1.0",
+  Description = [[Adds a sphere showing the cardinal directions, that follows the camera
+    around when navigating on the planet surface. It also includes actions to change the
+    texture of the sphere to different styles.
+  ]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/ecliptic_band.asset
+++ b/data/assets/nightsky/ecliptic_band.asset
@@ -40,6 +40,7 @@ local EclipticLine = {
   },
   GUI = {
     Name = "Ecliptic Line",
+    Description = "A line representation of the Ecliptic plane",
     Path = "/Other/Lines"
   }
 }
@@ -65,6 +66,7 @@ local EclipticBand = {
   },
   GUI = {
     Name = "Ecliptic Band",
+    Description = "A band representation of the Ecliptic plane",
     Path = "/Other/Lines"
   }
 }
@@ -158,3 +160,14 @@ asset.export("ToggleEclipticLine", ToggleEclipticLine.Identifier)
 asset.export("ShowEclipticBand", ShowEclipticBand.Identifier)
 asset.export("HideEclipticBand", HideEclipticBand.Identifier)
 asset.export("ToggleEclipticBand", ToggleEclipticBand.Identifier)
+
+
+asset.meta = {
+  Name = "Ecliptic Band/Line",
+  Version = "1.0",
+  Description = [[A line and band representation of the Ecliptic plane, including actions
+    to toggle, hide and show each of them.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/ecliptic_band.asset
+++ b/data/assets/nightsky/ecliptic_band.asset
@@ -40,7 +40,7 @@ local EclipticLine = {
   },
   GUI = {
     Name = "Ecliptic Line",
-    Description = "A line representation of the Ecliptic plane",
+    Description = "A line representation of the Ecliptic plane.",
     Path = "/Other/Lines"
   }
 }
@@ -66,7 +66,7 @@ local EclipticBand = {
   },
   GUI = {
     Name = "Ecliptic Band",
-    Description = "A band representation of the Ecliptic plane",
+    Description = "A band representation of the Ecliptic plane.",
     Path = "/Other/Lines"
   }
 }

--- a/data/assets/nightsky/equatorial_band.asset
+++ b/data/assets/nightsky/equatorial_band.asset
@@ -33,7 +33,7 @@ local EquatorialLine = {
   },
   GUI = {
     Name = "Equatorial Line",
-    Description = "A line representation of the Equatorial plane",
+    Description = "A line representation of the Equatorial plane.",
     Path = "/Other/Lines"
   }
 }

--- a/data/assets/nightsky/equatorial_band.asset
+++ b/data/assets/nightsky/equatorial_band.asset
@@ -33,6 +33,7 @@ local EquatorialLine = {
   },
   GUI = {
     Name = "Equatorial Line",
+    Description = "A line representation of the Equatorial plane",
     Path = "/Other/Lines"
   }
 }
@@ -87,3 +88,14 @@ asset.export(EquatorialLine)
 asset.export("ShowEquatorialLine", ShowEquatorialLine.Identifier)
 asset.export("HideEquatorialLine", HideEquatorialLine.Identifier)
 asset.export("ToggleEquatorialLine", ToggleEquatorialLine.Identifier)
+
+
+asset.meta = {
+  Name = "Equatorial Line",
+  Version = "1.0",
+  Description = [[A line representation of the Equatorial plane, including actions
+    to toggle, hide and show it.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/galactic_band.asset
+++ b/data/assets/nightsky/galactic_band.asset
@@ -22,6 +22,7 @@ local GalacticBand = {
     },
     GUI = {
         Name = "Galactic Equator Line",
+        Description = "A line representation of the Galactic Equator plane",
         Path = "/Other/Lines"
     }
 }
@@ -73,3 +74,15 @@ end)
 asset.export(GalacticBand)
 asset.export("ShowGalacticBand", ShowGalacticBand.Identifier)
 asset.export("HideGalacticBand", HideGalacticBand.Identifier)
+
+
+asset.meta = {
+  Name = "Galactic Line",
+  Version = "1.0",
+  Description = [[A line representation of the Galactic Equator plane, including actions
+    to toggle, hide and show it.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}
+

--- a/data/assets/nightsky/galactic_band.asset
+++ b/data/assets/nightsky/galactic_band.asset
@@ -22,7 +22,7 @@ local GalacticBand = {
     },
     GUI = {
         Name = "Galactic Equator Line",
-        Description = "A line representation of the Galactic Equator plane",
+        Description = "A line representation of the Galactic Equator plane.",
         Path = "/Other/Lines"
     }
 }

--- a/data/assets/nightsky/light_pollution.asset
+++ b/data/assets/nightsky/light_pollution.asset
@@ -50,7 +50,7 @@ local LightPollutionSphere = {
     Name = "Light Pollution Sphere",
     Description = [[A sphere used to simulate the effect of light pollution on
       the night sky. Different pollution levels can be set using the provided actions.
-      These alter the opacity of the sphere.]]
+      These alter the opacity of the sphere.]],
     Path = "/Other/Night Sky",
     Hidden = false
   }

--- a/data/assets/nightsky/light_pollution.asset
+++ b/data/assets/nightsky/light_pollution.asset
@@ -48,6 +48,9 @@ local LightPollutionSphere = {
   },
   GUI = {
     Name = "Light Pollution Sphere",
+    Description = [[A sphere used to simulate the effect of light pollution on
+      the night sky. Different pollution levels can be set using the provided actions.
+      These alter the opacity of the sphere.]]
     Path = "/Other/Night Sky",
     Hidden = false
   }
@@ -250,3 +253,15 @@ asset.export("SetLightPollutionLevel7", SetLightPollutionLevel7.Identifier)
 asset.export("SetLightPollutionLevel8", SetLightPollutionLevel8.Identifier)
 asset.export("SetLightPollutionLevel9", SetLightPollutionLevel9.Identifier)
 asset.export("UndoLightPollution", UndoLightPollution.Identifier)
+
+
+asset.meta = {
+  Name = "Light Pollution",
+  Version = "1.0",
+  Description = [[Includes a sphere used to simulate the effect of light pollution on
+    the night sky, and actions to set the desired level of pollution (with a scale
+    from 1-9).]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/meridian.asset
+++ b/data/assets/nightsky/meridian.asset
@@ -50,6 +50,7 @@ local MeridianPlane = {
   },
   GUI = {
     Name = "Local Meridian",
+    Description = [[A line representation of the Local Meridian]],
     Path = "/Other/Lines"
   }
 }
@@ -118,3 +119,14 @@ asset.export(MeridianPlane)
 asset.export("ShowMeridian", ShowMeridian.Identifier)
 asset.export("HideMeridian", HideMeridian.Identifier)
 asset.export("ToggleMeridian", ToggleMeridian.Identifier)
+
+
+asset.meta = {
+  Name = "Meridian",
+  Version = "1.0",
+  Description = [[A line representation of the Local Meridian, including actions
+    to toggle, hide and show it.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/nightsky.asset
+++ b/data/assets/nightsky/nightsky.asset
@@ -9,3 +9,13 @@ asset.require("./zenith", false)
 asset.require("./planets", false)
 asset.require("actions/nightsky/camera", false)
 asset.require("actions/nightsky/daytime", false)
+
+
+asset.meta = {
+  Name = "Night Sky Assets",
+  Version = "1.0",
+  Description = [[A collection of assets useful for studying the night sky.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/planets.asset
+++ b/data/assets/nightsky/planets.asset
@@ -30,6 +30,8 @@ local Mercury = {
   Tag = { "nightsky_billboard" },
   GUI = {
     Name = "Night Sky Mercury",
+    Description = [[A night sky version of the planet Mercury, making it visible as
+      a bright object on the sky (textured representation)]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -50,6 +52,8 @@ local Venus = {
   Tag = { "nightsky_billboard" },
   GUI = {
     Name = "Night Sky Venus",
+    Description = [[A night sky version of the planet Venus, making it visible as
+      a bright object on the sky (textured representation)]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -90,6 +94,8 @@ local Jupiter = {
   Tag = { "nightsky_billboard" },
   GUI = {
     Name = "Night Sky Jupiter",
+    Description = [[A night sky version of the planet Jupiter, making it visible as
+      a bright object on the sky (textured representation)]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -110,6 +116,8 @@ local Saturn = {
   Tag = { "nightsky_billboard" },
   GUI = {
     Name = "Night Sky Saturn",
+    Description = [[A night sky version of the planet Saturn, making it visible as
+      a bright object on the sky (textured representation)]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -198,3 +206,14 @@ asset.export(Saturn)
 asset.export("ShowNightSkyPlanets", ShowNightSkyPlanets.Identifier)
 asset.export("HideNightSkyPlanets", HideNightSkyPlanets.Identifier)
 asset.export("ToggleNightSkyPlanets", ToggleNightSkyPlanets.Identifier)
+
+
+asset.meta = {
+  Name = "Night Sky Planets",
+  Version = "1.0",
+  Description = [[A collection of night sky versions of the planets Mercury, Venus,
+    Mars, Jupiter and Saturn, including actions to toggle, hide and show them.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}

--- a/data/assets/nightsky/planets.asset
+++ b/data/assets/nightsky/planets.asset
@@ -31,7 +31,7 @@ local Mercury = {
   GUI = {
     Name = "Night Sky Mercury",
     Description = [[A night sky version of the planet Mercury, making it visible as
-      a bright object on the sky (textured representation)]],
+      a bright object on the sky (textured representation).]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -53,7 +53,7 @@ local Venus = {
   GUI = {
     Name = "Night Sky Venus",
     Description = [[A night sky version of the planet Venus, making it visible as
-      a bright object on the sky (textured representation)]],
+      a bright object on the sky (textured representation).]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -95,7 +95,7 @@ local Jupiter = {
   GUI = {
     Name = "Night Sky Jupiter",
     Description = [[A night sky version of the planet Jupiter, making it visible as
-      a bright object on the sky (textured representation)]],
+      a bright object on the sky (textured representation).]],
     Path = "/Other/Night Sky/Planets"
   }
 }
@@ -117,7 +117,7 @@ local Saturn = {
   GUI = {
     Name = "Night Sky Saturn",
     Description = [[A night sky version of the planet Saturn, making it visible as
-      a bright object on the sky (textured representation)]],
+      a bright object on the sky (textured representation).]],
     Path = "/Other/Night Sky/Planets"
   }
 }

--- a/data/assets/nightsky/zenith.asset
+++ b/data/assets/nightsky/zenith.asset
@@ -58,6 +58,9 @@ local ZenithDot = {
   },
   GUI = {
     Name = "Zenith",
+    Description = [[A dot representation of the Local Zenith, based on the camera's
+      current position on a planet. Use the provided show or toggle action to move it
+      between planets. The default is Earth.]],
     Path = "/Other/Points"
   }
 }
@@ -124,3 +127,14 @@ asset.export(ZenithDot)
 asset.export("ShowZenith", ShowZenith.Identifier)
 asset.export("HideZenith", HideZenith.Identifier)
 asset.export("ToggleZenith", ToggleZenith.Identifier)
+
+
+asset.meta = {
+  Name = "Zenith",
+  Version = "1.0",
+  Description = [[A dot representation of the Local Zenith (based on the current
+    camera positon), including actions to toggle, hide and show it.]],
+  Author = "OpenSpace Team",
+  URL = "http://openspaceproject.com",
+  License = "MIT license"
+}


### PR DESCRIPTION
Add UI description and asset.meta to a bunch of asset files (mainly scale objects, night sky and examples)

To make them more useful for our users, especially with the improvements to the node meta panel from PR https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/154