### PR TITLE
Add a proper blackout to the ScreenSpaceRenderables and a property and codegen option to toggle that behavior

### DIFF
--- a/include/openspace/rendering/screenspacerenderable.h
+++ b/include/openspace/rendering/screenspacerenderable.h
@@ -61,7 +61,7 @@ public:
     ScreenSpaceRenderable(const ghoul::Dictionary& dictionary);
     virtual ~ScreenSpaceRenderable() override;
 
-    virtual void render();
+    virtual void render(float blackoutFactor);
 
     virtual bool initialize();
     virtual bool initializeGL();
@@ -102,7 +102,7 @@ protected:
     glm::vec3 raeToCartesian(const glm::vec3& rae) const;
     glm::vec3 cartesianToRae(const glm::vec3& cartesian) const;
 
-    void draw(glm::mat4 modelTransform);
+    void draw(glm::mat4 modelTransform, float blackoutFactor);
 
     virtual void bindTexture() = 0;
     virtual void unbindTexture();
@@ -114,6 +114,7 @@ protected:
     glm::vec3 sanitizeSphericalCoordinates(glm::vec3 spherical) const;
 
     properties::BoolProperty _enabled;
+    properties::BoolProperty _renderDuringBlackout;
     properties::BoolProperty _usePerspectiveProjection;
     properties::BoolProperty _useRadiusAzimuthElevation;
     properties::BoolProperty _faceCamera;
@@ -140,7 +141,7 @@ protected:
     properties::TriggerProperty _delete;
 
     glm::ivec2 _objectSize = glm::ivec2(0);
-    UniformCache(color, opacity, mvp, texture, backgroundColor, gamma,
+    UniformCache(color, opacity, blackoutFactor, mvp, texture, backgroundColor, gamma,
         borderColor, borderWidth) _uniformCache;
     std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
 };

--- a/modules/base/rendering/screenspaceframebuffer.cpp
+++ b/modules/base/rendering/screenspaceframebuffer.cpp
@@ -105,7 +105,7 @@ bool ScreenSpaceFramebuffer::deinitializeGL() {
     return true;
 }
 
-void ScreenSpaceFramebuffer::render() {
+void ScreenSpaceFramebuffer::render(float blackoutFactor) {
     const glm::vec2& resolution = global::windowDelegate->currentDrawBufferResolution();
     const glm::vec4& size = _size.value();
 
@@ -145,7 +145,7 @@ void ScreenSpaceFramebuffer::render() {
             glm::vec3((1.f / xratio), (1.f / yratio), 1.f)
         );
         const glm::mat4 modelTransform = globalRotation*translation*localRotation*scale;
-        draw(modelTransform);
+        draw(modelTransform, blackoutFactor);
     }
 }
 

--- a/modules/base/rendering/screenspaceframebuffer.h
+++ b/modules/base/rendering/screenspaceframebuffer.h
@@ -55,7 +55,7 @@ public:
 
     bool initializeGL() override;
     bool deinitializeGL() override;
-    void render() override;
+    void render(float blackoutFactor) override;
     bool isReady() const override;
 
     void setSize(glm::vec4 size);

--- a/modules/base/shaders/screenspace_fs.glsl
+++ b/modules/base/shaders/screenspace_fs.glsl
@@ -31,6 +31,7 @@ in float vs_depth;
 uniform sampler2D tex;
 uniform vec3 color = vec3(1.0);
 uniform float opacity = 1.0;
+uniform float blackoutFactor = 1.0;
 uniform vec4 backgroundColor = vec4(0.0);
 uniform float gamma = 1.0;
 uniform vec2 borderWidth = vec2(0.1);
@@ -56,6 +57,6 @@ Fragment getFragment() {
   }
 
   frag.depth = vs_depth;
-  frag.color.rgb = pow(frag.color.rgb, vec3(1.0/(gamma)));
+  frag.color.rgb = pow(frag.color.rgb, vec3(1.0/(gamma))) * blackoutFactor;
   return frag;
 }

--- a/modules/skybrowser/include/screenspaceskybrowser.h
+++ b/modules/skybrowser/include/screenspaceskybrowser.h
@@ -43,7 +43,7 @@ public:
     bool initializeGL() override;
     bool deinitializeGL() override;
     glm::mat4 scaleMatrix() override;
