### PR TITLE
Fix for crash when reading meta of corrupt config file

### DIFF
--- a/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
@@ -588,10 +588,17 @@ bool handleConfigurationFile(QComboBox& box, const std::filesystem::directory_en
 
     // Add tooltip
     if (isJson) {
-        sgct::config::Meta meta = sgct::readMeta(p.path().string(), true);
-        if (!meta.description.empty()) {
+        std::string tooltipDescription;
+        try {
+            sgct::config::Meta meta = sgct::readMeta(p.path().string());
+            tooltipDescription = meta.description;
+        }
+        catch (const sgct::Error&) {
+            tooltipDescription = "(no description available)";
+        }
+        if (!tooltipDescription.empty()) {
             QString toolTip = QString::fromStdString(
-                fmt::format("<p>{}</p>", meta.description)
+                fmt::format("<p>{}</p>", tooltipDescription)
             );
             box.setItemData(box.count() - 1, toolTip, Qt::ToolTipRole);
         }


### PR DESCRIPTION
The launcher calls readMeta in order to get the description to get hover-over tooltip text. If a config file is corrupted (e.g. with a `\` character), then the readMeta function's exception will be caught, and the tooltip will be a "No description available" message.
If user runs with this configuration file, OpenSpace will quit, but with a useful description of why the config file load failed.