### PR TITLE
More explicit handling of zero duration paths

### DIFF
--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -120,7 +120,7 @@ Path::Path(Waypoint start, Waypoint end, Type type, std::optional<double> durati
     // computing how much faster/slower it should be
     _speedFactorFromDuration = 1.0;
     if (duration.has_value()) {
-        if (*duration > 0) {
+        if (*duration > 0.0) {
             constexpr double dt = 0.05; // 20 fps
             while (!hasReachedEnd()) {
                 traversePath(dt);

--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -120,14 +120,20 @@ Path::Path(Waypoint start, Waypoint end, Type type, std::optional<double> durati
     // computing how much faster/slower it should be
     _speedFactorFromDuration = 1.0;
     if (duration.has_value()) {
-        constexpr double dt = 0.05; // 20 fps
-        while (!hasReachedEnd()) {
-            traversePath(dt);
-        }
+        if (*duration > 0) {
+            constexpr double dt = 0.05; // 20 fps
+            while (!hasReachedEnd()) {
+                traversePath(dt);
+            }
 
-        // We now know how long it took to traverse the path. Use that
-        _speedFactorFromDuration = _progressedTime / *duration;
-        resetPlaybackVariables();
+            // We now know how long it took to traverse the path. Use that
+            _speedFactorFromDuration = _progressedTime / *duration;
+            resetPlaybackVariables();
+        }
+        else {
+            // A duration of zero means infinite speed. Handle this explicity
+            _speedFactorFromDuration = std::numeric_limits<double>::infinity();
+        }
     }
 }
 
@@ -148,6 +154,13 @@ std::vector<glm::dvec3> Path::controlPoints() const {
 }
 
 CameraPose Path::traversePath(double dt, float speedScale) {
+    if (std::isinf(_speedFactorFromDuration)) {
+        _shouldQuit = true;
+        _prevPose = _start.pose();
+        _traveledDistance = pathLength();
+        return _end.pose();
+    }
+
     double speed = speedAlongPath(_traveledDistance);
     speed *= static_cast<double>(speedScale);
     double displacement = dt * speed;


### PR DESCRIPTION
Make it more obvious when the camera path speed is infinite (duration is zero), and prevent doing redundant computations.  Instead, just jump to the end of the path in traversal

Honestly, it's just lucky that the math worked before... The use of infinite speed was a bit nasty 