### PR TITLE
Fix for issue/2860

### DIFF
--- a/config/schema/sgcteditor.schema.json
+++ b/config/schema/sgcteditor.schema.json
@@ -313,6 +313,9 @@
         "minor": { "type": "integer" }
       },
       "required": [ "name", "major", "minor" ]
+    },
+    "meta": {
+      "$ref": "sgct.schema.json#/$defs/meta"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Fixes issue 2860 by correcting typo in sgct schema file, which allows editing of user-created config files again.