### PR TITLE
Update HttpSynchronization to keep track of files downloaded (#2587)

### DIFF
--- a/include/openspace/util/resourcesynchronization.h
+++ b/include/openspace/util/resourcesynchronization.h
@@ -176,12 +176,13 @@ protected:
         Unsynced,
         Syncing,
         Resolved,
-        Rejected
+        Rejected,
+        PartialResolved
     };
 
     /// Creates a file next to the directory that indicates that this
     /// ResourceSynchronization has successfully synchronized its contents
-    void createSyncFile() const;
+    virtual void createSyncFile(bool fullySynchronized = true) const;
 
     /// Returns whether the synchronization file create in #createSyncFile exists
     bool hasSyncFile() const;

--- a/include/openspace/util/resourcesynchronization.h
+++ b/include/openspace/util/resourcesynchronization.h
@@ -176,8 +176,7 @@ protected:
         Unsynced,
         Syncing,
         Resolved,
-        Rejected,
-        PartialResolved
+        Rejected
     };
 
     /// Creates a file next to the directory that indicates that this

--- a/modules/atmosphere/shaders/atmosphere_deferred_fs.glsl
+++ b/modules/atmosphere/shaders/atmosphere_deferred_fs.glsl
@@ -509,8 +509,8 @@ vec3 sunColor(vec3 v, vec3 s, float r, float mu, float irradianceFactor) {
   // const float SunAngularSize = (0.3 * M_PI / 180.0);
   const float FuzzyFactor = 0.5; // How fuzzy should the edges be
 
-  const float p1 = cos(sunAngularSize);
-  const float p2 = cos(sunAngularSize * FuzzyFactor);
+  float p1 = cos(sunAngularSize);
+  float p2 = cos(sunAngularSize * FuzzyFactor);
 
   float t = (angle - p1) / (p2 - p1);
   float scale = clamp(t, 0.0, 1.0);

--- a/modules/sync/syncs/httpsynchronization.cpp
+++ b/modules/sync/syncs/httpsynchronization.cpp
@@ -118,36 +118,36 @@ void HttpSynchronization::start() {
 
     _syncThread = std::thread(
         [this](const std::string& q) {
-        for (const std::string& url : _syncRepositories) {
-            //TODO: handle multiple syncRepositories, before it would only create
-            // syncfile from first success and then continue
-            const bool success = trySyncFromUrl(url + q);
-            if (success) {
-                _state = State::Resolved;
-                createSyncFile(success);
-                break;
-            }
-            else {
-                // If it was not successful we should add any files that were potentially
-                // downloaded, so we dont download them again from the new repository
-                _existingSyncedFiles.insert(
-                    _existingSyncedFiles.end(),
-                    _newSyncedFiles.begin(),
-                    _newSyncedFiles.end()
-                );
-                _newSyncedFiles.clear();
-                createSyncFile(success);
+            for (const std::string& url : _syncRepositories) {
+                //TODO: handle multiple syncRepositories, before it would only create
+                // syncfile from first success and then continue
+                const bool success = trySyncFromUrl(url + q);
+                if (success) {
+                    _state = State::Resolved;
+                    createSyncFile(success);
+                    break;
+                }
+                else {
+                    // If it was not successful we should add any files that were potentially
+                    // downloaded, so we dont download them again from the new repository
+                    _existingSyncedFiles.insert(
+                        _existingSyncedFiles.end(),
+                        _newSyncedFiles.begin(),
+                        _newSyncedFiles.end()
+                    );
+                    _newSyncedFiles.clear();
+                    createSyncFile(success);
 
-                // TODO: What should status be if only partially synched, rn it does not
-                // exit gracefully and one have to restart openspace
-                // _state = State::PartialResolved;
+                    // TODO: What should status be if only partially synched, rn it does not
+                    // exit gracefully and one have to restart openspace
+                    // _state = State::PartialResolved;
                 
-                // I believe setting another status than syncing
-                // will mess with download screen splash as it depends on status being state::Syncing
-                // Or it might mess with other parts of the sync module?
+                    // I believe setting another status than syncing
+                    // will mess with download screen splash as it depends on status being
+                    // state::Syncing or it might mess with other parts of the sync module?
                 }
             }
-            if (!_shouldCancel) {
+            if (!isResolved() && !_shouldCancel) {
                 _state = State::Rejected;
             }
         },

--- a/modules/sync/syncs/httpsynchronization.cpp
+++ b/modules/sync/syncs/httpsynchronization.cpp
@@ -174,8 +174,9 @@ void HttpSynchronization::createSyncFile(bool isFullySynchronized = true) const 
     syncFile << _ossyncVersionNumber << '\n' <<
         (isFullySynchronized ? _synchronizationToken : "Partial Synchronized") << '\n';
 
-    if (fullySynchronized) {
-        return; // All files successfully downloaded, no need to write anything else to file
+    if (isFullySynchronized) {
+        // All files successfully downloaded, no need to write anything else to file
+        return;
     }
 
     // Store all files that successfully downloaded
@@ -297,7 +298,8 @@ bool HttpSynchronization::trySyncFromUrl(std::string listUrl) {
         // Check if the file exists in stored files in ossync, if so we ignore that download. 
         auto it = std::find(_existingSyncedFiles.begin() ,_existingSyncedFiles.end(), line);
         if (it != _existingSyncedFiles.end()) {
-            // File has already been synced. TODO: Ok? Unless there is some form of force download all new files?
+            // File has already been synced.
+            // TODO: Ok? Unless there is some form of force download all new files?
             continue;
         }
 
@@ -347,7 +349,7 @@ bool HttpSynchronization::trySyncFromUrl(std::string listUrl) {
     int downloadTry = 0;
     bool downloadFailed = false;
     //If a download has failed try to restart it
-    while (downloadTry < downloadRetries) {
+    while (downloadTry < MaxDownloadRetries) {
         for (const std::unique_ptr<HttpFileDownload>& d : downloads) {
             d->wait();
             if (d->hasFailed()) {

--- a/modules/sync/syncs/httpsynchronization.h
+++ b/modules/sync/syncs/httpsynchronization.h
@@ -92,6 +92,13 @@ public:
 
     static documentation::Documentation Documentation();
 
+protected:
+    void createSyncFile(bool fullySynchronized) const override;
+
+    /// Check ossync file and returns true if all files are downloaded or false
+    /// if partially synched or if there is an ossync file error (rejected)
+    bool checkSyncFile();
+
 private:
     /// Tries to get a reply from the provided URL and returns that success to the caller
     bool trySyncFromUrl(std::string url);
@@ -110,6 +117,16 @@ private:
 
     // The thread that will be doing the synchronization
     std::thread _syncThread;
+
+    //The files that have already been synchronized
+    std::vector<std::string> _existingSyncedFiles;
+
+    //The files that have been synchronized this time
+    std::vector<std::string> _newSyncedFiles;
+
+    const std::string _ossyncVersionNumber = "1.0";
+
+    const std::string _synchronizationToken = "Synchronized";
 };
 
 } // namespace openspace

--- a/modules/sync/syncs/httpsynchronization.h
+++ b/modules/sync/syncs/httpsynchronization.h
@@ -97,7 +97,7 @@ protected:
 
     /// Check ossync file and returns true if all files are downloaded or false
     /// if partially synched or if there is an ossync file error (rejected)
-    bool checkSyncFile();
+    bool isEachFileDownloaded();
 
 private:
     /// Tries to get a reply from the provided URL and returns that success to the caller
@@ -123,10 +123,6 @@ private:
 
     //The files that have been synchronized this time
     std::vector<std::string> _newSyncedFiles;
-
-    const std::string _ossyncVersionNumber = "1.0";
-
-    const std::string _synchronizationToken = "Synchronized";
 };
 
 } // namespace openspace

--- a/modules/sync/syncs/httpsynchronization.h
+++ b/modules/sync/syncs/httpsynchronization.h
@@ -93,15 +93,24 @@ public:
     static documentation::Documentation Documentation();
 
 protected:
-    void createSyncFile(bool isFullySynchronized) const override;
+    /// Creates a file next to the directory that indicates that this
+    /// ResourceSynchronization has successfully synchronized its contents
+    void createSyncFile(bool isFullySynchronized = true) const override;
 
     /// Check ossync file and returns true if all files are downloaded or false
     /// if partially synched or if there is an ossync file error (rejected)
     bool isEachFileDownloaded();
 
+    /// Representation of 'global' synchronization state that encodes where a fail happen.
+    enum class SynchronizationState {
+        Success,
+        ListDownloadFail,
+        FileDownloadFail
+    };
+
 private:
     /// Tries to get a reply from the provided URL and returns that success to the caller
-    bool trySyncFromUrl(std::string url);
+    SynchronizationState trySyncFromUrl(std::string url);
 
     /// Contains a flag whether the current transfer should be cancelled
     std::atomic_bool _shouldCancel = false;

--- a/modules/sync/syncs/httpsynchronization.h
+++ b/modules/sync/syncs/httpsynchronization.h
@@ -127,10 +127,10 @@ private:
     // The thread that will be doing the synchronization
     std::thread _syncThread;
 
-    //The files that have already been synchronized
+    // The files that have already been synchronized
     std::vector<std::string> _existingSyncedFiles;
 
-    //The files that have been synchronized this time
+    // The files that have been synchronized this time
     std::vector<std::string> _newSyncedFiles;
 };
 

--- a/src/util/resourcesynchronization.cpp
+++ b/src/util/resourcesynchronization.cpp
@@ -105,7 +105,7 @@ const std::string& ResourceSynchronization::name() const {
     return _name;
 }
 
-void ResourceSynchronization::createSyncFile() const {
+void ResourceSynchronization::createSyncFile(bool fullySynchronized) const {
     std::filesystem::path dir = directory();
     std::filesystem::create_directories(dir);
 


### PR DESCRIPTION
Reads ossync file on synchronization and download files that are missing, will automatically retry download if an error occurred. 