### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ env:
   BUILD_TYPE: Debug
 
 jobs:
-
   line-count:
     strategy:
       fail-fast: false
@@ -224,6 +223,7 @@ jobs:
           cmake -B ${{ env.BUILD_DIR }} -G "Xcode"
           cmake -B ${{ env.BUILD_DIR }} -G "Xcode" -DOPENSPACE_ENABLE_ALL_MODULES=ON
 
+      # Xcode outputs a lot of noise to the log, this makes it quieter and only outputs on compiler warnings or errors
       - name: Build
         run: |
           cmake --build ${{ github.workspace }}/build --target OpenSpace --config ${{env.BUILD_TYPE}} -- -quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,229 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+    branches: [ "**" ]
+
+concurrency:
+  group: ${{ github.workflow }}@${{ github.ref }}+${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+  cancel-in-progress: false
+
+# Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+
+  line-count:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    name: Count lines of code
+    
+    steps:
+      - uses: actions/checkout@v4
+        
+      - name: Count Lines of Code (cloc)
+        uses: djdefi/cloc-action@5
+
+  build-linux:
+    needs: line-count
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+        qt-ver: [apt, 6.2, 6.5]
+        compiler:
+          - { compiler: GCC 11, cc: gcc-11, cxx: g++-11 }
+          - { compiler: GCC 12, cc: gcc-12, cxx: g++-12 }
+          - { compiler: GCC 13, cc: gcc-13, cxx: g++-13 }
+          - { compiler: Clang 14, cc: clang-14, cxx: clang++-14 }
+          - { compiler: Clang 15, cc: clang-15, cxx: clang++-15 }
+          - { compiler: Clang 16, cc: clang-16, cxx: clang++-16 }
+          - { compiler: Clang 17, cc: clang-17, cxx: clang++-17 }
+        generator:
+          - { generator: Make, flag: Unix Makefiles }
+          - { generator: Ninja, flag: Ninja }
+        exclude:
+          - os: ubuntu-20.04
+            qt-ver: apt
+
+    runs-on: ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} (${{ matrix.compiler.compiler }}/${{ matrix.generator.Generator }}/Qt ${{ matrix.qt-ver }})
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build
+      
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gdal-bin libgdal-dev libxrandr-dev libxinerama-dev xorg-dev libxcursor-dev libxi-dev libasound2-dev libgdal-dev libboost-dev freeglut3-dev glew-utils libpng-dev libcurl4-openssl-dev libvulkan-dev zlib1g-dev libmpv-dev
+
+      # GCC 13 is not available by default, this helps with installing newer versions of GCC
+      - name: Install updated GCC and set priorities
+        if: matrix.compiler.compiler == 'GCC 13'
+        run: |
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get install --install-suggests -y g++-13 gcc-13
+  
+      # Clang 15 and newer are not available by default, this helps with installing new and more recent versions of Clang, as well as versions not in the Ubuntu repositories
+      - name: Install updated LLVM/Clang
+        if: matrix.compiler.compiler == 'Clang 15' || matrix.compiler.compiler == 'Clang 16' || matrix.compiler.compiler == 'Clang 17' 
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          if [[ "${{ matrix.compiler.compiler }}" == 'Clang 15' ]]; then
+            sudo apt install --install-suggests -y clang-15 clang-format-15 clang-tidy-15 clang-tools-15 clangd-15
+          elif [[ "${{ matrix.compiler.compiler }}" == 'Clang 16' ]]; then
+            sudo ./llvm.sh 16
+          elif [[ "${{ matrix.compiler.compiler }}" == 'Clang 17' ]]; then
+            sudo ./llvm.sh 17
+          fi
+
+      # Ninja is not available by default, this helps with installing Ninja
+      - name: Install Ninja
+        if: matrix.generator.generator == 'Ninja'
+        run: sudo apt-get install ninja-build
+
+      # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+      - name: Install Qt6 from aqtinstall
+        uses: jurplel/install-qt-action@v3.0.0
+        if: matrix.qt-ver != 'apt'
+        with:
+          version: ${{ matrix.qt-ver }}
+          cache: true
+
+      # Qt is available on Ubuntu APT repositories, abiet older versions
+      - name: Install Qt6 from APT
+        if: matrix.qt-ver == 'apt'
+        run: sudo apt-get install -y qt6-base-dev
+        
+      # Helps with disk space issues, OpenSpace builds are large and can cause the runner to fail with a low disk or full disk error
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+      # Increase swapfile size to help with low memory issues during builds
+      - name: Increase swapfile
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l 15G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+
+      - name: Configure CMake
+        run: cmake -G "${{ matrix.generator.flag }}" -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.compiler.cc }} -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.compiler.cxx }} -B ${{ env.BUILD_DIR }} -DOPENSPACE_ENABLE_ALL_MODULES=ON -DCMAKE_CXX_FLAGS:STRING=-DGLM_ENABLE_EXPERIMENTAL -DOpenGL_GL_PREFERENCE:STRING=GLVND -DASSIMP_BUILD_MINIZIP=1
+
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --target OpenSpace --config ${{env.BUILD_TYPE}}
+
+  build-win:
+    needs: line-count
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-2022, windows-2019]
+        qt-ver: [6.2, 6.5]
+    runs-on: ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} (Qt ${{ matrix.qt-ver }})
+    env:
+      BUILD_DIR: C:\OpenSpace\build
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v3.0.0
+        with:
+          version: ${{ matrix.qt-ver }}
+          host: "windows"
+          target: "desktop"
+          arch: "win64_msvc2019_64"
+          cache: true
+
+      # Boost is not available on Windows by default, this action resolves this issue
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.4
+        id: install-boost
+        with:
+          boost_version: 1.81.0
+          platform_version: 2022
+          toolset: msvc
+
+      # Due to a limitation on free Windows-based GitHub runners, we need a larger build drive, the C:\ drive on the runner will suffice
+      - name: Hack - Move repository to larger drive
+        run: |
+          cp ${{github.workspace}} C:\OpenSpace
+          ls C:\
+
+      - name: Configure CMake
+        run: cmake -B ${{ env.BUILD_DIR }} -DOPENSPACE_ENABLE_ALL_MODULES=ON
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+
+      - name: Build
+        run: |
+          cmake --build ${{ env.BUILD_DIR }} --target OpenSpace --config ${{env.BUILD_TYPE}}
+
+  build-macos:
+    needs: line-count
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-13, macos-12]
+        qt-ver: [6.2, 6.5]
+        xcode-ver: ['latest-stable', 'latest', 'default']
+    runs-on: ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} (Xcode ${{matrix.xcode-ver}}/Qt ${{ matrix.qt-ver }})
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      # This specifies the Xcode version to use, the default is the latest stable version
+      - name: Setup Xcode version
+        if: matrix.xcode-ver != 'default'
+        uses: maxim-lobanov/setup-xcode@v1.5.1
+        with:
+          xcode-version: ${{ matrix.xcode-ver }}
+
+      # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v3.0.0
+        with:
+          version: ${{ matrix.qt-ver }}
+          cache: true
+
+      - name: Install dependencies
+        run: brew install boost glew freeimage mpv vulkan-headers vulkan-loader brotli gdal
+
+      # The project will fail to compile unless you run CMake twice, very strange issue
+      - name: Configure CMake
+        run: |
+          cmake -B ${{ env.BUILD_DIR }} -G "Xcode"
+          cmake -B ${{ env.BUILD_DIR }} -G "Xcode" -DOPENSPACE_ENABLE_ALL_MODULES=ON
+
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --target OpenSpace --config ${{env.BUILD_TYPE}} -- -quiet

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,117 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "**" ]
+
+concurrency:
+  group: "${{ github.workflow }} @${{ github.run_number }}+${{ github.run_attempt }}-${{ github.run_id}}"
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ matrix.os }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    # Self-hosted runners are required for the C++ CodeQL checks due to the GitHub provided runners will time out and hit resource limits.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'self-hosted' ]
+        language: [ 'cpp', 'javascript', 'python' ]
+        exclude:
+          - os: 'self-hosted'
+            language: 'javascript'
+          - os: 'self-hosted'
+            language: 'python'
+          - os: 'ubuntu-latest'
+            language: 'cpp'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    # Helps with disk space issues, OpenSpace builds are large and can cause the runner to fail with a low disk or full disk error
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gdal-bin libgdal-dev libxrandr-dev libxinerama-dev xorg-dev libxcursor-dev libxi-dev libasound2-dev libgdal-dev libboost-dev freeglut3-dev glew-utils libpng-dev libcurl4-openssl-dev libmpv-dev libvulkan-dev zlib1g-dev
+    
+    # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+    - name: Install Qt6
+      uses: jurplel/install-qt-action@v3.0.0
+      with:
+        version: 6.5
+
+    # Increase swapfile size to prevent out of memory errors during builds/anaylsis
+    - name: Increase swapfile
+      run: |
+        sudo swapoff -a
+        sudo fallocate -l 15G /swapfile
+        sudo chmod 600 /swapfile
+        sudo mkswap /swapfile
+        sudo swapon /swapfile
+        sudo swapon --show
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"
+        upload: False
+        output: sarif-results
+
+    # Due to submodules, the analysis results contain a lot of files that are not part of the main repository.
+    - name: Filter analysis
+      uses: advanced-security/filter-sarif@v1
+      with:
+        # filter out all test files unless they contain a sql-injection vulnerability
+        patterns: |
+          -apps/OpenSpace/ext/sgct/**
+          -apps/OpenSpace-MinVR/ext/minvr/**
+          -apps/OpenSpace-MinVR/ext/glfw/**
+          -documentation/**
+          -ext/date/**
+          -ext/ghoul/**
+          -ext/spice/**
+          -modules/kameleon/ext/kameleon/**
+          -modules/fitsfilereader/ext/CCfits/**
+          -modules/fitsfilereader/ext/cfitsio/**
+          -modules/globebrowsing/ext/geos/**
+          -modules/touch/ext/libTUIO11/**
+          -support/coding/codegen/**
+        input: sarif-results/${{ matrix.language }}.sarif
+        output: sarif-results/${{ matrix.language }}.sarif
+
+    - name: Upload filtered CodeQL analysis results
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,347 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'rc/*'
+    tags:
+      - 'releases/*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "${{ github.workflow }} @${{ github.run_number }}+${{ github.run_attempt }}-${{ github.run_id}}"
+  cancel-in-progress: false
+
+# Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+env:
+  BUILD_DIR: ${{ github.workspace }}/build
+  BUILD_DIR_WIN: C:\OpenSpace\build
+
+jobs:
+  deploy-win:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        qt-ver: [6.5]
+    runs-on: ${{ matrix.os }}
+    name: Build Windows Release binaries
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          version: ${{ matrix.qt-ver }}
+          host: "windows"
+          target: "desktop"
+          arch: "win64_msvc2019_64"
+          cache: true
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.3.1
+
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.4
+        id: install-boost
+        with:
+          boost_version: 1.81.0
+          platform_version: 2022
+          toolset: msvc
+
+      # Due to a limitation on free Windows-based GitHub runners, we need a larger build drive, the C:\ drive on the runner will suffice
+      - name: Hack - Move repository to larger drive
+        run: |
+          cp ${{github.workspace}} C:\OpenSpace
+          ls C:\
+
+      - name: Configure CMake
+        run: cmake -DSGCT_BUILD_TESTS=OFF -DGHOUL_HIGH_DEBUG_MODE=OFF -DGHOUL_HAVE_TESTS=OFF -DOPENSPACE_HAVE_TESTS=OFF -DOPENSPACE_ENABLE_ALL_MODULES=ON -B ${{ env.BUILD_DIR_WIN }}
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+
+      - name: Build in RelWithDebInfo mode
+        run: cmake --build ${{ env.BUILD_DIR_WIN }} --config RelWithDebInfo
+
+      - name: Upload PDB artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: pdbs-win
+          path: ${{ github.workspace }}\bin\RelWithDebInfo\*.pdb
+          if-no-files-found: error
+
+      - name: Cleanup files before archiving artifact
+        shell: cmd
+        continue-on-error: true
+        run: |
+          del ${{ github.workspace }}\bin\RelWithDebInfo\*.pdb
+          del ${{ github.workspace }}\bin\RelWithDebInfo\codegen.exe
+          del ${{ github.workspace }}\bin\RelWithDebInfo\Qt6Svg.dll
+          rmdir /S /Q ${{ github.workspace }}\bin\RelWithDebInfo\iconengines
+          rmdir /S /Q ${{ github.workspace }}\bin\RelWithDebInfo\imageformats
+          rmdir /S /Q ${{ github.workspace }}\bin\RelWithDebInfo\networkinformation
+          robocopy ${{ github.workspace }}\\bin\\RelWithDebInfo bin /E /MOV
+          rmdir /S /Q ${{ github.workspace }}\\bin\\RelWithDebInfo
+
+      - name: Reset Documentation
+        continue-on-error: true
+        run: |
+          copy ${{ github.workspace }}\documentation\documentationData.js ${{ github.workspace }}
+          git checkout HEAD -- documentationData.js
+
+      - name: Curl Microsoft VC++ Resistributable
+        continue-on-error: true
+        run: curl "http://aka.ms/vs/17/release/vc_redist.x64.exe" --output vc_redist.x64.exe -L
+
+      - name: Upload OpenSpace artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: OpenSpace-win
+          path: |
+            ${{ github.workspace }}/bin/*
+            config/*
+            data/*
+            documentation/*
+            scripts/*
+            shaders/*
+            ACKNOWLEDGMENTS.md
+            CITATION.cff
+            CODE_OF_CONDUCT.md
+            COMMIT.md
+            CREDITS.md
+            LICENSE.md
+            openspace.cfg
+            README.md
+            vc_redist.x64.exe
+            modules/*/shaders/*
+            modules/*/scripts/*
+            modules/globebrowsing/gdal_data/*
+            modules/webgui/ext/nodejs/node.exe
+            !documentation/.git
+          if-no-files-found: error
+
+  deploy-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        qt-ver: [6.5]
+        compiler:
+          - { compiler: GCC, cc: gcc-11, cxx: g++-11 }
+        generator:
+          - { generator: Make, flag: Unix Makefiles }
+    runs-on: ${{ matrix.os }}
+    name: Build Linux Release binaries
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+      - name: Install Qt6 from aqtinstall
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          version: ${{ matrix.qt-ver }}
+          cache: true
+
+      - name: Install dependencies
+        run: sudo apt-get install -y gdal-bin libgdal-dev libxrandr-dev libxinerama-dev xorg-dev libxcursor-dev libxi-dev libasound2-dev libgdal-dev libboost-dev freeglut3-dev glew-utils libpng-dev libcurl4-openssl-dev libmpv-dev libvulkan-dev zlib1g-dev
+
+      # Helps with disk space issues, OpenSpace builds are large and can cause the runner to fail with a low disk or full disk error
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+      # Increase swapfile size to help with low memory issues during builds
+      - name: Increase swapfile
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l 15G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+
+      - name: Configure CMake
+        env:
+          CC: ${{ matrix.compiler.cc }}
+          CXX: ${{ matrix.compiler.cxx }}
+        run: cmake -G "${{ matrix.generator.flag }}" -B ${{ env.BUILD_DIR }} -DSGCT_BUILD_TESTS=OFF -DGHOUL_HIGH_DEBUG_MODE=OFF -DGHOUL_HAVE_TESTS=OFF -DOPENSPACE_HAVE_TESTS=OFF -DOPENSPACE_ENABLE_ALL_MODULES=ON
+
+      - name: Build in RelWithDebInfo mode
+        env:
+          CC: ${{ matrix.compiler.cc }}
+          CXX: ${{ matrix.compiler.cxx }}
+        run: cmake --build ${{ github.workspace }}/build --config RelWithDebInfo --target OpenSpace
+
+      - name: Cleanup
+        continue-on-error: true
+        run: |
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo/codegen
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo/Qt6Svg
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo/iconengines
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo/imageformats
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo/networkinformation
+          mv ${{ github.workspace }}/bin/RelWithDebInfo/* ${{ github.workspace }}/bin
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo
+
+      - name: Reset Documentation
+        continue-on-error: true
+        run: |
+          cp ${{ github.workspace }}\documentation\documentationData.js ${{ github.workspace }}
+          git checkout HEAD -- documentationData.js
+
+      - name: Upload OpenSpace artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: OpenSpace-linux
+          path: |
+            ${{ github.workspace }}/bin/*
+            config/*
+            data/*
+            documentation/*
+            scripts/*
+            shaders/*
+            ACKNOWLEDGMENTS.md
+            CITATION.cff
+            CODE_OF_CONDUCT.md
+            COMMIT.md
+            CREDITS.md
+            LICENSE.md
+            openspace.cfg
+            README.md
+            modules/*/shaders/*
+            modules/*/scripts/*
+            modules/globebrowsing/gdal_data/*
+            modules/webgui/ext/nodejs/node
+            !documentation/.git
+          if-no-files-found: error
+
+  deploy-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        qt-ver: [6.5]
+    runs-on: ${{ matrix.os }}
+    name: Build macOS Release Binaries
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      # Qt is not friendly to install manually, nor any runner has Qt installed by default, this action resolves this issue
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          version: ${{ matrix.qt-ver }}
+          cache: true
+
+      - name: Install dependencies
+        run: brew install boost glew freeimage mpv vulkan-headers vulkan-loader brotli gdal
+
+      # The project will fail to compile unless you run CMake twice
+      - name: Configure CMake
+        run: |
+          cmake -B ${{ env.BUILD_DIR }} -G "Xcode"
+          cmake -B ${{ env.BUILD_DIR }} -G "Xcode" -DSGCT_BUILD_TESTS=OFF -DGHOUL_HIGH_DEBUG_MODE=OFF -DGHOUL_HAVE_TESTS=OFF -DOPENSPACE_HAVE_TESTS=OFF -DOPENSPACE_ENABLE_ALL_MODULES=ON
+
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/build --config RelWithDebInfo --target OpenSpace -- -quiet
+
+      - name: Cleanup
+        continue-on-error: true
+        run: |
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo/codegen
+          mv ${{ github.workspace }}/bin/RelWithDebInfo ${{ github.workspace }}/bin
+          rm -rf ${{ github.workspace }}/bin/RelWithDebInfo
+
+      - name: Reset Documentation
+        continue-on-error: true
+        run: |
+          cp ${{ github.workspace }}\documentation\documentationData.js ${{ github.workspace }}
+          git checkout HEAD -- documentationData.js
+
+      - name: Upload OpenSpace artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: OpenSpace-macos
+          path: |
+            ${{ github.workspace }}/bin/*
+            config/*
+            data/*
+            documentation/*
+            scripts/*
+            shaders/*
+            ACKNOWLEDGMENTS.md
+            CITATION.cff
+            CODE_OF_CONDUCT.md
+            COMMIT.md
+            CREDITS.md
+            LICENSE.md
+            openspace.cfg
+            README.md
+            modules/*/shaders/*
+            modules/*/scripts/*
+            modules/globebrowsing/gdal_data/*
+            modules/webgui/ext/nodejs/node
+            !documentation/.git
+          if-no-files-found: error
+  
+  gh-release:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    needs: [deploy-win, deploy-linux, deploy-macos]
+    name: Create GitHub Release
+    steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: OpenSpace-win
+          path: ${{ github.workspace }}/OpenSpace-win
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: OpenSpace-linux
+          path: ${{ github.workspace }}/OpenSpace-linux
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: OpenSpace-macos-latest
+          path: ${{ github.workspace }}/OpenSpace-macos
+
+      - name: Zip archives
+        run: |
+          zip -r OpenSpace-win ${{ github.workspace }}/OpenSpace-win
+          zip -r OpenSpace-linux ${{ github.workspace }}/OpenSpace-linux
+          zip -r OpenSpace-macos ${{ github.workspace }}/OpenSpace-macos
+          zip -r pdbs-win ${{ github.workspace }}/pdbs-win
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ github.workspace }}/OpenSpace-win.zip
+            ${{ github.workspace }}/OpenSpace-linux.zip
+            ${{ github.workspace }}/OpenSpace-macos.zip
+            ${{ github.workspace }}/pdbs-win.zip
+          draft: true
+          prerelease: false


### PR DESCRIPTION
The Jenkins build server compiles hundreds of commits and branches. Over time it has been backed up by a large amount of jobs and only a few nodes to cover them all, and even fewer online.

GitHub Actions is a free platform for public repositories to utilize build infrastructure on each push made. 

This can cover a lot more use cases and environments outside the Jenkins infrastructure. As well as get results from builds faster.

List of all possible configurations goes as follows:

* Windows 10/11
  * Visual Studio 2019/2022
  * Qt 6.2/6.5 LTS
* Ubuntu 22.04 LTS
  * GCC 11/12/13
  * Clang 14/15/16/17
  * Ninja/Makefile generator
  * Qt 6.2/6.5 LTS, APT package
* macOS 12/13
  * Xcode 14/15/betas
  * Qt 6.2/6.5 LTS
  
The `build.yml` workflow is a thorough attempt at recreating the `Jenkinsfile` in the repository for builds. This runs every single configuration possible.

The `codeql.yml` workflow is for static analysis of three set languages, C++, JavaScript, and Python. It is recommended to run a single runner locally for a C++ CodeQL action as OpenSpace is so large it maxes out a single runner on GitHub's infrastructure. This will run a specific configuration to not use as many resources since only one configuration is needed. You can spin up one following [this guide](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners).

The `release.yml` workflow automatically drafts releases for new versions when there is a tag or a branch made for a specific release or release candidate. This only uses a set configuration so it won't be using as many resources as it does not need to run multiple configurations for the same Operating System.