### PR TITLE
Issue/2768

### DIFF
--- a/include/openspace/interaction/actionmanager.h
+++ b/include/openspace/interaction/actionmanager.h
@@ -35,14 +35,16 @@ namespace openspace::interaction {
 
 class ActionManager {
 public:
+    BooleanType(ShouldBeSynchronized);
+
     bool hasAction(const std::string& identifier) const;
     void registerAction(Action action);
     void removeAction(const std::string& identifier);
     const Action& action(const std::string& identifier) const;
     std::vector<Action> actions() const;
 
-    void triggerAction(const std::string& identifier,
-        const ghoul::Dictionary& arguments, bool shouldBeSynchronized) const;
+    void triggerAction(const std::string& identifier, const ghoul::Dictionary& arguments,
+        ShouldBeSynchronized shouldBeSynchronized) const;
     static scripting::LuaLibrary luaLibrary();
 
 private:

--- a/include/openspace/interaction/actionmanager.h
+++ b/include/openspace/interaction/actionmanager.h
@@ -42,7 +42,7 @@ public:
     std::vector<Action> actions() const;
 
     void triggerAction(const std::string& identifier,
-        const ghoul::Dictionary& arguments) const;
+        const ghoul::Dictionary& arguments, bool shouldBeSynchronized) const;
     static scripting::LuaLibrary luaLibrary();
 
 private:

--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -66,7 +66,7 @@ private:
     void addToCommand(std::string c);
 
     properties::BoolProperty _isVisible;
-    properties::BoolProperty _remoteScripting;
+    properties::BoolProperty _shouldSendToRemote;
 
     properties::Vec4Property _backgroundColor;
     properties::Vec4Property _entryTextColor;

--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -66,6 +66,7 @@ private:
     void addToCommand(std::string c);
 
     properties::BoolProperty _isVisible;
+    properties::BoolProperty _shouldBeSynchronized;
     properties::BoolProperty _shouldSendToRemote;
 
     properties::Vec4Property _backgroundColor;

--- a/include/openspace/scripting/scriptengine.h
+++ b/include/openspace/scripting/scriptengine.h
@@ -51,11 +51,11 @@ namespace openspace::scripting {
 class ScriptEngine : public Syncable {
 public:
     using ScriptCallback = std::function<void(ghoul::Dictionary)>;
-    BooleanType(RemoteScripting);
+    BooleanType(ShouldSendToRemote);
 
     struct QueueItem {
         std::string script;
-        RemoteScripting remoteScripting;
+        ShouldSendToRemote shouldSendToRemote;
         ScriptCallback callback;
     };
 
@@ -89,7 +89,7 @@ public:
     virtual void decode(SyncBuffer* syncBuffer) override;
     virtual void postSync(bool isMaster) override;
 
-    void queueScript(std::string script, RemoteScripting remoteScripting,
+    void queueScript(std::string script, ShouldSendToRemote shouldSendToRemote,
         ScriptCallback cb = ScriptCallback());
 
     std::vector<std::string> allLuaFunctions() const;

--- a/include/openspace/scripting/scriptengine.h
+++ b/include/openspace/scripting/scriptengine.h
@@ -51,10 +51,12 @@ namespace openspace::scripting {
 class ScriptEngine : public Syncable {
 public:
     using ScriptCallback = std::function<void(ghoul::Dictionary)>;
+    BooleanType(ShouldBeSynchronized);
     BooleanType(ShouldSendToRemote);
 
     struct QueueItem {
         std::string script;
+        ShouldBeSynchronized shouldBeSynchronized;
         ShouldSendToRemote shouldSendToRemote;
         ScriptCallback callback;
     };
@@ -89,8 +91,8 @@ public:
     virtual void decode(SyncBuffer* syncBuffer) override;
     virtual void postSync(bool isMaster) override;
 
-    void queueScript(std::string script, ShouldSendToRemote shouldSendToRemote,
-        ScriptCallback cb = ScriptCallback());
+    void queueScript(std::string script, ShouldBeSynchronized shouldBeSynchronized,
+        ShouldSendToRemote shouldSendToRemote, ScriptCallback cb = ScriptCallback());
 
     std::vector<std::string> allLuaFunctions() const;
 

--- a/modules/debugging/debuggingmodule_lua.inl
+++ b/modules/debugging/debuggingmodule_lua.inl
@@ -66,6 +66,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
     global::scriptEngine->queueScript(
         addParentScript,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
@@ -98,6 +99,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
         global::scriptEngine->queueScript(
             fmt::format("openspace.addSceneGraphNode({})", pointNode),
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     };
@@ -120,6 +122,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
         global::scriptEngine->queueScript(
             fmt::format("openspace.addSceneGraphNode({})", lineNode),
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     };
@@ -157,6 +160,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
     using namespace openspace;
     global::scriptEngine->queueScript(
         fmt::format("openspace.removeSceneGraphNode('{}');", RenderedPathIdentifier),
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -189,6 +193,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
     global::scriptEngine->queueScript(
         addParentScript,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
@@ -226,6 +231,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
         global::scriptEngine->queueScript(
             fmt::format("openspace.addSceneGraphNode({})", node),
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -236,6 +242,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
     using namespace openspace;
     global::scriptEngine->queueScript(
         fmt::format("openspace.removeSceneGraphNode('{}');", RenderedPointsIdentifier),
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -291,6 +298,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
     global::scriptEngine->queueScript(
         fmt::format("openspace.addSceneGraphNode({});", axes),
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/debugging/debuggingmodule_lua.inl
+++ b/modules/debugging/debuggingmodule_lua.inl
@@ -66,7 +66,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
     global::scriptEngine->queueScript(
         addParentScript,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     // Get the poses along the path
@@ -98,7 +98,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
         global::scriptEngine->queueScript(
             fmt::format("openspace.addSceneGraphNode({})", pointNode),
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     };
 
@@ -120,7 +120,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
         global::scriptEngine->queueScript(
             fmt::format("openspace.addSceneGraphNode({})", lineNode),
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     };
 
@@ -157,7 +157,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
     using namespace openspace;
     global::scriptEngine->queueScript(
         fmt::format("openspace.removeSceneGraphNode('{}');", RenderedPathIdentifier),
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -189,7 +189,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
     global::scriptEngine->queueScript(
         addParentScript,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     const std::vector<glm::dvec3> points = currentPath->controlPoints();
@@ -226,7 +226,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
         global::scriptEngine->queueScript(
             fmt::format("openspace.addSceneGraphNode({})", node),
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 }
@@ -236,7 +236,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
     using namespace openspace;
     global::scriptEngine->queueScript(
         fmt::format("openspace.removeSceneGraphNode('{}');", RenderedPointsIdentifier),
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -291,7 +291,7 @@ constexpr glm::vec3 OrientationLineColor = glm::vec3(0.0, 1.0, 1.0);
 
     global::scriptEngine->queueScript(
         fmt::format("openspace.addSceneGraphNode({});", axes),
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -211,7 +211,7 @@ void createExoplanetSystem(const std::string& starName,
         "}"
     "}";
 
-    // No sync or send because this is already inside a lua script, therefor it has
+    // No sync or send because this is already inside a Lua script, therefor it has
     // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + starParent + ");",
@@ -330,7 +330,7 @@ void createExoplanetSystem(const std::string& starName,
             "}"
         "}";
 
-        // No sync or send because this is already inside a lua script, therefor it has
+        // No sync or send because this is already inside a Lua script, therefor it has
         // already been synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + planetTrailNode + ");"
@@ -383,7 +383,7 @@ void createExoplanetSystem(const std::string& starName,
                 "}"
             "}";
 
-            // No sync or send because this is already inside a lua script, therefor it
+            // No sync or send because this is already inside a Lua script, therefor it
             // has already been synced and sent to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + discNode + ");",
@@ -431,7 +431,7 @@ void createExoplanetSystem(const std::string& starName,
         "}"
     "}";
 
-    // No sync or send because this is already inside a lua script, therefor it has
+    // No sync or send because this is already inside a Lua script, therefor it has
     // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + circle + ");",
@@ -489,7 +489,7 @@ void createExoplanetSystem(const std::string& starName,
             "}"
         "}";
 
-        // No sync or send because this is already inside a lua script, therefor it has
+        // No sync or send because this is already inside a Lua script, therefor it has
         // already been synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + zoneDiscNode + ");",
@@ -533,7 +533,7 @@ void createExoplanetSystem(const std::string& starName,
                 "}"
             "}";
 
-            // No sync or send because this is already inside a lua script, therefor it
+            // No sync or send because this is already inside a Lua script, therefor it
             // has already been synced and sent to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + starGlare + ");",
@@ -646,7 +646,7 @@ std::vector<std::string> hostStarsWithSufficientData() {
     using namespace exoplanets;
     const std::string starIdentifier = makeIdentifier(std::move(starName));
 
-    // No sync or send because this is already inside a lua script, therefor it has
+    // No sync or send because this is already inside a Lua script, therefor it has
     // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + starIdentifier + "');",

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -213,7 +213,7 @@ void createExoplanetSystem(const std::string& starName,
 
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + starParent + ");",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     // Planets
@@ -330,7 +330,7 @@ void createExoplanetSystem(const std::string& starName,
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + planetTrailNode + ");"
             "openspace.addSceneGraphNode(" + planetNode + ");",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
 
         bool hasUpperAUncertainty = !std::isnan(planet.aUpper);
@@ -379,7 +379,7 @@ void createExoplanetSystem(const std::string& starName,
 
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + discNode + ");",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     }
@@ -424,7 +424,7 @@ void createExoplanetSystem(const std::string& starName,
 
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + circle + ");",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     // Habitable Zone
@@ -479,7 +479,7 @@ void createExoplanetSystem(const std::string& starName,
 
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + zoneDiscNode + ");",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
 
         // Star glare
@@ -520,7 +520,7 @@ void createExoplanetSystem(const std::string& starName,
 
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + starGlare + ");",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     }
@@ -629,7 +629,7 @@ std::vector<std::string> hostStarsWithSufficientData() {
     const std::string starIdentifier = makeIdentifier(std::move(starName));
     global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + starIdentifier + "');",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -211,6 +211,8 @@ void createExoplanetSystem(const std::string& starName,
         "}"
     "}";
 
+    // No sync or send because this is already inside a lua script, therefor it has
+    // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + starParent + ");",
         scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -328,6 +330,8 @@ void createExoplanetSystem(const std::string& starName,
             "}"
         "}";
 
+        // No sync or send because this is already inside a lua script, therefor it has
+        // already been synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + planetTrailNode + ");"
             "openspace.addSceneGraphNode(" + planetNode + ");",
@@ -379,6 +383,8 @@ void createExoplanetSystem(const std::string& starName,
                 "}"
             "}";
 
+            // No sync or send because this is already inside a lua script, therefor it
+            // has already been synced and sent to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + discNode + ");",
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -425,6 +431,8 @@ void createExoplanetSystem(const std::string& starName,
         "}"
     "}";
 
+    // No sync or send because this is already inside a lua script, therefor it has
+    // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + circle + ");",
         scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -481,6 +489,8 @@ void createExoplanetSystem(const std::string& starName,
             "}"
         "}";
 
+        // No sync or send because this is already inside a lua script, therefor it has
+        // already been synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + zoneDiscNode + ");",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -523,6 +533,8 @@ void createExoplanetSystem(const std::string& starName,
                 "}"
             "}";
 
+            // No sync or send because this is already inside a lua script, therefor it
+            // has already been synced and sent to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + starGlare + ");",
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -633,6 +645,9 @@ std::vector<std::string> hostStarsWithSufficientData() {
     using namespace openspace;
     using namespace exoplanets;
     const std::string starIdentifier = makeIdentifier(std::move(starName));
+
+    // No sync or send because this is already inside a lua script, therefor it has
+    // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + starIdentifier + "');",
         scripting::ScriptEngine::ShouldBeSynchronized::No,

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -213,7 +213,8 @@ void createExoplanetSystem(const std::string& starName,
 
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + starParent + ");",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 
     // Planets
@@ -330,7 +331,8 @@ void createExoplanetSystem(const std::string& starName,
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + planetTrailNode + ");"
             "openspace.addSceneGraphNode(" + planetNode + ");",
-            scripting::ScriptEngine::ShouldSendToRemote::Yes
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
 
         bool hasUpperAUncertainty = !std::isnan(planet.aUpper);
@@ -379,7 +381,8 @@ void createExoplanetSystem(const std::string& starName,
 
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + discNode + ");",
-                scripting::ScriptEngine::ShouldSendToRemote::Yes
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
     }
@@ -424,7 +427,8 @@ void createExoplanetSystem(const std::string& starName,
 
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + circle + ");",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 
     // Habitable Zone
@@ -479,7 +483,8 @@ void createExoplanetSystem(const std::string& starName,
 
         global::scriptEngine->queueScript(
             "openspace.addSceneGraphNode(" + zoneDiscNode + ");",
-            scripting::ScriptEngine::ShouldSendToRemote::Yes
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
 
         // Star glare
@@ -520,7 +525,8 @@ void createExoplanetSystem(const std::string& starName,
 
             global::scriptEngine->queueScript(
                 "openspace.addSceneGraphNode(" + starGlare + ");",
-                scripting::ScriptEngine::ShouldSendToRemote::Yes
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
     }
@@ -629,7 +635,8 @@ std::vector<std::string> hostStarsWithSufficientData() {
     const std::string starIdentifier = makeIdentifier(std::move(starName));
     global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + starIdentifier + "');",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 }
 

--- a/modules/globebrowsing/src/geojson/geojsoncomponent.cpp
+++ b/modules/globebrowsing/src/geojson/geojsoncomponent.cpp
@@ -840,7 +840,7 @@ void GeoJsonComponent::flyToFeature(std::optional<int> index) const {
             "openspace.globebrowsing.flyToGeo(\"{}\", {}, {}, {})",
             _globeNode.owner()->identifier(), lat, lon, d
         ),
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -850,7 +850,7 @@ void GeoJsonComponent::triggerDeletion() const {
             "openspace.globebrowsing.deleteGeoJson(\"{}\", \"{}\")",
             _globeNode.owner()->identifier(), _identifier
         ),
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/globebrowsing/src/geojson/geojsoncomponent.cpp
+++ b/modules/globebrowsing/src/geojson/geojsoncomponent.cpp
@@ -840,6 +840,7 @@ void GeoJsonComponent::flyToFeature(std::optional<int> index) const {
             "openspace.globebrowsing.flyToGeo(\"{}\", {}, {}, {})",
             _globeNode.owner()->identifier(), lat, lon, d
         ),
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -850,6 +851,7 @@ void GeoJsonComponent::triggerDeletion() const {
             "openspace.globebrowsing.deleteGeoJson(\"{}\", \"{}\")",
             _globeNode.owner()->identifier(), _identifier
         ),
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/imgui/src/guiactioncomponent.cpp
+++ b/modules/imgui/src/guiactioncomponent.cpp
@@ -55,7 +55,11 @@ void GuiActionComponent::render() {
     for (const std::pair<const K, V>& p : binds) {
         boundActions.insert(p.second);
         if (ImGui::Button(ghoul::to_string(p.first).c_str())) {
-            global::actionManager->triggerAction(p.second, ghoul::Dictionary(), true);
+            global::actionManager->triggerAction(
+                p.second,
+                ghoul::Dictionary(),
+                interaction::ActionManager::ShouldBeSynchronized::Yes
+            );
         }
         ImGui::SameLine();
 
@@ -78,7 +82,11 @@ void GuiActionComponent::render() {
         }
 
         if (ImGui::Button(action.identifier.c_str())) {
-            global::actionManager->triggerAction(action.command, ghoul::Dictionary(), true);
+            global::actionManager->triggerAction(
+                action.command,
+                ghoul::Dictionary(),
+                interaction::ActionManager::ShouldBeSynchronized::Yes
+            );
         }
         ImGui::SameLine();
 

--- a/modules/imgui/src/guiactioncomponent.cpp
+++ b/modules/imgui/src/guiactioncomponent.cpp
@@ -55,7 +55,7 @@ void GuiActionComponent::render() {
     for (const std::pair<const K, V>& p : binds) {
         boundActions.insert(p.second);
         if (ImGui::Button(ghoul::to_string(p.first).c_str())) {
-            global::actionManager->triggerAction(p.second, ghoul::Dictionary());
+            global::actionManager->triggerAction(p.second, ghoul::Dictionary(), true);
         }
         ImGui::SameLine();
 
@@ -78,7 +78,7 @@ void GuiActionComponent::render() {
         }
 
         if (ImGui::Button(action.identifier.c_str())) {
-            global::actionManager->triggerAction(action.command, ghoul::Dictionary());
+            global::actionManager->triggerAction(action.command, ghoul::Dictionary(), true);
         }
         ImGui::SameLine();
 

--- a/modules/imgui/src/guigibscomponent.cpp
+++ b/modules/imgui/src/guigibscomponent.cpp
@@ -147,6 +147,7 @@ void GuiGIBSComponent::render() {
         );
         global::scriptEngine->queueScript(
             script,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }

--- a/modules/imgui/src/guigibscomponent.cpp
+++ b/modules/imgui/src/guigibscomponent.cpp
@@ -147,7 +147,7 @@ void GuiGIBSComponent::render() {
         );
         global::scriptEngine->queueScript(
             script,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 

--- a/modules/imgui/src/guiglobebrowsingcomponent.cpp
+++ b/modules/imgui/src/guiglobebrowsingcomponent.cpp
@@ -344,7 +344,7 @@ void GuiGlobeBrowsingComponent::render() {
                     l.name,
                     l.url
                 ),
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         };
 

--- a/modules/imgui/src/guiglobebrowsingcomponent.cpp
+++ b/modules/imgui/src/guiglobebrowsingcomponent.cpp
@@ -344,6 +344,7 @@ void GuiGlobeBrowsingComponent::render() {
                     l.name,
                     l.url
                 ),
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         };

--- a/modules/imgui/src/guispacetimecomponent.cpp
+++ b/modules/imgui/src/guispacetimecomponent.cpp
@@ -109,12 +109,12 @@ void GuiSpaceTimeComponent::render() {
                     "openspace.setPropertyValue('" +
                     std::string(AnchorProperty) + "', '" +
                     n->identifier() + "');",
-                    scripting::ScriptEngine::RemoteScripting::Yes
+                    scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
                 global::scriptEngine->queueScript(
                     "openspace.setPropertyValue('" +
                     std::string(RetargetAnchorProperty) + "', nil);",
-                    scripting::ScriptEngine::RemoteScripting::Yes
+                    scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             }
         }
@@ -144,12 +144,12 @@ void GuiSpaceTimeComponent::render() {
         global::scriptEngine->queueScript(
             "openspace.setPropertyValue('" + std::string(AnchorProperty) + "', '" +
             nodes[currentPosition]->identifier() + "');",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         global::scriptEngine->queueScript(
             "openspace.setPropertyValue('" +
             std::string(RetargetAnchorProperty) + "', nil);",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 
@@ -159,7 +159,7 @@ void GuiSpaceTimeComponent::render() {
         global::scriptEngine->queueScript(
             "openspace.setPropertyValue('" +
             std::string(RetargetAnchorProperty) + "', nil);",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 
@@ -197,7 +197,7 @@ void GuiSpaceTimeComponent::render() {
             if (ImGui::Button(t.name.c_str())) {
                 global::scriptEngine->queueScript(
                     "openspace.time.setTime(\"" + t.time + "\")",
-                    scripting::ScriptEngine::RemoteScripting::No
+                    scripting::ScriptEngine::ShouldSendToRemote::No
                 );
             }
 
@@ -225,7 +225,7 @@ void GuiSpaceTimeComponent::render() {
     if (dateChanged) {
         global::scriptEngine->queueScript(
             "openspace.time.setTime(\"" + std::string(Buffer) + "\")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
 
@@ -258,14 +258,14 @@ void GuiSpaceTimeComponent::render() {
             // If any shift key is pressed we want to always jump to the time
             global::scriptEngine->queueScript(
                 "openspace.time.setTime(" + std::to_string(newTime) + ")",
-                scripting::ScriptEngine::RemoteScripting::No
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
         else {
             global::scriptEngine->queueScript(
                 "openspace.time.interpolateTime(" + std::to_string(newTime) + ", " +
                 std::to_string(duration) + ")",
-                scripting::ScriptEngine::RemoteScripting::No
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
     };
@@ -304,7 +304,7 @@ void GuiSpaceTimeComponent::render() {
 
         global::scriptEngine->queueScript(
             "openspace.time.setTime(\"" + nowTime + "\")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
 
     }
@@ -384,7 +384,7 @@ void GuiSpaceTimeComponent::render() {
             double newDt = convertTime(_deltaTime, _deltaTimeUnit, TimeUnit::Second);
             global::scriptEngine->queueScript(
                 "openspace.time.interpolateDeltaTime(" + std::to_string(newDt) + ")",
-                scripting::ScriptEngine::RemoteScripting::No
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
         if (unitChanged) {
@@ -432,14 +432,14 @@ void GuiSpaceTimeComponent::render() {
 
             global::scriptEngine->queueScript(
                 "openspace.time.setDeltaTime(" + std::to_string(newDeltaTime) + ")",
-                scripting::ScriptEngine::RemoteScripting::No
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
         if (!ImGui::IsItemActive() && !ImGui::IsItemClicked()) {
             if (_slidingDelta != 0.f) {
                 global::scriptEngine->queueScript(
                     "openspace.time.setDeltaTime(" + std::to_string(_oldDeltaTime) + ")",
-                    scripting::ScriptEngine::RemoteScripting::No
+                    scripting::ScriptEngine::ShouldSendToRemote::No
                 );
 
             }
@@ -466,7 +466,7 @@ void GuiSpaceTimeComponent::render() {
 
             global::scriptEngine->queueScript(
                 "openspace.time.setDeltaTime(" + std::to_string(newDeltaTime) + ")",
-                scripting::ScriptEngine::RemoteScripting::No
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
         else {
@@ -484,7 +484,7 @@ void GuiSpaceTimeComponent::render() {
     if (pauseChanged) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateTogglePause()",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -495,7 +495,7 @@ void GuiSpaceTimeComponent::render() {
     if (invert) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(-1 * openspace.time.deltaTime());",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
 
@@ -503,7 +503,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusDs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-24 * 60 * 60) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -512,7 +512,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusHs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-60 * 60) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -521,7 +521,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusMs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-60) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -530,7 +530,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusSs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-1) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -539,7 +539,7 @@ void GuiSpaceTimeComponent::render() {
     if (zero) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(0) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -549,7 +549,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusSs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(1) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -558,7 +558,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusMs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(60) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -567,7 +567,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusHs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(60 * 60) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
     ImGui::SameLine();
@@ -576,7 +576,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusDs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(24 * 60 * 60) + ")",
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
 

--- a/modules/imgui/src/guispacetimecomponent.cpp
+++ b/modules/imgui/src/guispacetimecomponent.cpp
@@ -109,11 +109,13 @@ void GuiSpaceTimeComponent::render() {
                     "openspace.setPropertyValue('" +
                     std::string(AnchorProperty) + "', '" +
                     n->identifier() + "');",
+                    scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                     scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
                 global::scriptEngine->queueScript(
                     "openspace.setPropertyValue('" +
                     std::string(RetargetAnchorProperty) + "', nil);",
+                    scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                     scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             }
@@ -144,11 +146,13 @@ void GuiSpaceTimeComponent::render() {
         global::scriptEngine->queueScript(
             "openspace.setPropertyValue('" + std::string(AnchorProperty) + "', '" +
             nodes[currentPosition]->identifier() + "');",
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         global::scriptEngine->queueScript(
             "openspace.setPropertyValue('" +
             std::string(RetargetAnchorProperty) + "', nil);",
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -159,6 +163,7 @@ void GuiSpaceTimeComponent::render() {
         global::scriptEngine->queueScript(
             "openspace.setPropertyValue('" +
             std::string(RetargetAnchorProperty) + "', nil);",
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -197,6 +202,7 @@ void GuiSpaceTimeComponent::render() {
             if (ImGui::Button(t.name.c_str())) {
                 global::scriptEngine->queueScript(
                     "openspace.time.setTime(\"" + t.time + "\")",
+                    scripting::ScriptEngine::ShouldBeSynchronized::No,
                     scripting::ScriptEngine::ShouldSendToRemote::No
                 );
             }
@@ -225,6 +231,7 @@ void GuiSpaceTimeComponent::render() {
     if (dateChanged) {
         global::scriptEngine->queueScript(
             "openspace.time.setTime(\"" + std::string(Buffer) + "\")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -258,6 +265,7 @@ void GuiSpaceTimeComponent::render() {
             // If any shift key is pressed we want to always jump to the time
             global::scriptEngine->queueScript(
                 "openspace.time.setTime(" + std::to_string(newTime) + ")",
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
                 scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
@@ -265,6 +273,7 @@ void GuiSpaceTimeComponent::render() {
             global::scriptEngine->queueScript(
                 "openspace.time.interpolateTime(" + std::to_string(newTime) + ", " +
                 std::to_string(duration) + ")",
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
                 scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
@@ -304,6 +313,7 @@ void GuiSpaceTimeComponent::render() {
 
         global::scriptEngine->queueScript(
             "openspace.time.setTime(\"" + nowTime + "\")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
 
@@ -384,6 +394,7 @@ void GuiSpaceTimeComponent::render() {
             double newDt = convertTime(_deltaTime, _deltaTimeUnit, TimeUnit::Second);
             global::scriptEngine->queueScript(
                 "openspace.time.interpolateDeltaTime(" + std::to_string(newDt) + ")",
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
                 scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
@@ -432,6 +443,7 @@ void GuiSpaceTimeComponent::render() {
 
             global::scriptEngine->queueScript(
                 "openspace.time.setDeltaTime(" + std::to_string(newDeltaTime) + ")",
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
                 scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
@@ -439,6 +451,7 @@ void GuiSpaceTimeComponent::render() {
             if (_slidingDelta != 0.f) {
                 global::scriptEngine->queueScript(
                     "openspace.time.setDeltaTime(" + std::to_string(_oldDeltaTime) + ")",
+                    scripting::ScriptEngine::ShouldBeSynchronized::No,
                     scripting::ScriptEngine::ShouldSendToRemote::No
                 );
 
@@ -466,6 +479,7 @@ void GuiSpaceTimeComponent::render() {
 
             global::scriptEngine->queueScript(
                 "openspace.time.setDeltaTime(" + std::to_string(newDeltaTime) + ")",
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
                 scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
@@ -484,7 +498,8 @@ void GuiSpaceTimeComponent::render() {
     if (pauseChanged) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateTogglePause()",
-            scripting::ScriptEngine::ShouldSendToRemote::No
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
     ImGui::SameLine();
@@ -495,6 +510,7 @@ void GuiSpaceTimeComponent::render() {
     if (invert) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(-1 * openspace.time.deltaTime());",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -503,6 +519,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusDs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-24 * 60 * 60) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -512,6 +529,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusHs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-60 * 60) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -521,6 +539,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusMs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-60) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -530,6 +549,7 @@ void GuiSpaceTimeComponent::render() {
     if (minusSs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-1) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -539,6 +559,7 @@ void GuiSpaceTimeComponent::render() {
     if (zero) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(0) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -549,6 +570,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusSs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(1) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -558,6 +580,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusMs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(60) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -567,6 +590,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusHs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(60 * 60) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
@@ -576,6 +600,7 @@ void GuiSpaceTimeComponent::render() {
     if (plusDs) {
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(24 * 60 * 60) + ")",
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }

--- a/modules/imgui/src/guispacetimecomponent.cpp
+++ b/modules/imgui/src/guispacetimecomponent.cpp
@@ -200,6 +200,9 @@ void GuiSpaceTimeComponent::render() {
         for (size_t i = 0; i < interestingTimes.size(); ++i) {
             const Scene::InterestingTime& t = interestingTimes[i];
             if (ImGui::Button(t.name.c_str())) {
+
+                // No sync or send because time settings are always synced and sent
+                // to the connected nodes and peers
                 global::scriptEngine->queueScript(
                     "openspace.time.setTime(\"" + t.time + "\")",
                     scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -229,6 +232,8 @@ void GuiSpaceTimeComponent::render() {
         ImGuiInputTextFlags_EnterReturnsTrue
     );
     if (dateChanged) {
+        // No sync or send because time settings are always synced and sent to the
+        // connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.setTime(\"" + std::string(Buffer) + "\")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -262,7 +267,9 @@ void GuiSpaceTimeComponent::render() {
             j2000 + seconds;
 
         if (shift) {
-            // If any shift key is pressed we want to always jump to the time
+            // If any shift key is pressed we want to always jump to the time.
+            // No sync or send because time settings are always synced and sent
+            // to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.time.setTime(" + std::to_string(newTime) + ")",
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -270,6 +277,8 @@ void GuiSpaceTimeComponent::render() {
             );
         }
         else {
+            // No sync or send because time settings are always synced and sent
+            // to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.time.interpolateTime(" + std::to_string(newTime) + ", " +
                 std::to_string(duration) + ")",
@@ -311,6 +320,8 @@ void GuiSpaceTimeComponent::render() {
         // setTime doesn't like the T in it and wants a space instead
         nowTime[11] = ' ';
 
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.setTime(\"" + nowTime + "\")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -392,6 +403,9 @@ void GuiSpaceTimeComponent::render() {
             // If the value changed, we want to change the delta time to the new value
 
             double newDt = convertTime(_deltaTime, _deltaTimeUnit, TimeUnit::Second);
+
+            // No sync or send because time settings are always synced and sent
+            // to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.time.interpolateDeltaTime(" + std::to_string(newDt) + ")",
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -441,6 +455,8 @@ void GuiSpaceTimeComponent::render() {
                 TimeUnit::Second
             );
 
+            // No sync or send because time settings are always synced and sent
+            // to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.time.setDeltaTime(" + std::to_string(newDeltaTime) + ")",
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -449,6 +465,8 @@ void GuiSpaceTimeComponent::render() {
         }
         if (!ImGui::IsItemActive() && !ImGui::IsItemClicked()) {
             if (_slidingDelta != 0.f) {
+                // No sync or send because time settings are always synced and sent
+                // to the connected nodes and peers
                 global::scriptEngine->queueScript(
                     "openspace.time.setDeltaTime(" + std::to_string(_oldDeltaTime) + ")",
                     scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -477,6 +495,8 @@ void GuiSpaceTimeComponent::render() {
                 TimeUnit::Second
             );
 
+            // No sync or send because time settings are always synced and sent
+            // to the connected nodes and peers
             global::scriptEngine->queueScript(
                 "openspace.time.setDeltaTime(" + std::to_string(newDeltaTime) + ")",
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -508,6 +528,8 @@ void GuiSpaceTimeComponent::render() {
         { ImGui::GetWindowWidth() / 2 - 7.5f, 0.f }
     );
     if (invert) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(-1 * openspace.time.deltaTime());",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -517,6 +539,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool minusDs = ImGui::Button("-1d/s");
     if (minusDs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-24 * 60 * 60) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -527,6 +551,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool minusHs = ImGui::Button("-1h/s");
     if (minusHs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-60 * 60) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -537,6 +563,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool minusMs = ImGui::Button("-1min/s");
     if (minusMs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-60) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -547,6 +575,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool minusSs = ImGui::Button("-1s/s");
     if (minusSs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(-1) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -557,6 +587,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool zero = ImGui::Button("0");
     if (zero) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(0) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -568,6 +600,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool plusSs = ImGui::Button("+1s/s");
     if (plusSs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(1) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -578,6 +612,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool plusMs = ImGui::Button("1min/s");
     if (plusMs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(60) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -588,6 +624,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool plusHs = ImGui::Button("1h/s");
     if (plusHs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(60 * 60) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -598,6 +636,8 @@ void GuiSpaceTimeComponent::render() {
 
     const bool plusDs = ImGui::Button("1d/s");
     if (plusDs) {
+        // No sync or send because time settings are always synced and sent
+        // to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.time.interpolateDeltaTime(" + std::to_string(24 * 60 * 60) + ")",
             scripting::ScriptEngine::ShouldBeSynchronized::No,

--- a/modules/imgui/src/renderproperties.cpp
+++ b/modules/imgui/src/renderproperties.cpp
@@ -74,6 +74,7 @@ void renderTooltip(Property* prop, double delay) {
 void executeSetPropertyScript(const std::string& id, const std::string& value) {
     global::scriptEngine->queueScript(
         fmt::format("openspace.setPropertyValueSingle('{}', {});", id, value),
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/imgui/src/renderproperties.cpp
+++ b/modules/imgui/src/renderproperties.cpp
@@ -74,7 +74,7 @@ void renderTooltip(Property* prop, double delay) {
 void executeSetPropertyScript(const std::string& id, const std::string& value) {
     global::scriptEngine->queueScript(
         fmt::format("openspace.setPropertyValueSingle('{}', {});", id, value),
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/iswa/rendering/iswacygnet.cpp
+++ b/modules/iswa/rendering/iswacygnet.cpp
@@ -139,6 +139,7 @@ void IswaCygnet::initializeGL() {
             deinitialize();
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + identifier() + "')",
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         });
@@ -306,6 +307,7 @@ void IswaCygnet::initializeGroup() {
             LDEBUG(identifier() + " Event clearGroup");
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + identifier() + "')",
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }

--- a/modules/iswa/rendering/iswacygnet.cpp
+++ b/modules/iswa/rendering/iswacygnet.cpp
@@ -139,7 +139,7 @@ void IswaCygnet::initializeGL() {
             deinitialize();
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + identifier() + "')",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         });
     }
@@ -306,7 +306,7 @@ void IswaCygnet::initializeGroup() {
             LDEBUG(identifier() + " Event clearGroup");
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + identifier() + "')",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     );

--- a/modules/iswa/rendering/iswakameleongroup.cpp
+++ b/modules/iswa/rendering/iswakameleongroup.cpp
@@ -153,7 +153,7 @@ void IswaKameleonGroup::updateFieldlineSeeds() {
 
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + std::get<0>(seedPath.second) + "')",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
             std::get<2>(seedPath.second) = false;
         // if this option was turned on
@@ -180,7 +180,7 @@ void IswaKameleonGroup::clearFieldlines() {
 
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + std::get<0>(seedPath.second) + "')",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
             std::get<2>(seedPath.second) = false;
         }

--- a/modules/iswa/rendering/iswakameleongroup.cpp
+++ b/modules/iswa/rendering/iswakameleongroup.cpp
@@ -153,6 +153,7 @@ void IswaKameleonGroup::updateFieldlineSeeds() {
 
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + std::get<0>(seedPath.second) + "')",
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
             std::get<2>(seedPath.second) = false;
@@ -180,6 +181,7 @@ void IswaKameleonGroup::clearFieldlines() {
 
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + std::get<0>(seedPath.second) + "')",
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
             std::get<2>(seedPath.second) = false;

--- a/modules/iswa/rendering/kameleonplane.cpp
+++ b/modules/iswa/rendering/kameleonplane.cpp
@@ -292,6 +292,7 @@ void KameleonPlane::updateFieldlineSeeds() {
             LDEBUG("Removed fieldlines: " + std::get<0>(seedPath.second));
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + std::get<0>(seedPath.second) + "')",
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
             std::get<2>(seedPath.second) = false;

--- a/modules/iswa/rendering/kameleonplane.cpp
+++ b/modules/iswa/rendering/kameleonplane.cpp
@@ -292,7 +292,7 @@ void KameleonPlane::updateFieldlineSeeds() {
             LDEBUG("Removed fieldlines: " + std::get<0>(seedPath.second));
             global::scriptEngine->queueScript(
                 "openspace.removeSceneGraphNode('" + std::get<0>(seedPath.second) + "')",
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
             std::get<2>(seedPath.second) = false;
         // if this option was turned on

--- a/modules/iswa/rendering/screenspacecygnet.cpp
+++ b/modules/iswa/rendering/screenspacecygnet.cpp
@@ -55,6 +55,7 @@ ScreenSpaceCygnet::ScreenSpaceCygnet(const ghoul::Dictionary& dictionary)
     _delete.onChange([this]() {
         global::scriptEngine->queueScript(
             "openspace.iswa.removeScreenSpaceCygnet("+std::to_string(_cygnetId)+");",
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     });

--- a/modules/iswa/rendering/screenspacecygnet.cpp
+++ b/modules/iswa/rendering/screenspacecygnet.cpp
@@ -55,7 +55,7 @@ ScreenSpaceCygnet::ScreenSpaceCygnet(const ghoul::Dictionary& dictionary)
     _delete.onChange([this]() {
         global::scriptEngine->queueScript(
             "openspace.iswa.removeScreenSpaceCygnet("+std::to_string(_cygnetId)+");",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     });
 }

--- a/modules/iswa/util/iswamanager.cpp
+++ b/modules/iswa/util/iswamanager.cpp
@@ -87,6 +87,7 @@ namespace {
         std::string idStr = std::to_string(id);
         openspace::global::scriptEngine->queueScript(
             "openspace.iswa.addScreenSpaceCygnet({CygnetId =" + idStr + "});",
+            openspace::scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -546,6 +547,7 @@ void IswaManager::createPlane(MetadataFuture& data) {
         std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
         global::scriptEngine->queueScript(
             script,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -579,6 +581,7 @@ void IswaManager::createSphere(MetadataFuture& data) {
         std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
         global::scriptEngine->queueScript(
             script,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -612,6 +615,7 @@ void IswaManager::createKameleonPlane(CdfInfo info, std::string cut) {
             std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
             global::scriptEngine->queueScript(
                 script,
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
@@ -653,6 +657,7 @@ void IswaManager::createFieldline(std::string name, std::string cdfPath,
             std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
             global::scriptEngine->queueScript(
                 script,
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }

--- a/modules/iswa/util/iswamanager.cpp
+++ b/modules/iswa/util/iswamanager.cpp
@@ -87,7 +87,7 @@ namespace {
         std::string idStr = std::to_string(id);
         openspace::global::scriptEngine->queueScript(
             "openspace.iswa.addScreenSpaceCygnet({CygnetId =" + idStr + "});",
-            openspace::scripting::ScriptEngine::RemoteScripting::Yes
+            openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 } // namespace
@@ -546,7 +546,7 @@ void IswaManager::createPlane(MetadataFuture& data) {
         std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
         global::scriptEngine->queueScript(
             script,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 }
@@ -579,7 +579,7 @@ void IswaManager::createSphere(MetadataFuture& data) {
         std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
         global::scriptEngine->queueScript(
             script,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 }
@@ -612,7 +612,7 @@ void IswaManager::createKameleonPlane(CdfInfo info, std::string cut) {
             std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     }
@@ -653,7 +653,7 @@ void IswaManager::createFieldline(std::string name, std::string cdfPath,
             std::string script = "openspace.addSceneGraphNode(" + luaTable + ");";
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     }

--- a/modules/iswa/util/iswamanager_lua.inl
+++ b/modules/iswa/util/iswamanager_lua.inl
@@ -71,6 +71,7 @@ namespace {
     using namespace openspace;
     global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + name + "')",
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -96,6 +97,7 @@ namespace {
 
     global::scriptEngine->queueScript(
         script,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/iswa/util/iswamanager_lua.inl
+++ b/modules/iswa/util/iswamanager_lua.inl
@@ -71,7 +71,7 @@ namespace {
     using namespace openspace;
     global::scriptEngine->queueScript(
         "openspace.removeSceneGraphNode('" + name + "')",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -96,7 +96,7 @@ namespace {
 
     global::scriptEngine->queueScript(
         script,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/server/include/topics/luascripttopic.h
+++ b/modules/server/include/topics/luascripttopic.h
@@ -35,7 +35,7 @@ public:
     bool isDone() const override;
 
 private:
-    void runScript(std::string script, bool returnValue);
+    void runScript(std::string script, bool returnValue, bool shouldBeSynchronized);
 
     bool _waitingForReturnValue = true;
 };

--- a/modules/server/src/topics/flightcontrollertopic.cpp
+++ b/modules/server/src/topics/flightcontrollertopic.cpp
@@ -467,7 +467,8 @@ void FlightControllerTopic::processLua(const nlohmann::json &json) {
     const std::string script = json[LuaScript];
     global::scriptEngine->queueScript(
         script,
-        openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/server/src/topics/flightcontrollertopic.cpp
+++ b/modules/server/src/topics/flightcontrollertopic.cpp
@@ -467,7 +467,7 @@ void FlightControllerTopic::processLua(const nlohmann::json &json) {
     const std::string script = json[LuaScript];
     global::scriptEngine->queueScript(
         script,
-        openspace::scripting::ScriptEngine::RemoteScripting::Yes
+        openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/server/src/topics/luascripttopic.cpp
+++ b/modules/server/src/topics/luascripttopic.cpp
@@ -195,7 +195,7 @@ void LuaScriptTopic::runScript(std::string script, bool shouldReturn) {
 
     global::scriptEngine->queueScript(
         std::move(script),
-        scripting::ScriptEngine::RemoteScripting::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No,
         callback
     );
 }

--- a/modules/server/src/topics/luascripttopic.cpp
+++ b/modules/server/src/topics/luascripttopic.cpp
@@ -37,6 +37,7 @@ namespace {
     constexpr std::string_view KeyFunction = "function";
     constexpr std::string_view KeyArguments = "arguments";
     constexpr std::string_view KeyReturn = "return";
+    constexpr std::string_view KeyShouldBeSynchronized = "shouldBeSynchronized";
     constexpr std::string_view _loggerCat = "LuaScriptTopic";
 
     std::string formatLua(const nlohmann::json::const_iterator& it);
@@ -146,7 +147,13 @@ void LuaScriptTopic::handleJson(const nlohmann::json& json) {
                                  ret->is_boolean() &&
                                  ret->get<bool>();
 
-            runScript(luaScript, shouldReturn);
+            nlohmann::json::const_iterator sync = json.find(KeyShouldBeSynchronized);
+            bool shouldBeSynchronized = true;
+            if (sync != json.end() && sync->is_boolean()) {
+                shouldBeSynchronized = sync->get<bool>();
+            }
+
+            runScript(luaScript, shouldReturn, shouldBeSynchronized);
         }
         else if (function != json.end() && function->is_string()) {
             std::string luaFunction = function->get<std::string>();
@@ -154,6 +161,12 @@ void LuaScriptTopic::handleJson(const nlohmann::json& json) {
             bool shouldReturn = (ret != json.end()) &&
                                  ret->is_boolean() &&
                                  ret->get<bool>();
+
+            nlohmann::json::const_iterator sync = json.find(KeyShouldBeSynchronized);
+            bool shouldBeSynchronized = true;
+            if (sync != json.end() && sync->is_boolean()) {
+                shouldBeSynchronized = sync->get<bool>();
+            }
 
             nlohmann::json::const_iterator args = json.find(KeyArguments);
             if (!args->is_array()) {
@@ -167,7 +180,7 @@ void LuaScriptTopic::handleJson(const nlohmann::json& json) {
             }
 
             std::string luaScript = generateScript(luaFunction, formattedArgs);
-            runScript(luaScript, shouldReturn);
+            runScript(luaScript, shouldReturn, shouldBeSynchronized);
         }
     }
     catch (const std::out_of_range& e) {
@@ -176,7 +189,9 @@ void LuaScriptTopic::handleJson(const nlohmann::json& json) {
     }
 }
 
-void LuaScriptTopic::runScript(std::string script, bool shouldReturn) {
+void LuaScriptTopic::runScript(std::string script, bool shouldReturn,
+                               bool shouldBeSynchronized)
+{
     scripting::ScriptEngine::ScriptCallback callback;
     if (shouldReturn) {
         callback = [this](ghoul::Dictionary data) {
@@ -195,8 +210,8 @@ void LuaScriptTopic::runScript(std::string script, bool shouldReturn) {
 
     global::scriptEngine->queueScript(
         std::move(script),
-        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
-        scripting::ScriptEngine::ShouldSendToRemote::Yes,
+        scripting::ScriptEngine::ShouldBeSynchronized(shouldBeSynchronized),
+        scripting::ScriptEngine::ShouldSendToRemote(shouldBeSynchronized),
         callback
     );
 }

--- a/modules/server/src/topics/luascripttopic.cpp
+++ b/modules/server/src/topics/luascripttopic.cpp
@@ -195,7 +195,8 @@ void LuaScriptTopic::runScript(std::string script, bool shouldReturn) {
 
     global::scriptEngine->queueScript(
         std::move(script),
-        scripting::ScriptEngine::ShouldSendToRemote::No,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
+        scripting::ScriptEngine::ShouldSendToRemote::Yes,
         callback
     );
 }

--- a/modules/server/src/topics/setpropertytopic.cpp
+++ b/modules/server/src/topics/setpropertytopic.cpp
@@ -127,7 +127,7 @@ void SetPropertyTopic::handleJson(const nlohmann::json& json) {
                     "openspace.setPropertyValueSingle(\"{}\", {})", propertyKey, literal
                 ),
                 scripting::ScriptEngine::ShouldBeSynchronized::Yes,
-                 scripting::ScriptEngine::ShouldSendToRemote::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
              );
         }
     }

--- a/modules/server/src/topics/setpropertytopic.cpp
+++ b/modules/server/src/topics/setpropertytopic.cpp
@@ -126,7 +126,7 @@ void SetPropertyTopic::handleJson(const nlohmann::json& json) {
                 fmt::format(
                     "openspace.setPropertyValueSingle(\"{}\", {})", propertyKey, literal
                 ),
-                 scripting::ScriptEngine::RemoteScripting::Yes
+                 scripting::ScriptEngine::ShouldSendToRemote::Yes
              );
         }
     }

--- a/modules/server/src/topics/setpropertytopic.cpp
+++ b/modules/server/src/topics/setpropertytopic.cpp
@@ -126,6 +126,7 @@ void SetPropertyTopic::handleJson(const nlohmann::json& json) {
                 fmt::format(
                     "openspace.setPropertyValueSingle(\"{}\", {})", propertyKey, literal
                 ),
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                  scripting::ScriptEngine::ShouldSendToRemote::Yes
              );
         }

--- a/modules/server/src/topics/triggerpropertytopic.cpp
+++ b/modules/server/src/topics/triggerpropertytopic.cpp
@@ -44,6 +44,7 @@ void TriggerPropertyTopic::handleJson(const nlohmann::json& json) {
             fmt::format(
                 "openspace.setPropertyValueSingle(\"{}\", nil)", propertyKey
             ),
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }

--- a/modules/server/src/topics/triggerpropertytopic.cpp
+++ b/modules/server/src/topics/triggerpropertytopic.cpp
@@ -44,7 +44,7 @@ void TriggerPropertyTopic::handleJson(const nlohmann::json& json) {
             fmt::format(
                 "openspace.setPropertyValueSingle(\"{}\", nil)", propertyKey
             ),
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
     catch (const std::out_of_range& e) {

--- a/modules/skybrowser/skybrowsermodule.cpp
+++ b/modules/skybrowser/skybrowsermodule.cpp
@@ -356,7 +356,7 @@ void SkyBrowserModule::moveHoverCircle(const std::string& imageUrl, bool useScri
         );
         global::scriptEngine->queueScript(
             script,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
     else {
@@ -379,7 +379,7 @@ void SkyBrowserModule::moveHoverCircle(const std::string& imageUrl, bool useScri
     );
     global::scriptEngine->queueScript(
         script,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -392,7 +392,7 @@ void SkyBrowserModule::disableHoverCircle(bool useScript) {
             );
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
         else {

--- a/modules/skybrowser/skybrowsermodule.cpp
+++ b/modules/skybrowser/skybrowsermodule.cpp
@@ -356,6 +356,7 @@ void SkyBrowserModule::moveHoverCircle(const std::string& imageUrl, bool useScri
         );
         global::scriptEngine->queueScript(
             script,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -379,6 +380,7 @@ void SkyBrowserModule::moveHoverCircle(const std::string& imageUrl, bool useScri
     );
     global::scriptEngine->queueScript(
         script,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -392,6 +394,7 @@ void SkyBrowserModule::disableHoverCircle(bool useScript) {
             );
             global::scriptEngine->queueScript(
                 script,
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }

--- a/modules/skybrowser/skybrowsermodule_lua.inl
+++ b/modules/skybrowser/skybrowsermodule_lua.inl
@@ -228,7 +228,7 @@ std::string prunedIdentifier(std::string identifier) {
 }
 
 /**
- * Starts the setup process of the sky browers. This function calls the lua function
+ * Starts the setup process of the sky browers. This function calls the Lua function
  * 'sendOutIdsToBrowsers' in all nodes in the cluster.
  */
 [[codegen::luawrap]] void startSetup() {
@@ -247,7 +247,7 @@ std::string prunedIdentifier(std::string identifier) {
                 id, color.r, color.g, color.b
             );
 
-            // No sync or send because this is already inside a lua script, therefor it
+            // No sync or send because this is already inside a Lua script, therefor it
             // has already been synced and sent to the connected nodes and peers
             global::scriptEngine->queueScript(
                 script,
@@ -258,7 +258,7 @@ std::string prunedIdentifier(std::string identifier) {
     }
     // To ensure each node in a cluster calls its own instance of the wwt application
     // Do not send this script to the other nodes. (Note malej 2023-AUG-23: Due to this
-    // already being inside a lua funciton that have already been synced out)
+    // already being inside a Lua function that have already been synced out)
     global::scriptEngine->queueScript(
         "openspace.skybrowser.sendOutIdsToBrowsers()",
         scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -605,7 +605,7 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
         "}"
     "}";
 
-    // No sync or send because this is already inside a lua script, therefor it has
+    // No sync or send because this is already inside a Lua script, therefor it has
     // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.addScreenSpaceRenderable(" + browser + ");",
@@ -622,7 +622,6 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
     global::scriptEngine->queueScript(
         "openspace.skybrowser.addPairToSkyBrowserModule('" + idTarget + "','"
         + idBrowser + "');",
-
         scripting::ScriptEngine::ShouldBeSynchronized::No,
         scripting::ScriptEngine::ShouldSendToRemote::No
     );
@@ -649,7 +648,7 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
         module->removeTargetBrowserPair(identifier);
 
         // Remove from engine.
-        // No sync or send because this is already inside a lua script, therefor it has
+        // No sync or send because this is already inside a Lua script, therefor it has
         // already been synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.removeScreenSpaceRenderable('" + browser + "');",

--- a/modules/skybrowser/skybrowsermodule_lua.inl
+++ b/modules/skybrowser/skybrowsermodule_lua.inl
@@ -248,7 +248,7 @@ std::string prunedIdentifier(std::string identifier) {
             );
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     }
@@ -256,7 +256,7 @@ std::string prunedIdentifier(std::string identifier) {
     // Do not send this script to the other nodes
     global::scriptEngine->queueScript(
         "openspace.skybrowser.sendOutIdsToBrowsers()",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -601,23 +601,23 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
 
     global::scriptEngine->queueScript(
         "openspace.addScreenSpaceRenderable(" + browser + ");",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + target + ");",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     global::scriptEngine->queueScript(
         "openspace.skybrowser.addPairToSkyBrowserModule('" + idTarget + "','"
         + idBrowser + "');",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 
     global::scriptEngine->queueScript(
         "openspace.skybrowser.setSelectedBrowser('" + idBrowser + "');",
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -638,12 +638,12 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
         // Remove from engine
         global::scriptEngine->queueScript(
             "openspace.removeScreenSpaceRenderable('" + browser + "');",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
 
         global::scriptEngine->queueScript(
             "openspace.removeSceneGraphNode('" + target + "');",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 }

--- a/modules/skybrowser/skybrowsermodule_lua.inl
+++ b/modules/skybrowser/skybrowsermodule_lua.inl
@@ -248,15 +248,18 @@ std::string prunedIdentifier(std::string identifier) {
             );
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::ShouldSendToRemote::Yes
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
         }
     }
     // To ensure each node in a cluster calls its own instance of the wwt application
-    // Do not send this script to the other nodes
+    // Do not send this script to the other nodes. (Note malej 2023-AUG-23: Due to this
+    // already being inside a lua funciton that have already been synced out)
     global::scriptEngine->queueScript(
         "openspace.skybrowser.sendOutIdsToBrowsers()",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 }
 
@@ -601,23 +604,28 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
 
     global::scriptEngine->queueScript(
         "openspace.addScreenSpaceRenderable(" + browser + ");",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 
     global::scriptEngine->queueScript(
         "openspace.addSceneGraphNode(" + target + ");",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 
     global::scriptEngine->queueScript(
         "openspace.skybrowser.addPairToSkyBrowserModule('" + idTarget + "','"
         + idBrowser + "');",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 
     global::scriptEngine->queueScript(
         "openspace.skybrowser.setSelectedBrowser('" + idBrowser + "');",
-        scripting::ScriptEngine::ShouldSendToRemote::Yes
+        scripting::ScriptEngine::ShouldBeSynchronized::No,
+        scripting::ScriptEngine::ShouldSendToRemote::No
     );
 }
 
@@ -638,12 +646,14 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
         // Remove from engine
         global::scriptEngine->queueScript(
             "openspace.removeScreenSpaceRenderable('" + browser + "');",
-            scripting::ScriptEngine::ShouldSendToRemote::Yes
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
 
         global::scriptEngine->queueScript(
             "openspace.removeSceneGraphNode('" + target + "');",
-            scripting::ScriptEngine::ShouldSendToRemote::Yes
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     }
 }

--- a/modules/skybrowser/skybrowsermodule_lua.inl
+++ b/modules/skybrowser/skybrowsermodule_lua.inl
@@ -246,6 +246,9 @@ std::string prunedIdentifier(std::string identifier) {
                 "openspace.skybrowser.setBorderColor('{}', {}, {}, {})",
                 id, color.r, color.g, color.b
             );
+
+            // No sync or send because this is already inside a lua script, therefor it
+            // has already been synced and sent to the connected nodes and peers
             global::scriptEngine->queueScript(
                 script,
                 scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -602,6 +605,8 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
         "}"
     "}";
 
+    // No sync or send because this is already inside a lua script, therefor it has
+    // already been synced and sent to the connected nodes and peers
     global::scriptEngine->queueScript(
         "openspace.addScreenSpaceRenderable(" + browser + ");",
         scripting::ScriptEngine::ShouldBeSynchronized::No,
@@ -643,7 +648,9 @@ ghoul::Dictionary wwtImageCollectionUrlDeprecated()
 
         module->removeTargetBrowserPair(identifier);
 
-        // Remove from engine
+        // Remove from engine.
+        // No sync or send because this is already inside a lua script, therefor it has
+        // already been synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             "openspace.removeScreenSpaceRenderable('" + browser + "');",
             scripting::ScriptEngine::ShouldBeSynchronized::No,

--- a/modules/skybrowser/src/targetbrowserpair.cpp
+++ b/modules/skybrowser/src/targetbrowserpair.cpp
@@ -51,7 +51,7 @@ namespace {
         );
         openspace::global::scriptEngine->queueScript(
             script,
-            openspace::scripting::ScriptEngine::RemoteScripting::Yes
+            openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 } // namespace
@@ -327,7 +327,7 @@ void TargetBrowserPair::startFading(float goal, float fadeTime) {
 
     global::scriptEngine->queueScript(
         script,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/skybrowser/src/targetbrowserpair.cpp
+++ b/modules/skybrowser/src/targetbrowserpair.cpp
@@ -51,6 +51,7 @@ namespace {
         );
         openspace::global::scriptEngine->queueScript(
             script,
+            openspace::scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
@@ -327,6 +328,7 @@ void TargetBrowserPair::startFading(float goal, float fadeTime) {
 
     global::scriptEngine->queueScript(
         script,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/statemachine/src/state.cpp
+++ b/modules/statemachine/src/state.cpp
@@ -62,6 +62,7 @@ State::State(const ghoul::Dictionary& dictionary) {
 void State::enter() const {
     global::scriptEngine->queueScript(
         _enter,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -69,6 +70,7 @@ void State::enter() const {
 void State::exit() const {
     global::scriptEngine->queueScript(
         _exit,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/statemachine/src/state.cpp
+++ b/modules/statemachine/src/state.cpp
@@ -62,14 +62,14 @@ State::State(const ghoul::Dictionary& dictionary) {
 void State::enter() const {
     global::scriptEngine->queueScript(
         _enter,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
 void State::exit() const {
     global::scriptEngine->queueScript(
         _exit,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/modules/statemachine/src/transition.cpp
+++ b/modules/statemachine/src/transition.cpp
@@ -71,6 +71,7 @@ void Transition::performAction() const {
     }
     global::scriptEngine->queueScript(
         _action,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }

--- a/modules/statemachine/src/transition.cpp
+++ b/modules/statemachine/src/transition.cpp
@@ -71,7 +71,7 @@ void Transition::performAction() const {
     }
     global::scriptEngine->queueScript(
         _action,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1124,7 +1124,7 @@ void OpenSpaceEngine::preSynchronization() {
         for (const std::string& script : scheduledScripts) {
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
 
@@ -1577,7 +1577,7 @@ void OpenSpaceEngine::handleDragDrop(std::filesystem::path file) {
     std::string script = ghoul::lua::value<std::string>(s);
     global::scriptEngine->queueScript(
         script,
-        scripting::ScriptEngine::RemoteScripting::Yes
+        scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
 
@@ -1769,7 +1769,7 @@ void setCameraFromProfile(const Profile& p) {
                 geoScript += ")";
                 global::scriptEngine->queueScript(
                     geoScript,
-                    scripting::ScriptEngine::RemoteScripting::Yes
+                    scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             },
             [&checkNodeExists](const Profile::CameraGoToNode& node) {
@@ -1800,7 +1800,7 @@ void setModulesFromProfile(const Profile& p) {
             if (mod.loadedInstruction.has_value()) {
                 global::scriptEngine->queueScript(
                     mod.loadedInstruction.value(),
-                    scripting::ScriptEngine::RemoteScripting::Yes
+                    scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             }
         }
@@ -1808,7 +1808,7 @@ void setModulesFromProfile(const Profile& p) {
             if (mod.notLoadedInstruction.has_value()) {
                 global::scriptEngine->queueScript(
                     mod.notLoadedInstruction.value(),
-                    scripting::ScriptEngine::RemoteScripting::Yes
+                    scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             }
         }
@@ -1872,7 +1872,7 @@ void setAdditionalScriptsFromProfile(const Profile& p) {
     for (const std::string& a : p.additionalScripts) {
         global::scriptEngine->queueScript(
             a,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 }

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1124,6 +1124,7 @@ void OpenSpaceEngine::preSynchronization() {
         for (const std::string& script : scheduledScripts) {
             global::scriptEngine->queueScript(
                 script,
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
@@ -1577,6 +1578,7 @@ void OpenSpaceEngine::handleDragDrop(std::filesystem::path file) {
     std::string script = ghoul::lua::value<std::string>(s);
     global::scriptEngine->queueScript(
         script,
+        scripting::ScriptEngine::ShouldBeSynchronized::Yes,
         scripting::ScriptEngine::ShouldSendToRemote::Yes
     );
 }
@@ -1769,6 +1771,7 @@ void setCameraFromProfile(const Profile& p) {
                 geoScript += ")";
                 global::scriptEngine->queueScript(
                     geoScript,
+                    scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                     scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             },
@@ -1800,6 +1803,7 @@ void setModulesFromProfile(const Profile& p) {
             if (mod.loadedInstruction.has_value()) {
                 global::scriptEngine->queueScript(
                     mod.loadedInstruction.value(),
+                    scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                     scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             }
@@ -1808,6 +1812,7 @@ void setModulesFromProfile(const Profile& p) {
             if (mod.notLoadedInstruction.has_value()) {
                 global::scriptEngine->queueScript(
                     mod.notLoadedInstruction.value(),
+                    scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                     scripting::ScriptEngine::ShouldSendToRemote::Yes
                 );
             }
@@ -1872,6 +1877,7 @@ void setAdditionalScriptsFromProfile(const Profile& p) {
     for (const std::string& a : p.additionalScripts) {
         global::scriptEngine->queueScript(
             a,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }

--- a/src/events/eventengine.cpp
+++ b/src/events/eventengine.cpp
@@ -164,6 +164,8 @@ void EventEngine::triggerActions() const {
                 if (ai.isEnabled &&
                     (!ai.filter.has_value() || params.isSubset(*ai.filter)))
                 {
+                    // No sync because events are always synced and sent to the connected
+                    // nodes and peers
                     global::actionManager->triggerAction(ai.action, params, false);
                 }
             }

--- a/src/events/eventengine.cpp
+++ b/src/events/eventengine.cpp
@@ -166,7 +166,11 @@ void EventEngine::triggerActions() const {
                 {
                     // No sync because events are always synced and sent to the connected
                     // nodes and peers
-                    global::actionManager->triggerAction(ai.action, params, false);
+                    global::actionManager->triggerAction(
+                        ai.action,
+                        params,
+                        interaction::ActionManager::ShouldBeSynchronized::No
+                    );
                 }
             }
         }

--- a/src/events/eventengine.cpp
+++ b/src/events/eventengine.cpp
@@ -164,7 +164,7 @@ void EventEngine::triggerActions() const {
                 if (ai.isEnabled &&
                     (!ai.filter.has_value() || params.isSubset(*ai.filter)))
                 {
-                    global::actionManager->triggerAction(ai.action, params);
+                    global::actionManager->triggerAction(ai.action, params, false);
                 }
             }
         }

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -96,13 +96,13 @@ void ActionManager::triggerAction(const std::string& identifier,
     if (arguments.isEmpty()) {
         global::scriptEngine->queueScript(
             a.command,
-            scripting::ScriptEngine::RemoteScripting(!a.isLocal)
+            scripting::ScriptEngine::ShouldSendToRemote(!a.isLocal)
         );
     }
     else {
         global::scriptEngine->queueScript(
             fmt::format("args = {}\n{}", ghoul::formatLua(arguments), a.command),
-            scripting::ScriptEngine::RemoteScripting(!a.isLocal)
+            scripting::ScriptEngine::ShouldSendToRemote(!a.isLocal)
         );
     }
 }

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -94,20 +94,24 @@ void ActionManager::triggerAction(const std::string& identifier,
     }
 
     const Action& a = action(identifier);
+    std::string script;
     if (arguments.isEmpty()) {
-        global::scriptEngine->queueScript(
-            a.command,
-            scripting::ScriptEngine::ShouldBeSynchronized(shouldBeSynchronized),
-            scripting::ScriptEngine::ShouldSendToRemote(!a.isLocal)
-        );
+        script = a.command;
     }
     else {
-        global::scriptEngine->queueScript(
-            fmt::format("args = {}\n{}", ghoul::formatLua(arguments), a.command),
-            scripting::ScriptEngine::ShouldBeSynchronized(shouldBeSynchronized),
-            scripting::ScriptEngine::ShouldSendToRemote(!a.isLocal)
-        );
+        script = fmt::format("args = {}\n{}", ghoul::formatLua(arguments), a.command);
     }
+
+    using ShouldBeSynchronized = scripting::ScriptEngine::ShouldBeSynchronized;
+    using ShouldSendToRemote = scripting::ScriptEngine::ShouldSendToRemote;
+    ShouldBeSynchronized sync = ShouldBeSynchronized::Yes;
+    ShouldSendToRemote send = ShouldSendToRemote::Yes;
+    if (!shouldBeSynchronized || a.isLocal) {
+        sync = ShouldBeSynchronized::No;
+        send = ShouldSendToRemote::No;
+    }
+
+    global::scriptEngine->queueScript(script, sync, send);
 }
 
 scripting::LuaLibrary ActionManager::luaLibrary() {

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -80,7 +80,8 @@ std::vector<Action> ActionManager::actions() const {
 }
 
 void ActionManager::triggerAction(const std::string& identifier,
-                                  const ghoul::Dictionary& arguments) const
+                                  const ghoul::Dictionary& arguments,
+                                  bool shouldBeSynchronized) const
 {
     ghoul_assert(!identifier.empty(), "Identifier must not be empty");
 
@@ -96,12 +97,14 @@ void ActionManager::triggerAction(const std::string& identifier,
     if (arguments.isEmpty()) {
         global::scriptEngine->queueScript(
             a.command,
+            scripting::ScriptEngine::ShouldBeSynchronized(shouldBeSynchronized),
             scripting::ScriptEngine::ShouldSendToRemote(!a.isLocal)
         );
     }
     else {
         global::scriptEngine->queueScript(
             fmt::format("args = {}\n{}", ghoul::formatLua(arguments), a.command),
+            scripting::ScriptEngine::ShouldBeSynchronized(shouldBeSynchronized),
             scripting::ScriptEngine::ShouldSendToRemote(!a.isLocal)
         );
     }

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -81,7 +81,7 @@ std::vector<Action> ActionManager::actions() const {
 
 void ActionManager::triggerAction(const std::string& identifier,
                                   const ghoul::Dictionary& arguments,
-                                  bool shouldBeSynchronized) const
+                           ActionManager::ShouldBeSynchronized shouldBeSynchronized) const
 {
     ghoul_assert(!identifier.empty(), "Identifier must not be empty");
 

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -94,13 +94,10 @@ void ActionManager::triggerAction(const std::string& identifier,
     }
 
     const Action& a = action(identifier);
-    std::string script;
-    if (arguments.isEmpty()) {
-        script = a.command;
-    }
-    else {
-        script = fmt::format("args = {}\n{}", ghoul::formatLua(arguments), a.command);
-    }
+    std::string script =
+        arguments.isEmpty() ?
+        a.command :
+        fmt::format("args = {}\n{}", ghoul::formatLua(arguments), a.command);
 
     using ShouldBeSynchronized = scripting::ScriptEngine::ShouldBeSynchronized;
     using ShouldSendToRemote = scripting::ScriptEngine::ShouldSendToRemote;

--- a/src/interaction/actionmanager_lua.inl
+++ b/src/interaction/actionmanager_lua.inl
@@ -192,6 +192,8 @@ struct [[codegen::Dictionary(Action)]] Action {
         throw ghoul::lua::LuaError(fmt::format("Action '{}' not found", id));
     }
 
+    // No sync because this is already inside a lua script, therefor it has
+    // already been synced and sent to the connected nodes and peers
     global::actionManager->triggerAction(id, arg, false);
 }
 

--- a/src/interaction/actionmanager_lua.inl
+++ b/src/interaction/actionmanager_lua.inl
@@ -192,7 +192,7 @@ struct [[codegen::Dictionary(Action)]] Action {
         throw ghoul::lua::LuaError(fmt::format("Action '{}' not found", id));
     }
 
-    global::actionManager->triggerAction(id, arg);
+    global::actionManager->triggerAction(id, arg, false);
 }
 
 #include "actionmanager_lua_codegen.cpp"

--- a/src/interaction/actionmanager_lua.inl
+++ b/src/interaction/actionmanager_lua.inl
@@ -36,7 +36,7 @@ namespace {
 }
 
 /**
- * Removes an existing action from the list of possible actions.The action is identifies
+ * Removes an existing action from the list of possible actions. The action is identifies
  * either by the passed name, or if it is a table, the value behind the 'Identifier' key
  * is extract and used instead.
  */
@@ -192,7 +192,7 @@ struct [[codegen::Dictionary(Action)]] Action {
         throw ghoul::lua::LuaError(fmt::format("Action '{}' not found", id));
     }
 
-    // No sync because this is already inside a lua script, therefor it has
+    // No sync because this is already inside a Lua script, therefor it has
     // already been synced and sent to the connected nodes and peers
     global::actionManager->triggerAction(id, arg, false);
 }

--- a/src/interaction/actionmanager_lua.inl
+++ b/src/interaction/actionmanager_lua.inl
@@ -194,7 +194,11 @@ struct [[codegen::Dictionary(Action)]] Action {
 
     // No sync because this is already inside a Lua script, therefor it has
     // already been synced and sent to the connected nodes and peers
-    global::actionManager->triggerAction(id, arg, false);
+    global::actionManager->triggerAction(
+        id,
+        arg,
+        interaction::ActionManager::ShouldBeSynchronized::No
+    );
 }
 
 #include "actionmanager_lua_codegen.cpp"

--- a/src/interaction/joystickcamerastates.cpp
+++ b/src/interaction/joystickcamerastates.cpp
@@ -169,6 +169,7 @@ void JoystickCameraStates::updateStateFromInput(
 
                     global::scriptEngine->queueScript(
                         script,
+                        scripting::ScriptEngine::ShouldBeSynchronized(t.isRemote),
                         scripting::ScriptEngine::ShouldSendToRemote(t.isRemote)
                     );
                     break;
@@ -188,6 +189,9 @@ void JoystickCameraStates::updateStateFromInput(
                 if (active) {
                     global::scriptEngine->queueScript(
                         it->second.command,
+                        scripting::ScriptEngine::ShouldBeSynchronized(
+                            it->second.synchronization
+                        ),
                         scripting::ScriptEngine::ShouldSendToRemote(
                             it->second.synchronization
                         )

--- a/src/interaction/joystickcamerastates.cpp
+++ b/src/interaction/joystickcamerastates.cpp
@@ -169,7 +169,7 @@ void JoystickCameraStates::updateStateFromInput(
 
                     global::scriptEngine->queueScript(
                         script,
-                        scripting::ScriptEngine::RemoteScripting(t.isRemote)
+                        scripting::ScriptEngine::ShouldSendToRemote(t.isRemote)
                     );
                     break;
             }
@@ -188,7 +188,7 @@ void JoystickCameraStates::updateStateFromInput(
                 if (active) {
                     global::scriptEngine->queueScript(
                         it->second.command,
-                        scripting::ScriptEngine::RemoteScripting(
+                        scripting::ScriptEngine::ShouldSendToRemote(
                             it->second.synchronization
                         )
                     );

--- a/src/interaction/keybindingmanager.cpp
+++ b/src/interaction/keybindingmanager.cpp
@@ -52,7 +52,7 @@ void KeybindingManager::keyboardCallback(Key key, KeyModifier modifier, KeyActio
                 // bind a key to multiple actions, only one of which could be defined
                 continue;
             }
-            global::actionManager->triggerAction(it->second, ghoul::Dictionary());
+            global::actionManager->triggerAction(it->second, ghoul::Dictionary(), true);
         }
     }
 }

--- a/src/interaction/keybindingmanager.cpp
+++ b/src/interaction/keybindingmanager.cpp
@@ -52,7 +52,11 @@ void KeybindingManager::keyboardCallback(Key key, KeyModifier modifier, KeyActio
                 // bind a key to multiple actions, only one of which could be defined
                 continue;
             }
-            global::actionManager->triggerAction(it->second, ghoul::Dictionary(), true);
+            global::actionManager->triggerAction(
+                it->second,
+                ghoul::Dictionary(),
+                interaction::ActionManager::ShouldBeSynchronized::Yes
+            );
         }
     }
 }

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -2088,6 +2088,7 @@ bool SessionRecording::processScriptKeyframe() {
         );
         global::scriptEngine->queueScript(
             nextScript,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -2088,7 +2088,7 @@ bool SessionRecording::processScriptKeyframe() {
         );
         global::scriptEngine->queueScript(
             nextScript,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -281,7 +281,11 @@ void NavigationHandler::updateCameraTransitions() {
                 for (const std::string& action : anchorNode()->onExitAction()) {
                     // No sync because events are always synced and sent to the connected
                     // nodes and peers
-                    global::actionManager->triggerAction(action, dict, false);
+                    global::actionManager->triggerAction(
+                        action,
+                        dict,
+                        interaction::ActionManager::ShouldBeSynchronized::No
+                    );
                 }
             }
 
@@ -303,7 +307,11 @@ void NavigationHandler::updateCameraTransitions() {
                 for (const std::string& action : anchorNode()->onReachAction()) {
                     // No sync because events are always synced and sent to the connected
                     // nodes and peers
-                    global::actionManager->triggerAction(action, dict, false);
+                    global::actionManager->triggerAction(
+                        action,
+                        dict,
+                        interaction::ActionManager::ShouldBeSynchronized::No
+                    );
                 }
             }
 
@@ -326,7 +334,11 @@ void NavigationHandler::updateCameraTransitions() {
             for (const std::string& action : anchorNode()->onRecedeAction()) {
                 // No sync because events are always synced and sent to the connected
                 // nodes and peers
-                global::actionManager->triggerAction(action, dict, false);
+                global::actionManager->triggerAction(
+                    action,
+                    dict,
+                    interaction::ActionManager::ShouldBeSynchronized::No
+                );
             }
         }
 
@@ -349,7 +361,11 @@ void NavigationHandler::updateCameraTransitions() {
             for (const std::string& action : anchorNode()->onApproachAction()) {
                 // No sync because events are always synced and sent to the connected
                 // nodes and peers
-                global::actionManager->triggerAction(action, dict, false);
+                global::actionManager->triggerAction(
+                    action,
+                    dict,
+                    interaction::ActionManager::ShouldBeSynchronized::No
+                );
             }
         }
 

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -279,6 +279,8 @@ void NavigationHandler::updateCameraTransitions() {
                 dict.setValue("Node", anchorNode()->identifier());
                 dict.setValue("Transition", "Exiting"s);
                 for (const std::string& action : anchorNode()->onExitAction()) {
+                    // No sync because events are always synced and sent to the connected
+                    // nodes and peers
                     global::actionManager->triggerAction(action, dict, false);
                 }
             }
@@ -299,6 +301,8 @@ void NavigationHandler::updateCameraTransitions() {
                 dict.setValue("Node", anchorNode()->identifier());
                 dict.setValue("Transition", "Reaching"s);
                 for (const std::string& action : anchorNode()->onReachAction()) {
+                    // No sync because events are always synced and sent to the connected
+                    // nodes and peers
                     global::actionManager->triggerAction(action, dict, false);
                 }
             }
@@ -320,6 +324,8 @@ void NavigationHandler::updateCameraTransitions() {
             dict.setValue("Node", anchorNode()->identifier());
             dict.setValue("Transition", "Receding"s);
             for (const std::string& action : anchorNode()->onRecedeAction()) {
+                // No sync because events are always synced and sent to the connected
+                // nodes and peers
                 global::actionManager->triggerAction(action, dict, false);
             }
         }
@@ -341,6 +347,8 @@ void NavigationHandler::updateCameraTransitions() {
             dict.setValue("Node", anchorNode()->identifier());
             dict.setValue("Transition", "Approaching"s);
             for (const std::string& action : anchorNode()->onApproachAction()) {
+                // No sync because events are always synced and sent to the connected
+                // nodes and peers
                 global::actionManager->triggerAction(action, dict, false);
             }
         }

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -279,7 +279,7 @@ void NavigationHandler::updateCameraTransitions() {
                 dict.setValue("Node", anchorNode()->identifier());
                 dict.setValue("Transition", "Exiting"s);
                 for (const std::string& action : anchorNode()->onExitAction()) {
-                    global::actionManager->triggerAction(action, dict);
+                    global::actionManager->triggerAction(action, dict, false);
                 }
             }
 
@@ -299,7 +299,7 @@ void NavigationHandler::updateCameraTransitions() {
                 dict.setValue("Node", anchorNode()->identifier());
                 dict.setValue("Transition", "Reaching"s);
                 for (const std::string& action : anchorNode()->onReachAction()) {
-                    global::actionManager->triggerAction(action, dict);
+                    global::actionManager->triggerAction(action, dict, false);
                 }
             }
 
@@ -320,7 +320,7 @@ void NavigationHandler::updateCameraTransitions() {
             dict.setValue("Node", anchorNode()->identifier());
             dict.setValue("Transition", "Receding"s);
             for (const std::string& action : anchorNode()->onRecedeAction()) {
-                global::actionManager->triggerAction(action, dict);
+                global::actionManager->triggerAction(action, dict, false);
             }
         }
 
@@ -341,7 +341,7 @@ void NavigationHandler::updateCameraTransitions() {
             dict.setValue("Node", anchorNode()->identifier());
             dict.setValue("Transition", "Approaching"s);
             for (const std::string& action : anchorNode()->onApproachAction()) {
-                global::actionManager->triggerAction(action, dict);
+                global::actionManager->triggerAction(action, dict, false);
             }
         }
 

--- a/src/navigation/pathnavigator.cpp
+++ b/src/navigation/pathnavigator.cpp
@@ -322,6 +322,7 @@ void PathNavigator::startPath() {
     if (!global::timeManager->isPaused()) {
         openspace::global::scriptEngine->queueScript(
             "openspace.time.setPause(true)",
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
 
@@ -437,6 +438,7 @@ void PathNavigator::handlePathEnd() {
     if (_startSimulationTimeOnFinish) {
         openspace::global::scriptEngine->queueScript(
             "openspace.time.setPause(false)",
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         _startSimulationTimeOnFinish = false;
@@ -448,6 +450,7 @@ void PathNavigator::handlePathEnd() {
                 "'NavigationHandler.OrbitalNavigator.IdleBehavior.ApplyIdleBehavior',"
                 "true"
             ");",
+            openspace::scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }

--- a/src/navigation/pathnavigator.cpp
+++ b/src/navigation/pathnavigator.cpp
@@ -322,7 +322,7 @@ void PathNavigator::startPath() {
     if (!global::timeManager->isPaused()) {
         openspace::global::scriptEngine->queueScript(
             "openspace.time.setPause(true)",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
 
         _startSimulationTimeOnFinish = true;
@@ -437,7 +437,7 @@ void PathNavigator::handlePathEnd() {
     if (_startSimulationTimeOnFinish) {
         openspace::global::scriptEngine->queueScript(
             "openspace.time.setPause(false)",
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         _startSimulationTimeOnFinish = false;
     }
@@ -448,7 +448,7 @@ void PathNavigator::handlePathEnd() {
                 "'NavigationHandler.OrbitalNavigator.IdleBehavior.ApplyIdleBehavior',"
                 "true"
             ");",
-            openspace::scripting::ScriptEngine::RemoteScripting::Yes
+            openspace::scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
     }
 

--- a/src/network/parallelpeer.cpp
+++ b/src/network/parallelpeer.cpp
@@ -394,6 +394,7 @@ void ParallelPeer::dataMessageReceived(const std::vector<char>& message) {
 
             global::scriptEngine->queueScript(
                 sm._script,
+                scripting::ScriptEngine::ShouldBeSynchronized::No,
                 scripting::ScriptEngine::ShouldSendToRemote::No
             );
             break;

--- a/src/network/parallelpeer.cpp
+++ b/src/network/parallelpeer.cpp
@@ -394,7 +394,7 @@ void ParallelPeer::dataMessageReceived(const std::vector<char>& message) {
 
             global::scriptEngine->queueScript(
                 sm._script,
-                scripting::ScriptEngine::RemoteScripting::No
+                scripting::ScriptEngine::ShouldSendToRemote::No
             );
             break;
         }

--- a/src/network/parallelpeer.cpp
+++ b/src/network/parallelpeer.cpp
@@ -392,6 +392,8 @@ void ParallelPeer::dataMessageReceived(const std::vector<char>& message) {
             datamessagestructures::ScriptMessage sm;
             sm.deserialize(buffer);
 
+            // No sync or send because this has already been recived by a peer,
+            // don't send it back again
             global::scriptEngine->queueScript(
                 sm._script,
                 scripting::ScriptEngine::ShouldBeSynchronized::No,

--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -822,7 +822,7 @@ void LuaConsole::render() {
 
         const glm::vec2 loc = glm::vec2(
             EntryFontSize * dpi / 2.f,
-            res.y - _currentHeight + EntryFontSize * dpi
+            res.y - EntryFontSize * dpi
         );
 
         const glm::vec2 bbox = _font->boundingBox(text);

--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -76,6 +76,15 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
+    constexpr openspace::properties::Property::PropertyInfo ShouldBeSynchronizedInfo = {
+       "ShouldBeSynchronized",
+       "Should Be Synchronized",
+       "Determines whether the entered commands will only be executed locally (if this "
+       "is disabled), or whether they will be send to other connected nodes, for "
+       "example in a cluster envierment",
+       openspace::properties::Property::Visibility::AdvancedUser
+    };
+
     constexpr openspace::properties::Property::PropertyInfo ShouldSendToRemoteInfo = {
         "ShouldSendToRemote",
         "Should Send To Remote",
@@ -136,6 +145,7 @@ LuaConsole::LuaConsole()
     : properties::PropertyOwner({ "LuaConsole", "Lua Console" })
     , _isVisible(VisibleInfo, false)
     , _shouldSendToRemote(ShouldSendToRemoteInfo, false)
+    , _shouldBeSynchronized(ShouldBeSynchronizedInfo, true)
     , _backgroundColor(
         BackgroundColorInfo,
         glm::vec4(21.f / 255.f, 23.f / 255.f, 28.f / 255.f, 0.8f),
@@ -158,6 +168,7 @@ LuaConsole::LuaConsole()
     , _autoCompleteInfo({NoAutoComplete, false, ""})
 {
     addProperty(_isVisible);
+    addProperty(_shouldBeSynchronized);
     addProperty(_shouldSendToRemote);
     addProperty(_historyLength);
 
@@ -279,12 +290,25 @@ bool LuaConsole::keyboardCallback(Key key, KeyModifier modifier, KeyAction actio
         return false;
     }
 
+    const bool modifierShift = (modifier == KeyModifier::Shift);
+    const bool modifierControl = (modifier == KeyModifier::Control);
+
+    // Button left of 1 and above TAB (default)
+    // Can be changed to any other key with the setCommandInputButton funciton
     if (key == _commandInputButton) {
-        // Button left of 1 and above TAB
-        // How to deal with different keyboard languages? ---abock
         if (_isVisible) {
-            if (_shouldSendToRemote) {
-                _shouldSendToRemote = false;
+            if (modifierShift) {
+                // Toggle ShouldBeSynchronized property for all scripts
+                _shouldBeSynchronized = !_shouldBeSynchronized;
+            }
+            else if (modifierControl) {
+                // Only allow this toggle if a ParallelConnection exists
+                if (_shouldSendToRemote) {
+                    _shouldSendToRemote = false;
+                }
+                else if (global::parallelPeer->status() == ParallelConnection::Status::Host) {
+                    _shouldSendToRemote = true;
+                }
             }
             else {
                 _isVisible = false;
@@ -294,9 +318,6 @@ bool LuaConsole::keyboardCallback(Key key, KeyModifier modifier, KeyAction actio
         }
         else {
             _isVisible = true;
-            if (global::parallelPeer->status() == ParallelConnection::Status::Host) {
-                _shouldSendToRemote = true;
-            }
         }
 
         return true;
@@ -310,10 +331,6 @@ bool LuaConsole::keyboardCallback(Key key, KeyModifier modifier, KeyAction actio
         _isVisible = false;
         return true;
     }
-
-
-    const bool modifierControl = (modifier == KeyModifier::Control);
-    const bool modifierShift = (modifier == KeyModifier::Shift);
 
     // Paste from clipboard
     if (modifierControl && (key == Key::V || key == Key::Y)) {
@@ -433,8 +450,13 @@ bool LuaConsole::keyboardCallback(Key key, KeyModifier modifier, KeyAction actio
     if (key == Key::Enter || key == Key::KeypadEnter) {
         std::string cmd = _commands.at(_activeCommand);
         if (!cmd.empty()) {
+            using ShouldBeSynchronized = scripting::ScriptEngine::ShouldBeSynchronized;
             using ShouldSendToRemote = scripting::ScriptEngine::ShouldSendToRemote;
-            global::scriptEngine->queueScript(cmd, ShouldSendToRemote(_shouldSendToRemote));
+            global::scriptEngine->queueScript(
+                cmd,
+                ShouldBeSynchronized(_shouldBeSynchronized),
+                ShouldSendToRemote(_shouldSendToRemote)
+            );
 
             // Only add the current command to the history if it hasn't been
             // executed before. We don't want two of the same commands in a row
@@ -807,7 +829,15 @@ void LuaConsole::render() {
         return glm::vec2(loc.x + res.x - bbox.x - 10.f, loc.y);
     };
 
-    if (_shouldSendToRemote) {
+    if (!_shouldBeSynchronized) {
+        const glm::vec4 Yellow(1.0f, 1.0f, 0.f, 1.f);
+
+        const std::string masterOnlyExecutionText =
+            "Master only script execution (Nodes and Peers will not recieve scripts)";
+        const glm::vec2 loc = locationForRightJustifiedText(masterOnlyExecutionText);
+        RenderFont(*_font, loc, masterOnlyExecutionText, Yellow);
+    }
+    else if (_shouldSendToRemote) {
         const glm::vec4 Red(1.f, 0.f, 0.f, 1.f);
 
         ParallelConnection::Status status = global::parallelPeer->status();
@@ -827,7 +857,8 @@ void LuaConsole::render() {
     else if (global::parallelPeer->isHost()) {
         const glm::vec4 LightBlue(0.4f, 0.4f, 1.f, 1.f);
 
-        const std::string localExecutionText = "Local script execution";
+        const std::string localExecutionText =
+            "Local script execution (Peers will not recieve scripts)";
         const glm::vec2 loc = locationForRightJustifiedText(localExecutionText);
         RenderFont(*_font, loc, localExecutionText, LightBlue);
     }

--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -81,7 +81,7 @@ namespace {
        "Should Be Synchronized",
        "Determines whether the entered commands will only be executed locally (if this "
        "is disabled), or whether they will be send to other connected nodes, for "
-       "example in a cluster envierment",
+       "example in a cluster environment",
        openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -90,7 +90,7 @@ namespace {
         "Should Send To Remote",
         "Determines whether the entered commands will only be executed locally (if this "
         "is disabled), or whether they will be send to connected remote instances (other "
-        "peers through parallel connection)",
+        "peers through a parallel connection)",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -450,12 +450,10 @@ bool LuaConsole::keyboardCallback(Key key, KeyModifier modifier, KeyAction actio
     if (key == Key::Enter || key == Key::KeypadEnter) {
         std::string cmd = _commands.at(_activeCommand);
         if (!cmd.empty()) {
-            using ShouldBeSynchronized = scripting::ScriptEngine::ShouldBeSynchronized;
-            using ShouldSendToRemote = scripting::ScriptEngine::ShouldSendToRemote;
             global::scriptEngine->queueScript(
                 cmd,
-                ShouldBeSynchronized(_shouldBeSynchronized),
-                ShouldSendToRemote(_shouldSendToRemote)
+                scripting::ScriptEngine::ShouldBeSynchronized(_shouldBeSynchronized),
+                scripting::ScriptEngine::ShouldSendToRemote(_shouldSendToRemote)
             );
 
             // Only add the current command to the history if it hasn't been

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -776,7 +776,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
         global::scriptEngine->queueScript(
             ToggleRotationFrictionScript,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         return true;
     }
@@ -788,7 +788,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
         global::scriptEngine->queueScript(
             ToggleZoomFrictionScript,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         return true;
     }
@@ -800,7 +800,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
         global::scriptEngine->queueScript(
             ToggleRollFrictionScript,
-            scripting::ScriptEngine::RemoteScripting::Yes
+            scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         return true;
     }

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -776,6 +776,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
         global::scriptEngine->queueScript(
             ToggleRotationFrictionScript,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         return true;
@@ -788,6 +789,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
         global::scriptEngine->queueScript(
             ToggleZoomFrictionScript,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         return true;
@@ -800,6 +802,7 @@ bool RenderEngine::mouseActivationCallback(const glm::dvec2& mousePosition) cons
 
         global::scriptEngine->queueScript(
             ToggleRollFrictionScript,
+            scripting::ScriptEngine::ShouldBeSynchronized::Yes,
             scripting::ScriptEngine::ShouldSendToRemote::Yes
         );
         return true;

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -406,7 +406,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
             "openspace.removeScreenSpaceRenderable('" + identifier() + "');";
         global::scriptEngine->queueScript(
             script,
-            scripting::ScriptEngine::RemoteScripting::No
+            scripting::ScriptEngine::ShouldSendToRemote::No
         );
     });
     addProperty(_delete);

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -420,7 +420,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     _delete.onChange([this](){
         std::string script =
             "openspace.removeScreenSpaceRenderable('" + identifier() + "');";
-        // No sync or send because this is already inside a lua script that was triggered
+        // No sync or send because this is already inside a Lua script that was triggered
         // when this triggerProperty was pressed in the gui, therefor it has already been
         // synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -406,6 +406,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
             "openspace.removeScreenSpaceRenderable('" + identifier() + "');";
         global::scriptEngine->queueScript(
             script,
+            scripting::ScriptEngine::ShouldBeSynchronized::No,
             scripting::ScriptEngine::ShouldSendToRemote::No
         );
     });

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -404,6 +404,9 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     _delete.onChange([this](){
         std::string script =
             "openspace.removeScreenSpaceRenderable('" + identifier() + "');";
+        // No sync or send because this is already inside a lua script that was triggered
+        // when this triggerProperty was pressed in the gui, therefor it has already been
+        // synced and sent to the connected nodes and peers
         global::scriptEngine->queueScript(
             script,
             scripting::ScriptEngine::ShouldBeSynchronized::No,

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -548,6 +548,9 @@ void Scene::updateInterpolations() {
 
         if (i.isExpired) {
             if (!i.postScript.empty()) {
+                // No sync or send because this is already inside a lua script that was triggered
+                // when the interpolation of the property was triggered, therefor it has already been
+                // synced and sent to the connected nodes and peers
                 global::scriptEngine->queueScript(
                     std::move(i.postScript),
                     scripting::ScriptEngine::ShouldBeSynchronized::No,

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -550,6 +550,7 @@ void Scene::updateInterpolations() {
             if (!i.postScript.empty()) {
                 global::scriptEngine->queueScript(
                     std::move(i.postScript),
+                    scripting::ScriptEngine::ShouldBeSynchronized::No,
                     scripting::ScriptEngine::ShouldSendToRemote::No
                 );
             }

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -548,7 +548,7 @@ void Scene::updateInterpolations() {
 
         if (i.isExpired) {
             if (!i.postScript.empty()) {
-                // No sync or send because this is already inside a lua script that was triggered
+                // No sync or send because this is already inside a Lua script that was triggered
                 // when the interpolation of the property was triggered, therefor it has already been
                 // synced and sent to the connected nodes and peers
                 global::scriptEngine->queueScript(

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -550,7 +550,7 @@ void Scene::updateInterpolations() {
             if (!i.postScript.empty()) {
                 global::scriptEngine->queueScript(
                     std::move(i.postScript),
-                    scripting::ScriptEngine::RemoteScripting::No
+                    scripting::ScriptEngine::ShouldSendToRemote::No
                 );
             }
 

--- a/src/scripting/scriptengine.cpp
+++ b/src/scripting/scriptengine.cpp
@@ -534,12 +534,12 @@ void ScriptEngine::preSync(bool isMaster) {
             _incomingScripts.pop();
 
             _scriptsToSync.push_back(item.script);
-            const bool remoteScripting = item.remoteScripting;
+            const bool shouldSendToRemote = item.shouldSendToRemote;
 
             // Not really a received script but the master also needs to run the script...
             _masterScriptQueue.push(item);
 
-            if (global::parallelPeer->isHost() && remoteScripting) {
+            if (global::parallelPeer->isHost() && shouldSendToRemote) {
                 global::parallelPeer->sendScript(item.script);
             }
             if (global::sessionRecording->isRecording()) {
@@ -613,7 +613,7 @@ void ScriptEngine::postSync(bool isMaster) {
 }
 
 void ScriptEngine::queueScript(std::string script,
-                               ScriptEngine::RemoteScripting remoteScripting,
+                               ScriptEngine::ShouldSendToRemote shouldSendToRemote,
                                ScriptCallback callback)
 {
     ZoneScoped;
@@ -621,7 +621,7 @@ void ScriptEngine::queueScript(std::string script,
     if (script.empty()) {
         return;
     }
-    _incomingScripts.push({ std::move(script), remoteScripting, std::move(callback) });
+    _incomingScripts.push({ std::move(script), shouldSendToRemote, std::move(callback) });
 }
 
 

--- a/src/scripting/scriptengine.cpp
+++ b/src/scripting/scriptengine.cpp
@@ -533,17 +533,23 @@ void ScriptEngine::preSync(bool isMaster) {
             QueueItem item = std::move(_incomingScripts.front());
             _incomingScripts.pop();
 
-            _scriptsToSync.push_back(item.script);
-            const bool shouldSendToRemote = item.shouldSendToRemote;
-
             // Not really a received script but the master also needs to run the script...
             _masterScriptQueue.push(item);
 
-            if (global::parallelPeer->isHost() && shouldSendToRemote) {
-                global::parallelPeer->sendScript(item.script);
-            }
             if (global::sessionRecording->isRecording()) {
                 global::sessionRecording->saveScriptKeyframeToTimeline(item.script);
+            }
+
+            // Sync out to other nodes (cluster)
+            if (!item.shouldBeSynchronized) {
+                continue;
+            }
+            _scriptsToSync.push_back(item.script);
+
+            // Send to other peers (parallel connection)
+            const bool shouldSendToRemote = item.shouldSendToRemote;
+            if (global::parallelPeer->isHost() && shouldSendToRemote) {
+                global::parallelPeer->sendScript(item.script);
             }
         }
     }
@@ -613,6 +619,7 @@ void ScriptEngine::postSync(bool isMaster) {
 }
 
 void ScriptEngine::queueScript(std::string script,
+                               ScriptEngine::ShouldBeSynchronized shouldBeSynchronized,
                                ScriptEngine::ShouldSendToRemote shouldSendToRemote,
                                ScriptCallback callback)
 {
@@ -621,7 +628,12 @@ void ScriptEngine::queueScript(std::string script,
     if (script.empty()) {
         return;
     }
-    _incomingScripts.push({ std::move(script), shouldSendToRemote, std::move(callback) });
+    _incomingScripts.push({
+        std::move(script),
+        shouldBeSynchronized,
+        shouldSendToRemote,
+        std::move(callback)
+    });
 }
 
 

--- a/src/scripting/scriptscheduler.cpp
+++ b/src/scripting/scriptscheduler.cpp
@@ -262,7 +262,7 @@ void ScriptScheduler::setCurrentTime(double time) {
         for (const std::string& script : scheduledScripts) {
             global::scriptEngine->queueScript(
                 script,
-                scripting::ScriptEngine::RemoteScripting::Yes
+                scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }
     }

--- a/src/scripting/scriptscheduler.cpp
+++ b/src/scripting/scriptscheduler.cpp
@@ -262,6 +262,7 @@ void ScriptScheduler::setCurrentTime(double time) {
         for (const std::string& script : scheduledScripts) {
             global::scriptEngine->queueScript(
                 script,
+                scripting::ScriptEngine::ShouldBeSynchronized::Yes,
                 scripting::ScriptEngine::ShouldSendToRemote::Yes
             );
         }


### PR DESCRIPTION
Closes #2768.

The setting `remoteScripting` has been split into two, one bool to decide if it should be sent to all connected remotes, i.e. other connected **peers** in a parallel connection. The second is another bool to decide if it should be synced out to other connected **nodes** for example, a cluster in a dome. The setting for actions called `isLocal` is kept as is for now to qualify as a point release, but the plan for the next release is to change that to use the same structure too.

Requires this fix in the GUI repo too https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/159.

Note that this does not solve the problem for issue #2854.

Will do some more testing with the parallel peer connection to see if it could solve the issue for #2062 as well.
Edit: Tested it out and it seems to work for the exoplanets, however, there seem to still be some issues with scripts related to the skybrowser.