### PR TITLE
Add event topic

### DIFF
--- a/include/openspace/events/event.h
+++ b/include/openspace/events/event.h
@@ -80,7 +80,8 @@ struct Event {
         CameraPathStarted,
         CameraPathFinished,
         CameraMovedPosition,
-        Custom
+        Custom,
+        Last // sentinel value
     };
     constexpr explicit Event(Type type_) : type(type_) {}
 

--- a/include/openspace/events/eventengine.h
+++ b/include/openspace/events/eventengine.h
@@ -36,12 +36,19 @@ namespace events { struct Event; }
 
 class EventEngine {
 public:
+    using ScriptCallBack = std::function<void(ghoul::Dictionary)>;
+
     struct ActionInfo {
         events::Event::Type type;
         uint32_t id = std::numeric_limits<uint32_t>::max();
         bool isEnabled = true;
         std::string action;
         std::optional<ghoul::Dictionary> filter;
+    };
+
+    struct TopicInfo {
+        size_t id;
+        ScriptCallBack callback;
     };
 
     /**
@@ -88,6 +95,16 @@ public:
         std::optional<ghoul::Dictionary> filter = std::nullopt);
 
     /**
+     * Registers a new topic for a specific event type.
+     *
+     * \param topicId The id of the topic that will be triggered
+     * \param type The type for which a new topic is registered
+     * \param callback The callback function that will be called on triggered event
+    */
+    void registerEventTopic(size_t topicId, events::Event::Type type,
+        ScriptCallBack callback);
+
+    /**
      * Removing registration for a type/action combination.
      *
      * \param type The type of the action that should be unregistered
@@ -104,6 +121,14 @@ public:
      * \param identifier The unique identifier of the event that should be removed
      */
     void unregisterEventAction(uint32_t identifier);
+
+    /**
+     * Removing registration for a topic/type combination
+     *
+     * \param topicId The id of the topic that should b unregistered
+     * \param type The type of the topic that should be unregistered
+    */
+    void unregisterEventTopic(size_t topicId, events::Event::Type type);
 
     /**
      * Returns the list of all registered actions, sorted by their identifiers.
@@ -134,6 +159,12 @@ public:
      */
     void triggerActions() const;
 
+    /**
+     * Triggers all topics that are registered for events that are in the current event
+     * queue.
+    */
+    void triggerTopics() const;
+
     static scripting::LuaLibrary luaLibrary();
 
 private:
@@ -148,6 +179,8 @@ private:
     /// to be able to return them to a caller and we want it in this unordered_map to make
     /// the lookup really fast. So having this extra wasted memory is probably worth it
     std::unordered_map<events::Event::Type, std::vector<ActionInfo>> _eventActions;
+
+    std::unordered_map<events::Event::Type, std::vector<TopicInfo>> _eventTopics;
 
     static uint32_t nextRegisteredEventId;
 

--- a/include/openspace/events/eventengine.h
+++ b/include/openspace/events/eventengine.h
@@ -36,7 +36,7 @@ namespace events { struct Event; }
 
 class EventEngine {
 public:
-    using ScriptCallBack = std::function<void(ghoul::Dictionary)>;
+    using ScriptCallback = std::function<void(ghoul::Dictionary)>;
 
     struct ActionInfo {
         events::Event::Type type;
@@ -47,8 +47,8 @@ public:
     };
 
     struct TopicInfo {
-        size_t id;
-        ScriptCallBack callback;
+        uint32_t id = std::numeric_limits<uint32_t>::max();
+        ScriptCallback callback;
     };
 
     /**
@@ -102,7 +102,7 @@ public:
      * \param callback The callback function that will be called on triggered event
     */
     void registerEventTopic(size_t topicId, events::Event::Type type,
-        ScriptCallBack callback);
+        ScriptCallback callback);
 
     /**
      * Removing registration for a type/action combination.
@@ -125,7 +125,7 @@ public:
     /**
      * Removing registration for a topic/type combination
      *
-     * \param topicId The id of the topic that should b unregistered
+     * \param topicId The id of the topic that should be unregistered
      * \param type The type of the topic that should be unregistered
     */
     void unregisterEventTopic(size_t topicId, events::Event::Type type);

--- a/include/openspace/events/eventengine.h
+++ b/include/openspace/events/eventengine.h
@@ -123,7 +123,8 @@ public:
     void unregisterEventAction(uint32_t identifier);
 
     /**
-     * Removing registration for a topic/type combination
+     * Removing registration for a topic/type combination, does nothing if topicId or type
+     * combination does not exist
      *
      * \param topicId The id of the topic that should be unregistered
      * \param type The type of the topic that should be unregistered

--- a/modules/server/CMakeLists.txt
+++ b/modules/server/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADER_FILES
   include/topics/cameratopic.h
   include/topics/documentationtopic.h
   include/topics/enginemodetopic.h
+  include/topics/eventtopic.h
   include/topics/flightcontrollertopic.h
   include/topics/getpropertytopic.h
   include/topics/luascripttopic.h
@@ -65,6 +66,7 @@ set(SOURCE_FILES
   src/topics/cameratopic.cpp
   src/topics/documentationtopic.cpp
   src/topics/enginemodetopic.cpp
+  src/topics/eventtopic.cpp
   src/topics/flightcontrollertopic.cpp
   src/topics/getpropertytopic.cpp
   src/topics/luascripttopic.cpp

--- a/modules/server/include/topics/eventtopic.h
+++ b/modules/server/include/topics/eventtopic.h
@@ -26,6 +26,7 @@
 #define __OPENSPACE_MODULE_SERVER___EVENT_TOPIC___H__
 
 #include <modules/server/include/topics/topic.h>
+
 #include <openspace/events/event.h>
 
 namespace openspace::properties { class Property; }
@@ -41,7 +42,7 @@ public:
     bool isDone() const override;
 
 private:
-    // Returns true if there is atleast one subscription active, false otherwise
+    // Returns true if there is at least one subscription active, false otherwise
     bool isSubscribed() const;
 
     std::unordered_map<events::Event::Type, bool> _subscribedEvents;

--- a/modules/server/include/topics/eventtopic.h
+++ b/modules/server/include/topics/eventtopic.h
@@ -1,0 +1,52 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2023                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_MODULE_SERVER___EVENT_TOPIC___H__
+#define __OPENSPACE_MODULE_SERVER___EVENT_TOPIC___H__
+
+#include <modules/server/include/topics/topic.h>
+#include <openspace/events/event.h>
+
+namespace openspace::properties { class Property; }
+
+namespace openspace {
+
+class EventTopic : public Topic {
+public:
+    EventTopic() = default;
+    ~EventTopic() override = default;
+
+    void handleJson(const nlohmann::json& json) override;
+    bool isDone() const override;
+
+private:
+    // Returns true if there is atleast one subscription active, false otherwise
+    bool isSubscribed() const;
+
+    std::unordered_map<events::Event::Type, bool> _subscribedEvents;
+};
+
+} // namespace openspace
+
+#endif // __OPENSPACE_MODULE_SERVER___EVENT_TOPIC___H__

--- a/modules/server/src/connection.cpp
+++ b/modules/server/src/connection.cpp
@@ -30,6 +30,7 @@
 #include <modules/server/include/topics/cameratopic.h>
 #include <modules/server/include/topics/documentationtopic.h>
 #include <modules/server/include/topics/enginemodetopic.h>
+#include <modules/server/include/topics/eventtopic.h>
 #include <modules/server/include/topics/flightcontrollertopic.h>
 #include <modules/server/include/topics/getpropertytopic.h>
 #include <modules/server/include/topics/luascripttopic.h>
@@ -101,6 +102,7 @@ Connection::Connection(std::unique_ptr<ghoul::io::Socket> s, std::string address
     _topicFactory.registerClass<SkyBrowserTopic>("skybrowser");
     _topicFactory.registerClass<CameraTopic>("camera");
     _topicFactory.registerClass<CameraPathTopic>("cameraPath");
+    _topicFactory.registerClass<EventTopic>("event");
 }
 
 void Connection::handleMessage(const std::string& message) {

--- a/modules/server/src/topics/eventtopic.cpp
+++ b/modules/server/src/topics/eventtopic.cpp
@@ -50,6 +50,19 @@ bool EventTopic::isDone() const {
 void EventTopic::handleJson(const nlohmann::json& json) {
     std::vector<std::string> events;
 
+    auto eventJson = json.find("event");
+    auto statusJson = json.find("status");
+
+    if (eventJson == json.end()) {
+        LERROR("Payload does not contain 'event' key");
+        return;
+    }
+
+    if (statusJson == json.end() || !statusJson->is_string()) {
+        LERROR("Status must be a string");
+        return;
+    }
+
     if (json.at("event").is_array()) {
         events = json.at("event").get<std::vector<std::string>>();
     }

--- a/modules/server/src/topics/eventtopic.cpp
+++ b/modules/server/src/topics/eventtopic.cpp
@@ -1,0 +1,111 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2023                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <modules/server/include/topics/eventtopic.h>
+
+#include <modules/server/include/connection.h>
+#include <modules/server/include/jsonconverters.h>
+#include <openspace/engine/globals.h>
+#include <openspace/events/event.h>
+#include <openspace/events/eventengine.h>
+#include <ghoul/fmt.h>
+#include <ghoul/logging/logmanager.h>
+
+namespace {
+    constexpr std::string_view _loggerCat = "EventTopic";
+
+    constexpr std::string_view StartSubscription = "start_subscription";
+    constexpr std::string_view StopSubscription = "stop_subscription";
+} // namespace
+
+using nlohmann::json;
+
+namespace openspace {
+
+bool EventTopic::isDone() const {
+    return !isSubscribed();
+}
+
+void EventTopic::handleJson(const nlohmann::json& json) {
+    std::vector<std::string> events;
+
+    if (json.at("event").is_array()) {
+        events = json.at("event").get<std::vector<std::string>>();
+    }
+    else {
+        const std::string& event = json.at("event").get<std::string>();
+        if (event == "*" || event == "all") {
+            // Iterate over all event types and add them to list
+            const uint8_t lastEvent = static_cast<uint8_t>(events::Event::Type::Last);
+
+            for (uint8_t i = 0; i < lastEvent; i++) {
+                auto type = static_cast<events::Event::Type>(i);
+                events.push_back(std::string(events::toString(type)));
+            }
+        }
+        else {
+            events.push_back(event);
+        }
+    }
+
+    const std::string& status = json.at("status").get<std::string>();
+
+    for (const std::string& event : events) {
+        if (status == StartSubscription) {
+            const events::Event::Type type = events::fromString(event);
+
+            _subscribedEvents[type] = true;
+
+            auto onCallback = [this, event](ghoul::Dictionary params) {
+                // Include the fired event to the caller
+                params.setValue("Event", event);
+                _connection->sendJson(wrappedPayload(params));
+            };
+
+            global::eventEngine->registerEventTopic(_topicId, type, onCallback);
+        }
+        else if (status == StopSubscription) {
+            events::Event::Type type = events::fromString(event);
+            _subscribedEvents.erase(type);
+            global::eventEngine->unregisterEventTopic(_topicId, type);
+        }
+    }
+}
+
+bool EventTopic::isSubscribed() const {
+    if (_subscribedEvents.empty()) {
+        return false;
+    }
+
+    bool hasActiveSubscription = std::any_of(
+        _subscribedEvents.begin(),
+        _subscribedEvents.end(),
+        [](const std::pair<events::Event::Type, bool> subscription) {
+            return subscription.second;
+    });
+
+    return hasActiveSubscription;
+}
+
+} // namespace openspace

--- a/modules/server/src/topics/eventtopic.cpp
+++ b/modules/server/src/topics/eventtopic.cpp
@@ -101,7 +101,7 @@ bool EventTopic::isSubscribed() const {
     bool hasActiveSubscription = std::any_of(
         _subscribedEvents.begin(),
         _subscribedEvents.end(),
-        [](const std::pair<events::Event::Type, bool> subscription) {
+        [](const std::pair<const events::Event::Type, bool>& subscription) {
             return subscription.second;
     });
 

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1321,12 +1321,7 @@ void OpenSpaceEngine::postDraw() {
         events::logAllEvents(e);
     }
     global::eventEngine->triggerActions();
-    while (e) {
-        // @TODO (abock, 2021-08-25) Need to send all events to a topic to be sent out to
-        // others
-
-        e = e->next;
-    }
+    global::eventEngine->triggerTopics();
 
 
     global::eventEngine->postFrameCleanup();

--- a/src/events/event.cpp
+++ b/src/events/event.cpp
@@ -595,6 +595,8 @@ void logAllEvents(const Event* e) {
             case Event::Type::Custom:
                 log(i, *static_cast<const CustomEvent*>(e));
                 break;
+            default:
+                break;
         }
 
         i++;

--- a/src/events/eventengine.cpp
+++ b/src/events/eventengine.cpp
@@ -72,7 +72,7 @@ void EventEngine::registerEventAction(events::Event::Type type,
 }
 
 void EventEngine::registerEventTopic(size_t topicId, events::Event::Type type,
-                                     ScriptCallBack callback)
+                                     ScriptCalback callback)
 {
     TopicInfo ti;
     ti.id = topicId;

--- a/src/events/eventengine.cpp
+++ b/src/events/eventengine.cpp
@@ -72,7 +72,7 @@ void EventEngine::registerEventAction(events::Event::Type type,
 }
 
 void EventEngine::registerEventTopic(size_t topicId, events::Event::Type type,
-                                     ScriptCalback callback)
+                                     ScriptCallback callback)
 {
     TopicInfo ti;
     ti.id = topicId;

--- a/src/events/eventengine.cpp
+++ b/src/events/eventengine.cpp
@@ -29,6 +29,10 @@
 
 #include "eventengine_lua.inl"
 
+namespace {
+    constexpr std::string_view _loggerCat = "EventEngine";
+}
+
 namespace openspace {
 
 uint32_t EventEngine::nextRegisteredEventId = 0;
@@ -143,6 +147,16 @@ void EventEngine::unregisterEventTopic(size_t topicId, events::Event::Type type)
                 _eventTopics.erase(it);
             }
         }
+        else {
+            LWARNING(fmt::format("Could not find registered event '{}' with topicId: {}",
+                events::toString(type), topicId)
+            );
+        }
+    }
+    else {
+        LWARNING(fmt::format("Could not find registered event '{}'",
+            events::toString(type))
+        );
     }
 }
 


### PR DESCRIPTION
Add ability to subscribe to events via js-api. Closes #1810 

example: 

```
  const foo = api.startTopic("event", {
    event: ["RenderableEnabled", "RenderableDisabled"],
    status: "start_subscription"
  });
```
where property `event` can be either a string or a list of strings. To subscribe to all events use `"*"` or `"all"`