### PR TITLE
Feature/point cloud labels from csv

### DIFF
--- a/data/assets/examples/pointclouds/points_units_labels.asset
+++ b/data/assets/examples/pointclouds/points_units_labels.asset
@@ -9,7 +9,7 @@ local Example = {
     Type = "RenderablePointCloud",
     File = asset.resource("data/dummydata.csv"),
     Coloring = {
-      FixedColor = { 0.0, 0.3, 1.0 }
+      FixedColor = { 0.3, 0.8, 0.3 }
     },
     DataMapping = {
       -- When loading a CSV file, we need to provide information about which column
@@ -19,7 +19,7 @@ local Example = {
     },
     -- Add a unit to interpret the points to be in kilometers rather than meters
     Unit = "Km",
-    -- Add some labels. We also need to enable them for them ot be visible.
+    -- Add some labels. We also need to enable them for them to be visible.
     -- Since we do not specify a label file (see below), the positions and text of
     -- of the labels will be set based on the information in the CSV file
     Labels = {
@@ -39,6 +39,13 @@ local Example = {
 local Example_LabelFromFile = {
   Identifier = "ExamplePoints_UnitsAndLabels_File",
   Parent = earthAsset.Earth.Identifier,
+  -- Rotate to not overlap with the other dataset
+  Transform = {
+    Rotation = {
+      Type = "StaticRotation",
+      Rotation = { 0, 0, -0.5 * math.pi }
+    }
+  },
   Renderable = {
     Type = "RenderablePointCloud",
     File = asset.resource("data/dummydata.csv"),

--- a/data/assets/examples/pointclouds/points_units_labels.asset
+++ b/data/assets/examples/pointclouds/points_units_labels.asset
@@ -12,9 +12,9 @@ local Example = {
       FixedColor = { 0.3, 0.8, 0.3 }
     },
     DataMapping = {
-      -- When loading a CSV file, we need to provide information about which column
-      -- Corresponds to the name to be used for the labels (this is not required for
-      -- SPECK files)
+      -- When loading labels from a CSV file, we need to provide information about
+      -- which column corresponds to the name to be used for the labels (this is
+      -- not required for SPECK files)
       Name = "number_withNan"
     },
     -- Add a unit to interpret the points to be in kilometers rather than meters
@@ -32,7 +32,7 @@ local Example = {
     Path = "/Example/Point Clouds",
     Description = [[Example of a point cloud with labels created by specifying a 'Name'
       column for the dataset. The positions of the labels will exactly match that of the
-      points and the data values for the positions are interpreted in Kilometers]]
+      points]]
   }
 }
 
@@ -68,8 +68,7 @@ local Example_LabelFromFile = {
   GUI = {
     Name = "Units & Labels (Explicit Label file)",
     Path = "/Example/Point Clouds",
-    Description = [[Example of a point cloud with labels, created from a label file. The
-      positions are given in Kilometers]]
+    Description = [[Example of a point cloud with labels, created from a label file]]
   }
 }
 

--- a/data/assets/examples/pointclouds/points_units_labels.asset
+++ b/data/assets/examples/pointclouds/points_units_labels.asset
@@ -1,6 +1,6 @@
 local earthAsset = asset.require("scene/solarsystem/planets/earth/earth")
 
-
+-- @TODO The labels are not correctly oriented towards the camera!
 
 local Example = {
   Identifier = "ExamplePoints_UnitsAndLabels",
@@ -11,44 +11,81 @@ local Example = {
     Coloring = {
       FixedColor = { 0.0, 0.3, 1.0 }
     },
+    DataMapping = {
+      -- When loading a CSV file, we need to provide information about which column
+      -- Corresponds to the name to be used for the labels (this is not required for
+      -- SPECK files)
+      Name = "number_withNan"
+    },
     -- Add a unit to interpret the points to be in kilometers rather than meters
     Unit = "Km",
-    -- Also load a label file with the same position information as the CSV file.
-    -- The unit should be the same as the renderable
+    -- Add some labels. We also need to enable them for them ot be visible.
+    -- Since we do not specify a label file (see below), the positions and text of
+    -- of the labels will be set based on the information in the CSV file
     Labels = {
       Enabled = true,
-      File = asset.resource("data/dummydata.label"),
-      Size = 7.5,
-      Unit = "Km"
+      Size = 7.5
     }
-    -- @TODO The labels are not correctly oriented towards the camera!
   },
   GUI = {
     Name = "Units & Labels",
     Path = "/Example/Point Clouds",
-    Description = [[Example of a point cloud where a spcific unit is used when
-      interpreting the position values, and text labels are placed at the points]]
+    Description = [[Example of a point cloud with labels created by specifying a 'Name'
+      column for the dataset. The positions of the labels will exactly match that of the
+      points and the data values for the positions are interpreted in Kilometers]]
+  }
+}
+
+local Example_LabelFromFile = {
+  Identifier = "ExamplePoints_UnitsAndLabels_File",
+  Parent = earthAsset.Earth.Identifier,
+  Renderable = {
+    Type = "RenderablePointCloud",
+    File = asset.resource("data/dummydata.csv"),
+    Coloring = {
+      FixedColor = { 0.0, 0.3, 1.0 }
+    },
+    -- Add a unit to interpret the points to be in kilometers rather than meters
+    Unit = "Km",
+    -- Also load a label file with the positions of the label (in this case they are the
+    -- same as in the CSV file, but that is not always the case)
+    Labels = {
+      Enabled = true,
+      File = asset.resource("data/dummydata.label"),
+      Size = 7.5,
+      -- When we add an explicit label file we also have to specify the unit, if it is
+      -- different than meters
+      Unit = "Km"
+    }
+  },
+  GUI = {
+    Name = "Units & Labels (Explicit Label file)",
+    Path = "/Example/Point Clouds",
+    Description = [[Example of a point cloud with labels, created from a label file. The
+      positions are given in Kilometers]]
   }
 }
 
 
 asset.onInitialize(function()
   openspace.addSceneGraphNode(Example)
+  openspace.addSceneGraphNode(Example_LabelFromFile)
 end)
 
 asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Example_LabelFromFile)
   openspace.removeSceneGraphNode(Example)
 end)
 
 asset.export(Example)
-
+asset.export(Example_LabelFromFile)
 
 
 asset.meta = {
   Name = "Example - Point Cloud with Unit and Labels",
   Version = "1.0",
-  Description = [[Example of a point cloud where a spcific unit is used when
-    interpreting the position values, and text labels are placed at the points]],
+  Description = [[Example of point clouds with labels, either set from the data file
+    itself or from a separate .label file]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/include/openspace/data/dataloader.h
+++ b/include/openspace/data/dataloader.h
@@ -119,6 +119,8 @@ namespace label {
 
     Labelset loadFileWithCache(std::filesystem::path path);
 
+    Labelset loadFromDataset(const dataloader::Dataset& dataset);
+
 } // namespace label
 
 namespace color {

--- a/include/openspace/data/datamapping.h
+++ b/include/openspace/data/datamapping.h
@@ -44,6 +44,7 @@ struct DataMapping {
     std::optional<std::string> xColumnName;
     std::optional<std::string> yColumnName;
     std::optional<std::string> zColumnName;
+    std::optional<std::string> nameColumn;
 
     std::optional<float> missingDataValue;
 
@@ -68,6 +69,8 @@ bool isColumnX(const std::string& c, const std::optional<DataMapping>& mapping);
 bool isColumnY(const std::string& c, const std::optional<DataMapping>& mapping);
 
 bool isColumnZ(const std::string& c, const std::optional<DataMapping>& mapping);
+
+bool isNameColumn(const std::string& c, const std::optional<DataMapping>& mapping);
 
 } // namespace openspace::dataloader
 

--- a/include/openspace/rendering/labelscomponent.h
+++ b/include/openspace/rendering/labelscomponent.h
@@ -47,6 +47,21 @@ namespace documentation { struct Documentation; }
 class LabelsComponent : public properties::PropertyOwner, public Fadeable {
 public:
     explicit LabelsComponent(const ghoul::Dictionary& dictionary);
+
+    /**
+     * Create a labels component from an already loaded dataset. That dataset should have
+     * a comment per point to be used for the labels.
+     *
+     * \param dataset The dataset to create the labelset from, including xyz position and
+     * a string to be used for the text.
+     * \param unit The unit to use when interpreting the point information in the dataset
+     * \param dictionary A dictionary with the other information used for constructing
+     * the dataset
+     * \return The created \code LabelsComponent
+     */
+    explicit LabelsComponent(const ghoul::Dictionary& dictionary,
+        const dataloader::Dataset& dataset, DistanceUnit unit);
+
     ~LabelsComponent() override = default;
 
     dataloader::Labelset& labelSet();
@@ -75,6 +90,8 @@ private:
     std::shared_ptr<ghoul::fontrendering::Font> _font = nullptr;
 
     glm::dmat4 _transformationMatrix = glm::dmat4(1.0);
+
+    bool _createdFromDataset = false;
 
     // Properties
     properties::BoolProperty _enabled;

--- a/include/openspace/rendering/labelscomponent.h
+++ b/include/openspace/rendering/labelscomponent.h
@@ -52,12 +52,11 @@ public:
      * Create a labels component from an already loaded dataset. That dataset should have
      * a comment per point to be used for the labels.
      *
+     * \param dictionary A dictionary with the other information used for constructing
+     * the dataset
      * \param dataset The dataset to create the labelset from, including xyz position and
      * a string to be used for the text.
      * \param unit The unit to use when interpreting the point information in the dataset
-     * \param dictionary A dictionary with the other information used for constructing
-     * the dataset
-     * \return The created \code LabelsComponent
      */
     explicit LabelsComponent(const ghoul::Dictionary& dictionary,
         const dataloader::Dataset& dataset, DistanceUnit unit);
@@ -93,7 +92,6 @@ private:
 
     bool _createdFromDataset = false;
 
-    // Properties
     properties::BoolProperty _enabled;
     properties::Vec3Property _color;
     properties::FloatProperty _size;

--- a/modules/base/rendering/grids/renderableboxgrid.cpp
+++ b/modules/base/rendering/grids/renderableboxgrid.cpp
@@ -124,7 +124,6 @@ bool RenderableBoxGrid::isReady() const {
 void RenderableBoxGrid::initialize() {
     if (_hasLabels) {
         _labels->initialize();
-        _labels->loadLabels();
     }
 }
 

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -192,7 +192,6 @@ bool RenderableGrid::isReady() const {
 void RenderableGrid::initialize() {
     if (_hasLabels) {
         _labels->initialize();
-        _labels->loadLabels();
     }
 }
 

--- a/modules/base/rendering/grids/renderableradialgrid.cpp
+++ b/modules/base/rendering/grids/renderableradialgrid.cpp
@@ -169,7 +169,6 @@ bool RenderableRadialGrid::isReady() const {
 void RenderableRadialGrid::initialize() {
     if (_hasLabels) {
         _labels->initialize();
-        _labels->loadLabels();
     }
 }
 

--- a/modules/base/rendering/grids/renderablesphericalgrid.cpp
+++ b/modules/base/rendering/grids/renderablesphericalgrid.cpp
@@ -136,7 +136,6 @@ bool RenderableSphericalGrid::isReady() const {
 void RenderableSphericalGrid::initialize() {
     if (_hasLabels) {
         _labels->initialize();
-        _labels->loadLabels();
     }
 }
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -104,7 +104,10 @@ namespace {
     static const openspace::properties::PropertyOwner::PropertyOwnerInfo LabelsInfo = {
         "Labels",
         "Labels",
-        "The labels for the points"
+        "The labels for the points. If no label file is provided, the labels will be "
+        "created to match the points in the data file. For a CSV file, you should then "
+        "specify which column is the 'Name' column in the data mapping. For SPECK files "
+        "the labels are created from the comment at the end of each line"
     };
 
     constexpr openspace::properties::Property::PropertyInfo RenderOptionInfo = {

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -524,14 +524,6 @@ RenderablePointCloud::RenderablePointCloud(const ghoul::Dictionary& dictionary)
 
     _hasSpriteTexture = p.texture.has_value();
 
-    if (p.labels.has_value()) {
-        _labels = std::make_unique<LabelsComponent>(*p.labels);
-        _hasLabels = true;
-        addPropertySubOwner(_labels.get());
-        // Fading of the labels should also depend on the fading of the renderable
-        _labels->setParentFadeable(this);
-    }
-
     _transformationMatrix = p.transformationMatrix.value_or(_transformationMatrix);
 
     if (p.sizeSettings.has_value() && p.sizeSettings->sizeMapping.has_value()) {
@@ -574,6 +566,22 @@ RenderablePointCloud::RenderablePointCloud(const ghoul::Dictionary& dictionary)
         _nDataPoints = static_cast<unsigned int>(_dataset.entries.size());
     }
 
+    if (p.labels.has_value()) {
+        if (!(*p.labels).hasKey("File") && _hasDataFile) {
+            // Load the labelset from the dataset if no file was included
+            _labels = std::make_unique<LabelsComponent>(*p.labels, _dataset, _unit);
+        }
+        else {
+            _labels = std::make_unique<LabelsComponent>(*p.labels);
+        }
+
+        _hasLabels = true;
+        addPropertySubOwner(_labels.get());
+        // Fading of the labels should also depend on the fading of the renderable
+        _labels->setParentFadeable(this);
+    }
+
+
     // If no scale exponent was specified, compute one that will at least show the points
     // based on the scale of the positions in the dataset
     if (!p.sizeSettings.has_value() || !p.sizeSettings->scaleExponent.has_value()) {
@@ -607,7 +615,6 @@ void RenderablePointCloud::initialize() {
 
     if (_hasLabels) {
         _labels->initialize();
-        _labels->loadLabels();
     }
 }
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -570,7 +570,7 @@ RenderablePointCloud::RenderablePointCloud(const ghoul::Dictionary& dictionary)
     }
 
     if (p.labels.has_value()) {
-        if (!(*p.labels).hasKey("File") && _hasDataFile) {
+        if (!p.labels->hasKey("File") && _hasDataFile) {
             // Load the labelset from the dataset if no file was included
             _labels = std::make_unique<LabelsComponent>(*p.labels, _dataset, _unit);
         }
@@ -583,7 +583,6 @@ RenderablePointCloud::RenderablePointCloud(const ghoul::Dictionary& dictionary)
         // Fading of the labels should also depend on the fading of the renderable
         _labels->setParentFadeable(this);
     }
-
 
     // If no scale exponent was specified, compute one that will at least show the points
     // based on the scale of the positions in the dataset

--- a/modules/digitaluniverse/rendering/renderableplanescloud.cpp
+++ b/modules/digitaluniverse/rendering/renderableplanescloud.cpp
@@ -330,7 +330,6 @@ void RenderablePlanesCloud::initialize() {
 
     if (_hasLabels) {
         _labels->initialize();
-        _labels->loadLabels();
     }
 }
 

--- a/modules/space/rendering/renderableconstellationsbase.cpp
+++ b/modules/space/rendering/renderableconstellationsbase.cpp
@@ -193,7 +193,6 @@ void RenderableConstellationsBase::initialize() {
     }
 
     _labels->initialize();
-    _labels->loadLabels();
 
     for (dataloader::Labelset::Entry& entry : _labels->labelSet().entries) {
         if (!entry.identifier.empty()) {

--- a/src/data/csvloader.cpp
+++ b/src/data/csvloader.cpp
@@ -93,6 +93,7 @@ Dataset loadCsvFile(std::filesystem::path filePath, std::optional<DataMapping> s
     int xColumn = -1;
     int yColumn = -1;
     int zColumn = -1;
+    int nameColumn = -1;
 
     int nDataColumns = 0;
     bool hasExcludeColumns = specs.has_value() && (*specs).hasExcludeColumns();
@@ -114,6 +115,9 @@ Dataset loadCsvFile(std::filesystem::path filePath, std::optional<DataMapping> s
             if (isColumnZ(col, specs)) {
                 zColumn = static_cast<int>(i);
             }
+        }
+        else if (isNameColumn(col, specs)) {
+            nameColumn = static_cast<int>(i);
         }
         else if (hasExcludeColumns && (*specs).isExcludeColumn(col)) {
             skipColumns.push_back(i);
@@ -170,11 +174,14 @@ Dataset loadCsvFile(std::filesystem::path filePath, std::optional<DataMapping> s
             else if (i == zColumn) {
                 entry.position.z = value;
             }
+            else if (i == nameColumn) {
+                // Note that were we use the original stirng value, rather than the
+                // converted one
+                entry.comment = strValue;
+            }
             else {
                 entry.data.push_back(value);
             }
-
-            // @TODO: comment mapping
         }
 
         glm::vec3 positive = glm::abs(entry.position);

--- a/src/data/dataloader.cpp
+++ b/src/data/dataloader.cpp
@@ -467,11 +467,10 @@ Labelset loadFromDataset(const Dataset& dataset) {
         Labelset::Entry label;
         label.position = entry.position;
         label.text = entry.comment.value_or("MISSING LABEL");
-        label.identifier = fmt::format("Point-{}", count); // @TODO: make it possible to configure ID, based on point ID (when it exists)
+        // @TODO: make is possible to configure this identifier?
+        label.identifier = fmt::format("Point-{}", count);
         res.entries.push_back(std::move(label));
     }
-
-    // @TODO Perhaps it's more efficient to cache this information into a file?  DISCUSS!
 
     return res;
 }

--- a/src/data/dataloader.cpp
+++ b/src/data/dataloader.cpp
@@ -458,6 +458,24 @@ Labelset loadFileWithCache(std::filesystem::path filePath) {
     );
 }
 
+Labelset loadFromDataset(const Dataset& dataset) {
+    Labelset res;
+    res.entries.reserve(dataset.entries.size());
+
+    int count = 0;
+    for (const Dataset::Entry& entry : dataset.entries) {
+        Labelset::Entry label;
+        label.position = entry.position;
+        label.text = entry.comment.value_or("MISSING LABEL");
+        label.identifier = fmt::format("Point-{}", count); // @TODO: make it possible to configure ID, based on point ID (when it exists)
+        res.entries.push_back(std::move(label));
+    }
+
+    // @TODO Perhaps it's more efficient to cache this information into a file?  DISCUSS!
+
+    return res;
+}
+
 } // namespace label
 
 namespace color {

--- a/src/data/datamapping.cpp
+++ b/src/data/datamapping.cpp
@@ -75,7 +75,7 @@ namespace {
     // column names should be case sensitive, data value that represents missing
     // values in the dataset, and more. See details for each field / class member.
     //
-    // Note that things related to reading the point position will not be hadled for
+    // Note that things related to reading the point position will not be handled for
     // SPECK files, as for those we always expect the first three values per row to
     // specify the XYZ position
     struct [[codegen::Dictionary(DataMapping)]] Parameters {
@@ -89,7 +89,7 @@ namespace {
         std::optional<std::string> z;
 
         // Specifies the column name for the optional name column. Not valid for SPECK
-        // files, where the name is given by the comment at the end of each line.
+        // files, where the name is given by the comment at the end of each line
         std::optional<std::string> name;
 
         // Specifies whether to do case sensitive checks when reading column names.
@@ -103,7 +103,7 @@ namespace {
         std::optional<float> missingDataValue;
 
         // A list of column names, of columns that will not be loaded into the dataset.
-        // Note that not all data formats support this. E.g. SPECK files do not.
+        // Note that not all data formats support this. E.g. SPECK files do not
         std::optional<std::vector<std::string>> excludeColumns;
     };
 #include "datamapping_codegen.cpp"

--- a/src/rendering/labelscomponent.cpp
+++ b/src/rendering/labelscomponent.cpp
@@ -105,7 +105,7 @@ namespace {
         std::optional<bool> enabled;
 
         // [[codegen::verbatim(FileInfo.description)]]
-        std::filesystem::path file;
+        std::optional<std::filesystem::path> file;
 
         // If true (default), the loaded labels file will be cached so that it can be
         // loaded faster at a later time. Note that this also means that changes in the
@@ -170,7 +170,7 @@ LabelsComponent::LabelsComponent(const ghoul::Dictionary& dictionary)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
 
-    _labelFile = absPath(p.file);
+    _labelFile = absPath(p.file.value_or(""));
     _useCache = p.useCaching.value_or(true);
 
     if (p.unit.has_value()) {
@@ -223,6 +223,22 @@ LabelsComponent::LabelsComponent(const ghoul::Dictionary& dictionary)
     _transformationMatrix = p.transformationMatrix.value_or(_transformationMatrix);
 }
 
+LabelsComponent::LabelsComponent(const ghoul::Dictionary& dictionary,
+                                 const dataloader::Dataset& dataset,
+                                 DistanceUnit unit)
+    :LabelsComponent(dictionary)
+{
+    // The unit should match the one in the dataset, not the one that was included in the
+    // asset (if any)
+    _unit = unit;
+
+    // Load the labelset directly based on the dataset, and keep track of that it has
+    // already been loaded this way
+    _labelset = dataloader::label::loadFromDataset(dataset);
+    _createdFromDataset = true;
+}
+
+
 dataloader::Labelset& LabelsComponent::labelSet() {
     return _labelset;
 }
@@ -238,10 +254,18 @@ void LabelsComponent::initialize() {
         ghoul::fontrendering::FontManager::Outline::Yes,
         ghoul::fontrendering::FontManager::LoadGlyphs::No
     );
+
+    loadLabels();
 }
 
 void LabelsComponent::loadLabels() {
     LINFO(fmt::format("Loading label file {}", _labelFile));
+
+    if (_createdFromDataset) {
+        // The labelset should already have been loaded
+        return;
+    }
+
     if (_useCache) {
         _labelset = dataloader::label::loadFileWithCache(_labelFile);
     }


### PR DESCRIPTION
Add logic to read a "Name" column from a CSV file and use that to create the labels for the points.  Adds an example of how this works as well


Note that the labels currently have a faulty rotation, but to fix that is rather part pf the Labels rewrite that @Roxeena will look into