### PR TITLE
Feature - OrbitalNavigator Setting - Orbit Around Up

### DIFF
--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -442,6 +442,9 @@ private:
      */
     void orbitAroundAxis(const glm::dvec3 axis, double angle, glm::dvec3& position,
         glm::dquat& globalRotation);
+
+    double rotationSpeedScaleFromCameraHeight(const glm::dvec3& cameraPosition,
+        const SurfacePositionHandle& positionHandle) const;
 };
 
 } // namespace openspace::interaction

--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -332,14 +332,24 @@ private:
         double targetDistance);
 
     /**
+     * Modify the camera position and global rotation to rotate around the up vector
+     * of the current anchor based on x-wise input
+     *
+     * The up-vector to rotate around is determined by the "_upToUseForRotation" property
+     */
+    void rotateAroundAnchorUp(double deltaTime, double speedScale,
+        glm::dvec3& cameraPosition, glm::dquat& globalCameraRotation);
+
+    /**
      * Translates the horizontal direction. If far from the anchor object, this will
      * result in an orbital rotation around the object. This function does not affect the
      * rotation but only the position.
      *
      * \return a position vector adjusted in the horizontal direction.
      */
-    glm::dvec3 translateHorizontally(double deltaTime, const glm::dvec3& cameraPosition,
-        const glm::dvec3& objectPosition, const glm::dquat& globalCameraRotation,
+    glm::dvec3 translateHorizontally(double deltaTime, double speedScale,
+        const glm::dvec3& cameraPosition, const glm::dvec3& objectPosition,
+        const glm::dquat& globalCameraRotation,
         const SurfacePositionHandle& positionHandle) const;
 
     /*

--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -233,6 +233,15 @@ private:
 
     properties::BoolProperty _invertMouseButtons;
 
+    properties::BoolProperty _shouldRotateAroundUp;
+
+    enum class UpDirectionChoice {
+        XAxis = 0,
+        YAxis,
+        ZAxis
+    };
+    properties::OptionProperty _upToUseForRotation;
+
     MouseCameraStates _mouseStates;
     JoystickCameraStates _joystickStates;
     WebsocketCameraStates _websocketStates;

--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -419,13 +419,11 @@ private:
      *
      * Used for IdleBehavior::Behavior::Orbit
      *
-     * \param deltaTime The time step to use for the motion. Controls the rotation angle
+     * \param angle The rotation angle to use for the motion
      * \param position The position of the camera. Will be changed by the function
      * \param globalRotation The camera's global rotation. Will be changed by the function
-     * \param speedScale A speed scale that controls the speed of the motion
      */
-    void orbitAnchor(double deltaTime, glm::dvec3& position,
-        glm::dquat& globalRotation, double speedScale);
+    void orbitAnchor(double angle, glm::dvec3& position, glm::dquat& globalRotation);
 
     /**
      * Orbit the current anchor node, by adding a rotation around the given axis. For
@@ -438,13 +436,12 @@ private:
      * IdleBehavior::Behavior::OrbitAroundUp (axis = up = y-axis)
      *
      * \param axis The axis to arbit around, given in model coordinates of the anchor
-     * \param deltaTime The time step to use for the motion. Controls the rotation angle
+     * \param angle The rotation angle to use for the motion
      * \param position The position of the camera. Will be changed by the function
      * \param globalRotation The camera's global rotation. Will be changed by the function
-     * \param speedScale A speed scale that controls the speed of the motion
      */
-    void orbitAroundAxis(const glm::dvec3 axis, double deltaTime, glm::dvec3& position,
-        glm::dquat& globalRotation, double speedScale);
+    void orbitAroundAxis(const glm::dvec3 axis, double angle, glm::dvec3& position,
+        glm::dquat& globalRotation);
 };
 
 } // namespace openspace::interaction

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -396,7 +396,10 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo ShouldRotateAroundUpInfo = {
         "ShouldRotateAroundUp",
         "Should Rotate Around Up",
-        "When set to true, TODO...",
+        "When set to true, global rotation interactions in the X-direction will lead to "
+        "a rotation around the specified up vector instead of just around the object. "
+        "The up vector is the local coordinate axis, and can be set to either the X-, Y- "
+        "or Z-axis through the 'UpToUseForRotation' property",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -2039,6 +2039,10 @@ void OrbitalNavigator::orbitAroundAxis(const glm::dvec3 axis, double angle,
 {
     ghoul_assert(_anchorNode != nullptr, "Node to orbit must be set");
 
+    if (glm::abs(angle) < AngleEpsilon) {
+        return;
+    }
+
     const glm::dmat4 modelTransform = _anchorNode->modelTransform();
     const glm::dvec3 axisInWorldSpace =
         glm::normalize(glm::dmat3(modelTransform) * glm::normalize(axis));
@@ -2050,6 +2054,10 @@ void OrbitalNavigator::orbitAroundAxis(const glm::dvec3 axis, double angle,
     const glm::dvec3 anchorCenterToCamera = position - _anchorNode->worldPosition();
     const glm::dvec3 rotationDiffVec3 =
         spinRotation * anchorCenterToCamera - anchorCenterToCamera;
+
+    if (!(glm::length(rotationDiffVec3) > 0.0)) {
+        return;
+    }
 
     position += rotationDiffVec3;
 

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -721,18 +721,9 @@ OrbitalNavigator::OrbitalNavigator()
 
     addProperty(_shouldRotateAroundUp);
     _upToUseForRotation.addOptions({
-        {
-            static_cast<int>(UpDirectionChoice::XAxis),
-            "Local X"
-        },
-        {
-            static_cast<int>(UpDirectionChoice::YAxis),
-            "Local Y"
-        },
-        {
-            static_cast<int>(UpDirectionChoice::ZAxis),
-            "Local Z"
-        },
+        { static_cast<int>(UpDirectionChoice::XAxis), "Local X" },
+        { static_cast<int>(UpDirectionChoice::YAxis), "Local Y" },
+        { static_cast<int>(UpDirectionChoice::ZAxis), "Local Z" }
     });
     _upToUseForRotation = static_cast<int>(UpDirectionChoice::ZAxis);
     addProperty(_upToUseForRotation);
@@ -1643,17 +1634,17 @@ void OrbitalNavigator::rotateAroundAnchorUp(double deltaTime, double speedScale,
 {
     glm::dvec3 axis;
     switch (_upToUseForRotation) {
-    case static_cast<int>(UpDirectionChoice::XAxis):
-        axis = glm::dvec3(1.0, 0.0, 0.0);
-        break;
-    case static_cast<int>(UpDirectionChoice::YAxis):
-        axis = glm::dvec3(0.0, 1.0, 0.0);
-        break;
-    case static_cast<int>(UpDirectionChoice::ZAxis):
-        axis = glm::dvec3(0.0, 0.0, 1.0);
-        break;
-    default:
-        throw ghoul::MissingCaseException();
+        case static_cast<int>(UpDirectionChoice::XAxis):
+            axis = glm::dvec3(1.0, 0.0, 0.0);
+            break;
+        case static_cast<int>(UpDirectionChoice::YAxis):
+            axis = glm::dvec3(0.0, 1.0, 0.0);
+            break;
+        case static_cast<int>(UpDirectionChoice::ZAxis):
+            axis = glm::dvec3(0.0, 0.0, 1.0);
+            break;
+        default:
+            throw ghoul::MissingCaseException();
     }
 
     double combinedXInput = _mouseStates.globalRotationVelocity().x +
@@ -1709,12 +1700,14 @@ glm::dvec3 OrbitalNavigator::translateHorizontally(double deltaTime, double spee
         glm::inverse(globalCameraRotation);
 
     const glm::dmat4 modelTransform = _anchorNode->modelTransform();
-    const glm::dvec3 outDirection = glm::normalize(glm::dmat3(modelTransform) *
-        positionHandle.referenceSurfaceOutDirection);
+    const glm::dvec3 outDirection = glm::normalize(
+        glm::dmat3(modelTransform) *
+        positionHandle.referenceSurfaceOutDirection
+    );
 
     // Compute the vector to rotate to find the new position
     const double distFromCenterToCamera = glm::length(cameraPosition - objectPosition);
-    const glm::dvec3 outVector = (distFromCenterToCamera * outDirection);
+    const glm::dvec3 outVector = distFromCenterToCamera * outDirection;
 
     // Rotate and find the difference vector
     const glm::dvec3 rotationDiffVec3 = outVector * rotationDiffWorldSpace - outVector;
@@ -2055,7 +2048,7 @@ void OrbitalNavigator::orbitAroundAxis(const glm::dvec3 axis, double angle,
     const glm::dvec3 rotationDiffVec3 =
         spinRotation * anchorCenterToCamera - anchorCenterToCamera;
 
-    if (!(glm::length(rotationDiffVec3) > 0.0)) {
+    if (glm::length(rotationDiffVec3 == 0.0)) {
         return;
     }
 
@@ -2067,14 +2060,16 @@ void OrbitalNavigator::orbitAroundAxis(const glm::dvec3 axis, double angle,
 }
 
 double OrbitalNavigator::rotationSpeedScaleFromCameraHeight(
-                                              const glm::dvec3& cameraPosition,
-                                       const SurfacePositionHandle& positionHandle) const
+                                                         const glm::dvec3& cameraPosition,
+                                        const SurfacePositionHandle& positionHandle) const
 {
     const glm::dmat4 modelTransform = _anchorNode->modelTransform();
     const glm::dvec3 anchorPos = _anchorNode->worldPosition();
 
-    const glm::dvec3 outDirection = glm::normalize(glm::dmat3(modelTransform) *
-        positionHandle.referenceSurfaceOutDirection);
+    const glm::dvec3 outDirection = glm::normalize(
+        glm::dmat3(modelTransform) *
+        positionHandle.referenceSurfaceOutDirection
+    );
 
     const glm::dvec3 posDiff = cameraPosition - anchorPos;
     const glm::dvec3 centerToActualSurfaceModelSpace =

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -1632,20 +1632,18 @@ void OrbitalNavigator::rotateAroundAnchorUp(double deltaTime, double speedScale,
                                             glm::dvec3& cameraPosition,
                                             glm::dquat& globalCameraRotation)
 {
-    glm::dvec3 axis;
-    switch (_upToUseForRotation) {
-        case static_cast<int>(UpDirectionChoice::XAxis):
-            axis = glm::dvec3(1.0, 0.0, 0.0);
-            break;
-        case static_cast<int>(UpDirectionChoice::YAxis):
-            axis = glm::dvec3(0.0, 1.0, 0.0);
-            break;
-        case static_cast<int>(UpDirectionChoice::ZAxis):
-            axis = glm::dvec3(0.0, 0.0, 1.0);
-            break;
-        default:
-            throw ghoul::MissingCaseException();
-    }
+    const glm::dvec3 axis = [](UpDirectionChoice upAxis) {
+        switch (upAxis) {
+            case UpDirectionChoice::XAxis:
+                return glm::dvec3(1.0, 0.0, 0.0);
+            case UpDirectionChoice::YAxis:
+                return glm::dvec3(0.0, 1.0, 0.0);
+            case UpDirectionChoice::ZAxis:
+                return glm::dvec3(0.0, 0.0, 1.0);
+            default:
+                throw ghoul::MissingCaseException();
+        }
+    }(UpDirectionChoice(_upToUseForRotation.value()));
 
     double combinedXInput = _mouseStates.globalRotationVelocity().x +
         _joystickStates.globalRotationVelocity().x +
@@ -2048,7 +2046,7 @@ void OrbitalNavigator::orbitAroundAxis(const glm::dvec3 axis, double angle,
     const glm::dvec3 rotationDiffVec3 =
         spinRotation * anchorCenterToCamera - anchorCenterToCamera;
 
-    if (glm::length(rotationDiffVec3 == 0.0)) {
+    if (glm::length(rotationDiffVec3) == 0.0) {
         return;
     }
 


### PR DESCRIPTION
Adds a setting to let the user orbit around a certain axis (referred to as the "up") using the OrbitalNavigator. The axis can be set to either the local X Y or Z of the anchor node. 

Input in the x-direction will rotate around the provided vector, while input in the y-direction will move the camera as regular.  It works best when the "up" vector is set to point upwards in screen-space (we should maybe add a way to enforce this)

Should close https://github.com/OpenSpace/OpenSpace/issues/1372  (and partly https://github.com/OpenSpace/OpenSpace/issues/740?)

Here's a demonstration video of how it works. Feel free to try it out.  
https://github.com/OpenSpace/OpenSpace/assets/8808894/51f0cf30-1088-4f3d-a3ee-148e57796e6b

