### PR TITLE
Add property for actual bounding and interaction sphere value

### DIFF
--- a/include/openspace/scene/scenegraphnode.h
+++ b/include/openspace/scene/scenegraphnode.h
@@ -197,7 +197,9 @@ private:
     glm::dmat4 _modelTransformCached = glm::dmat4(1.0);
 
     properties::DoubleProperty _boundingSphere;
+    properties::DoubleProperty _evaluatedBoundingSphere;
     properties::DoubleProperty _interactionSphere;
+    properties::DoubleProperty _evaluatedInteractionSphere;
     properties::DoubleProperty _approachFactor;
     properties::DoubleProperty _reachFactor;
     properties::BoolProperty _computeScreenSpaceValues;

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -115,7 +115,7 @@ namespace {
         "This read-only property contains the evaluated value for the bounding sphere. "
         "This is the actual value that is used internally within the software. If the "
         "BoundingSphere property is set to -1, it is the computed value, otherwise it "
-        "should match the one set in the property",
+        "matches the one set in the property",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -125,7 +125,7 @@ namespace {
         "This read-only property contains the evaluated value for the interaction sphere. "
         "This is the actual value that is used internally within the software. If the "
         "InteractionSphere property is set to -1, it is the computed value, otherwise it "
-        "should match the one set in the property",
+        "matches the one set in the property",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -109,6 +109,26 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
+    constexpr openspace::properties::Property::PropertyInfo EvalBoundingSphereInfo = {
+        "EvaluatedBoundingSphere",
+        "Evaluated Bounding Sphere (Read Only)",
+        "This read-only property contains the evaluated value for the bounding sphere. "
+        "This is the actual value that is used internally within the software. If the "
+        "BoundingSphere property is set to -1, it is the computed value, otherwise it "
+        "should match the one set in the property",
+        openspace::properties::Property::Visibility::AdvancedUser
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo EvalInteractionSphereInfo = {
+        "EvaluatedInteractionSphere",
+        "Evaluated Interaction Sphere (Read Only)",
+        "This read-only property contains the evaluated value for the interaction sphere. "
+        "This is the actual value that is used internally within the software. If the "
+        "InteractionSphere property is set to -1, it is the computed value, otherwise it "
+        "should match the one set in the property",
+        openspace::properties::Property::Visibility::AdvancedUser
+    };
+
     constexpr openspace::properties::Property::PropertyInfo ApproachFactorInfo = {
         "ApproachFactor",
         "Approach Factor",
@@ -528,7 +548,9 @@ SceneGraphNode::SceneGraphNode()
         )
     }
     , _boundingSphere(BoundingSphereInfo, -1.0, -1.0, 1e12)
+    , _evaluatedBoundingSphere(EvalBoundingSphereInfo)
     , _interactionSphere(InteractionSphereInfo, -1.0, -1.0, 1e12)
+    , _evaluatedInteractionSphere(EvalInteractionSphereInfo)
     , _approachFactor(ApproachFactorInfo, 5.0, 0.0, 1e4)
     , _reachFactor(ReachFactorInfo, 1.25, 0.0, 1e4)
     , _computeScreenSpaceValues(ComputeScreenSpaceInfo, false)
@@ -548,6 +570,7 @@ SceneGraphNode::SceneGraphNode()
     addProperty(_distFromCamToNode);
     addProperty(_screenSizeRadius);
     addProperty(_visibilityDistance);
+
     _boundingSphere.onChange([this]() {
         if (_boundingSphere >= 0.0) {
             _overrideBoundingSphere = _boundingSphere;
@@ -555,11 +578,15 @@ SceneGraphNode::SceneGraphNode()
         else {
             _overrideBoundingSphere = std::nullopt;
         }
+        _evaluatedBoundingSphere = boundingSphere();
     });
     // @TODO (2021-06-30, emmbr) Uncomment this when exponential sliders support
     // negative values
     //_boundingSphere.setExponent(10.f);
     addProperty(_boundingSphere);
+    _evaluatedBoundingSphere.setReadOnly(true);
+    addProperty(_evaluatedBoundingSphere);
+
     _interactionSphere.onChange([this]() {
         if (_interactionSphere >= 0.0) {
             _overrideInteractionSphere = _interactionSphere;
@@ -567,11 +594,14 @@ SceneGraphNode::SceneGraphNode()
         else {
             _overrideInteractionSphere = std::nullopt;
         }
+        _evaluatedInteractionSphere = interactionSphere();
     });
     // @TODO (2021-06-30, emmbr) Uncomment this when exponential sliders support
     // negative values
     //_interactionSphere.setExponent(10.f);
     addProperty(_interactionSphere);
+    _evaluatedInteractionSphere.setReadOnly(true);
+    addProperty(_evaluatedInteractionSphere);
 
     _reachFactor.setExponent(3.f);
     addProperty(_reachFactor);
@@ -606,6 +636,10 @@ void SceneGraphNode::initialize() {
         _transform.scale->initialize();
     }
     _state = State::Initialized;
+
+    // Want this computed after the renderable and transforms have been initialized
+    _evaluatedBoundingSphere = boundingSphere();
+    _evaluatedInteractionSphere = interactionSphere();
 
     LDEBUG(fmt::format("Finished initializing: {}", identifier()));
 }

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -111,7 +111,7 @@ namespace {
 
     constexpr openspace::properties::Property::PropertyInfo EvalBoundingSphereInfo = {
         "EvaluatedBoundingSphere",
-        "Evaluated Bounding Sphere (Read Only)",
+        "Evaluated Bounding Sphere",
         "This read-only property contains the evaluated value for the bounding sphere. "
         "This is the actual value that is used internally within the software. If the "
         "BoundingSphere property is set to -1, it is the computed value, otherwise it "
@@ -121,7 +121,7 @@ namespace {
 
     constexpr openspace::properties::Property::PropertyInfo EvalInteractionSphereInfo = {
         "EvaluatedInteractionSphere",
-        "Evaluated Interaction Sphere (Read Only)",
+        "Evaluated Interaction Sphere",
         "This read-only property contains the evaluated value for the interaction sphere. "
         "This is the actual value that is used internally within the software. If the "
         "InteractionSphere property is set to -1, it is the computed value, otherwise it "


### PR DESCRIPTION
Closes #1828 

Have been wanting this for a while, and now when we talked about adding other read-only properties to display information, I thought it could be a good (and simple) approach for this issue

![image](https://github.com/OpenSpace/OpenSpace/assets/8808894/810a88fe-2ed0-43e6-bf6d-69fada8e51ef)
