### PR TITLE
Add options to disable roll and zoom in OrbitalNavigator

### DIFF
--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -214,6 +214,9 @@ private:
 
     LimitZoom _limitZoom;
 
+    properties::BoolProperty _disableZoom;
+    properties::BoolProperty _disableRoll;
+
     properties::FloatProperty _mouseSensitivity;
     properties::FloatProperty _joystickSensitivity;
     properties::FloatProperty _websocketSensitivity;


### PR DESCRIPTION
To discuss: Do we need similar settings for other camera motions, like panning and global rotation?  Should I add these too?


We used this setting in the Stort installation, to prevent the user from moving closer to objects in certain scenarios, without having to set exact distances for limiting the vertical navigation


Added warnings that show if either property is disabled. Feels like one of those things the user could easily forget is disabled, and be confused about. The warning increases the visibility of the effect, and warns the user about the consequences