### PR TITLE
Issue/2955

### DIFF
--- a/modules/globebrowsing/globebrowsingmodule.cpp
+++ b/modules/globebrowsing/globebrowsingmodule.cpp
@@ -532,22 +532,16 @@ glm::dquat GlobeBrowsingModule::lookDownCameraRotation(
 {
     using namespace globebrowsing;
 
-    // Lookup vector
     const glm::dvec3 positionModelSpace = globe.ellipsoid().cartesianSurfacePosition(
         geo2
     );
-    const glm::dvec3 slightlyNorth = globe.ellipsoid().cartesianSurfacePosition(
-        Geodetic2{ geo2.lat + 0.001, geo2.lon }
-    );
-    const glm::dvec3 lookUpModelSpace = glm::normalize(
-        slightlyNorth - positionModelSpace
-    );
-
-    // Matrix
+    // For globes, we know that the up-direction will always be positive Z.
+    // @TODO (2023-12-06 emmbr) Eventually, we want each scene graph node to be aware of
+    // its own preferred up-direction. At that time, this should no longer be hardcoded
+    const glm::dvec3 lookUpModelSpace = glm::dvec3(0.0, 0.0, 1.0);
     const glm::dmat4 lookAtMatrix =
         glm::lookAt(cameraModelSpace, positionModelSpace, lookUpModelSpace);
 
-    // Set rotation
     const glm::dquat rotation = glm::quat_cast(inverse(lookAtMatrix));
     return rotation;
 }

--- a/modules/globebrowsing/globebrowsingmodule.cpp
+++ b/modules/globebrowsing/globebrowsingmodule.cpp
@@ -513,16 +513,14 @@ void GlobeBrowsingModule::goToGeodetic3(const globebrowsing::RenderableGlobe& gl
     using namespace globebrowsing;
     const glm::dvec3 positionModelSpace = globe.ellipsoid().cartesianPosition(geo3);
 
-
-    const glm::dvec3 slightlyNorth = globe.ellipsoid().cartesianSurfacePosition(
-        Geodetic2{ geo3.geodetic2.lat + 0.001, geo3.geodetic2.lon }
-    );
-
     interaction::NavigationState state;
     state.anchor = globe.owner()->identifier();
     state.referenceFrame = globe.owner()->identifier();
     state.position = positionModelSpace;
-    state.up = slightlyNorth;
+    // For globes, we know that the up-direction will always be positive Z.
+    // @TODO (2023-12-06 emmbr) Eventually, we want each scene graph node to be aware of
+    // its own preferred up-direction. At that time, this should no longer be hardcoded
+    state.up = glm::dvec3(0.0, 0.0, 1.0);
 
     global::navigationHandler->setNavigationStateNextFrame(state);
 }

--- a/modules/globebrowsing/globebrowsingmodule.cpp
+++ b/modules/globebrowsing/globebrowsingmodule.cpp
@@ -525,27 +525,6 @@ void GlobeBrowsingModule::goToGeodetic3(const globebrowsing::RenderableGlobe& gl
     global::navigationHandler->setNavigationStateNextFrame(state);
 }
 
-glm::dquat GlobeBrowsingModule::lookDownCameraRotation(
-                                              const globebrowsing::RenderableGlobe& globe,
-                                                              glm::dvec3 cameraModelSpace,
-                                                            globebrowsing::Geodetic2 geo2)
-{
-    using namespace globebrowsing;
-
-    const glm::dvec3 positionModelSpace = globe.ellipsoid().cartesianSurfacePosition(
-        geo2
-    );
-    // For globes, we know that the up-direction will always be positive Z.
-    // @TODO (2023-12-06 emmbr) Eventually, we want each scene graph node to be aware of
-    // its own preferred up-direction. At that time, this should no longer be hardcoded
-    const glm::dvec3 lookUpModelSpace = glm::dvec3(0.0, 0.0, 1.0);
-    const glm::dmat4 lookAtMatrix =
-        glm::lookAt(cameraModelSpace, positionModelSpace, lookUpModelSpace);
-
-    const glm::dquat rotation = glm::quat_cast(inverse(lookAtMatrix));
-    return rotation;
-}
-
 const globebrowsing::RenderableGlobe*
 GlobeBrowsingModule::castFocusNodeRenderableToGlobe()
 {

--- a/modules/globebrowsing/globebrowsingmodule.h
+++ b/modules/globebrowsing/globebrowsingmodule.h
@@ -111,9 +111,6 @@ private:
     void goToGeodetic3(const globebrowsing::RenderableGlobe& globe,
         globebrowsing::Geodetic3 geo3, bool doResetCameraDirection);
 
-    glm::dquat lookDownCameraRotation(const globebrowsing::RenderableGlobe& globe,
-        glm::dvec3 cameraPositionModelSpace, globebrowsing::Geodetic2 geo2);
-
     properties::UIntProperty _tileCacheSizeMB;
 
     properties::StringProperty _defaultGeoPointTexturePath;


### PR DESCRIPTION
Solves the problem of up being incorrectly set sometimes when going to a globe position using `goToGeo` (i.e. fixes #2955). For nodes like Saturn and Jupiter, North somehow ended up pointing downwards instead of upwards. I guess it had to do with the fact that the reference ellipsoids are much larger for these nodes and that the precision was not enough, but I am not sure

Let me know what you think of the hardcoded up-direction... this is how we do it for the camera paths 

Also, the `lookDownCameraRotation` where I did the extra change, is never used anywhere, so I couldn't test it.  **What do you think about removing this function?**