-    void render() override;
+    void render(float blackoutFactor) override;
     void update() override;
 
     float opacity() const noexcept override;

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -314,16 +314,16 @@ bool ScreenSpaceSkyBrowser::deinitializeGL() {
     return true;
 }
 
-void ScreenSpaceSkyBrowser::render() {
+void ScreenSpaceSkyBrowser::render(float blackoutFactor) {
     WwtCommunicator::render();
 
     if (!_isHidden) {
-        draw(
+        glm::mat4 mat =
             globalRotationMatrix() *
             translationMatrix() *
             localRotationMatrix() *
-            scaleMatrix()
-        );
+            scaleMatrix();
+        draw(mat, blackoutFactor);
     }
 
     // Render the display copies
@@ -342,12 +342,12 @@ void ScreenSpaceSkyBrowser::render() {
                 ));
             }
 
-            draw(
+            glm::mat4 mat =
                 globalRotationMatrix() *
                 glm::translate(glm::mat4(1.f), coordinates) *
                 localRotation *
-                scaleMatrix()
-            );
+                scaleMatrix();
+            draw(mat, blackoutFactor);
         }
     }
 }

--- a/modules/video/include/screenspacevideo.h
+++ b/modules/video/include/screenspacevideo.h
@@ -43,7 +43,7 @@ public:
     bool initializeGL() override;
     bool deinitializeGL() override;
     void update() override;
-    void render() override;
+    void render(float blackoutFactor) override;
 
     static documentation::Documentation Documentation();
 

--- a/modules/video/src/screenspacevideo.cpp
+++ b/modules/video/src/screenspacevideo.cpp
@@ -79,9 +79,9 @@ void ScreenSpaceVideo::update() {
     }
 }
 
-void ScreenSpaceVideo::render() {
+void ScreenSpaceVideo::render(float blackoutFactor) {
     if (_videoPlayer.isInitialized()) {
-        ScreenSpaceRenderable::render();
+        ScreenSpaceRenderable::render(blackoutFactor);
     }
 }
 

--- a/modules/webbrowser/include/screenspacebrowser.h
+++ b/modules/webbrowser/include/screenspacebrowser.h
@@ -68,7 +68,7 @@ public:
     bool initializeGL() override;
     bool deinitializeGL() override;
 
-    void render() override;
+    void render(float blackoutFactor) override;
     void update() override;
     bool isReady() const override;
 

--- a/modules/webbrowser/src/screenspacebrowser.cpp
+++ b/modules/webbrowser/src/screenspacebrowser.cpp
@@ -152,18 +152,18 @@ bool ScreenSpaceBrowser::deinitializeGL() {
     return ScreenSpaceRenderable::deinitializeGL();
 }
 
-void ScreenSpaceBrowser::render() {
+void ScreenSpaceBrowser::render(float blackoutFactor) {
     if (!_renderHandler->isTextureReady()) {
         return;
     }
 
     _renderHandler->updateTexture();
-    draw(
+    glm::mat4 mat =
         globalRotationMatrix() *
         translationMatrix() *
         localRotationMatrix() *
-        scaleMatrix()
-    );
+        scaleMatrix();
+    draw(mat, blackoutFactor);
 }
 
 void ScreenSpaceBrowser::update() {

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -728,7 +728,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         RenderFont(*_fontFrameInfo, penPosition, res);
     }
 
-    if (renderingEnabled && !delegate.isGuiWindow() && _globalBlackOutFactor > 0.f) {
+    if (renderingEnabled && !delegate.isGuiWindow()) {
         ZoneScopedN("Render Screenspace Renderable");
 
         std::vector<ScreenSpaceRenderable*> ssrs;
@@ -755,7 +755,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         for (ScreenSpaceRenderable* ssr : ssrs) {
-            ssr->render();
+            ssr->render(_globalBlackOutFactor);
         }
         glDisable(GL_BLEND);
     }


### PR DESCRIPTION
Adds a new property to all ScreenSpaceRenderables `RenderDuringBlackout` that controls whether a ScreenSpaceRenderable should listen to the BlackoutFactor of the RenderEngine or not.  If it does listen, it will darken the image by the same value as the 3D rendering, if it does not listen, it will always render at full brightness.
Also fixed the issue where no ScreenSpaceRenderables are rendered when the blackout factor is 0