### PR TITLE
NavigationState handling

### DIFF
--- a/include/openspace/navigation/navigationstate.h
+++ b/include/openspace/navigation/navigationstate.h
@@ -26,6 +26,7 @@
 #define __OPENSPACE_CORE___NAVIGATIONSTATE___H__
 
 #include <openspace/documentation/documentation.h>
+#include <openspace/json.h>
 #include <optional>
 
 namespace openspace {
@@ -37,12 +38,14 @@ namespace openspace::interaction {
 struct NavigationState {
     NavigationState() = default;
     explicit NavigationState(const ghoul::Dictionary& dictionary);
+    explicit NavigationState(const nlohmann::json& json);
     NavigationState(std::string anchor, std::string aim, std::string referenceFrame,
         glm::dvec3 position, std::optional<glm::dvec3> up = std::nullopt,
         double yaw = 0.0, double pitch = 0.0);
 
     CameraPose cameraPose() const;
     ghoul::Dictionary dictionary() const;
+    nlohmann::json toJson() const;
     static documentation::Documentation Documentation();
 
     std::string anchor;

--- a/include/openspace/util/json_helper.h
+++ b/include/openspace/util/json_helper.h
@@ -25,8 +25,9 @@
 #ifndef __OPENSPACE_CORE___JSON_HELPER___H__
 #define __OPENSPACE_CORE___JSON_HELPER___H__
 
-#include <string>
 #include <openspace/json.h>
+#include <ghoul/misc/dictionary.h>
+#include <string>
 
 namespace openspace {
 

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -557,6 +557,10 @@ void NavigationHandler::saveNavigationState(const std::filesystem::path& filepat
     }
 
     std::filesystem::path absolutePath = absPath(filepath);
+    if (!absolutePath.has_extension()) {
+        // Adding the .navstate extension to the filepath if it came without one
+        absolutePath.replace_extension(".navstate");
+    }
     LINFO(fmt::format("Saving camera position: {}", absolutePath));
 
     std::ofstream ofs(absolutePath);
@@ -580,7 +584,7 @@ void NavigationHandler::loadNavigationState(const std::string& filepath) {
 
     std::ifstream f(filepath);
     std::string contents = std::string(
-        (std::istreambuf_iterator<char>(f)),
+        std::istreambuf_iterator<char>(f),
         std::istreambuf_iterator<char>()
     );
     nlohmann::json json = nlohmann::json::parse(contents);

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -38,7 +38,7 @@ namespace {
 }
 
 /**
- * Return the current navigation state as a lua table. The optional argument is the scene
+ * Return the current navigation state as a Lua table. The optional argument is the scene
  * graph node to use as reference frame. By default, the reference frame will picked based
  * on whether the orbital navigator is currently following the anchor node rotation. If it
  * is, the anchor will be chosen as reference frame. If not, the reference frame will be

--- a/src/navigation/navigationstate.cpp
+++ b/src/navigation/navigationstate.cpp
@@ -104,6 +104,9 @@ NavigationState::NavigationState(const nlohmann::json& json) {
     if (auto it = json.find("referenceframe");  it != json.end()) {
         referenceFrame = it->get<std::string>();
     }
+    else {
+        referenceFrame = anchor;
+    }
 
     if (auto it = json.find("aim");  it != json.end()) {
         aim = it->get<std::string>();
@@ -214,6 +217,9 @@ ghoul::Dictionary NavigationState::dictionary() const {
 
 nlohmann::json NavigationState::toJson() const {
     nlohmann::json result = nlohmann::json::object();
+
+    // Obligatory version number
+    result["version"] = 1;
 
     {
         nlohmann::json posObj = nlohmann::json::object();

--- a/src/navigation/navigationstate.cpp
+++ b/src/navigation/navigationstate.cpp
@@ -89,11 +89,39 @@ NavigationState::NavigationState(const ghoul::Dictionary& dictionary) {
     referenceFrame = p.referenceFrame.value_or(anchor);
     aim = p.aim.value_or(aim);
 
-    if (p.up.has_value()) {
-        up = *p.up;
+    up = p.up;
+    yaw = p.yaw.value_or(yaw);
+    pitch = p.pitch.value_or(pitch);
+}
 
-        yaw = p.yaw.value_or(yaw);
-        pitch = p.pitch.value_or(pitch);
+NavigationState::NavigationState(const nlohmann::json& json) {
+    position.x = json["position"]["x"].get<double>();
+    position.y = json["position"]["y"].get<double>();
+    position.z = json["position"]["z"].get<double>();
+
+    anchor = json["anchor"];
+
+    if (auto it = json.find("referenceframe");  it != json.end()) {
+        referenceFrame = it->get<std::string>();
+    }
+
+    if (auto it = json.find("aim");  it != json.end()) {
+        aim = it->get<std::string>();
+    }
+
+    if (auto it = json.find("up");  it != json.end()) {
+        up = glm::dvec3();
+        up->x = it->at("x").get<double>();
+        up->y = it->at("y").get<double>();
+        up->z = it->at("z").get<double>();
+    }
+
+    if (auto it = json.find("yaw");  it != json.end()) {
+        yaw = it->get<double>();
+    }
+
+    if (auto it = json.find("pitch");  it != json.end()) {
+        pitch = it->get<double>();
     }
 }
 
@@ -174,16 +202,53 @@ ghoul::Dictionary NavigationState::dictionary() const {
     }
     if (up.has_value()) {
         cameraDict.setValue("Up", *up);
+    }
+    if (std::abs(yaw) > Epsilon) {
+        cameraDict.setValue("Yaw", yaw);
+    }
+    if (std::abs(pitch) > Epsilon) {
+        cameraDict.setValue("Pitch", pitch);
+    }
+    return cameraDict;
+}
 
-        if (std::abs(yaw) > Epsilon) {
-            cameraDict.setValue("Yaw", yaw);
-        }
-        if (std::abs(pitch) > Epsilon) {
-            cameraDict.setValue("Pitch", pitch);
-        }
+nlohmann::json NavigationState::toJson() const {
+    nlohmann::json result = nlohmann::json::object();
+
+    {
+        nlohmann::json posObj = nlohmann::json::object();
+        posObj["x"] = position.x;
+        posObj["y"] = position.y;
+        posObj["z"] = position.z;
+        result["position"] = posObj;
     }
 
-    return cameraDict;
+    result["anchor"] = anchor;
+
+    if (anchor != referenceFrame) {
+        result["referenceframe"] = referenceFrame;
+    }
+
+    if (!aim.empty()) {
+        result["aim"] = aim;
+    }
+
+    if (up.has_value()) {
+        nlohmann::json upObj = nlohmann::json::object();
+        upObj["x"] = up->x;
+        upObj["y"] = up->y;
+        upObj["z"] = up->z;
+        result["up"] = upObj;
+    }
+
+    if (std::abs(yaw) > Epsilon) {
+        result["yaw"] = yaw;
+    }
+    if (std::abs(pitch) > Epsilon) {
+        result["pitch"] = pitch;
+    }
+
+    return result;
 }
 
 documentation::Documentation NavigationState::Documentation() {


### PR DESCRIPTION
Change the navigation state format from Lua to JSON (applies to `openspace.navigation.saveNavigationState` and `openspace.navigation.loadNavigationState`. Before, the `yaw` and `pitch` values were ignored if the `up` vector was not specified. Now, these three values are loaded independently.

Add the ability to set the navigation state in the profile editor based on the new JSON format.