### PR TITLE
Issue/3043 Added point outlines (RenderablePointCloud)

### DIFF
--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -232,26 +232,24 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo EnableOutlineInfo = {
         "EnableOutline",
         "Enable Point Outline",
-        "This setting determines if each point should have an outline or not. "
-        "An outline is only applied when rendering as colored points "
-        "(not when using textures).",
+        "This setting determines if each point should have an outline or not. An outline "
+        "is only applied when rendering as colored points (not when using textures).",
         openspace::properties::Property::Visibility::User
     };
 
     constexpr openspace::properties::Property::PropertyInfo OutlineColorInfo = {
         "OutlineColor",
         "Outline Color",
-        "This value defines the color of the outline. "
-        "Darker colors will be less visible if Additive Blending is enabled.",
+        "This value defines the color of the outline. Darker colors will be "
+        "less visible if Additive Blending is enabled.",
         openspace::properties::Property::Visibility::User
     };
 
     constexpr openspace::properties::Property::PropertyInfo OutlineWeightInfo = {
         "OutlineWeight",
         "Outline Weight",
-        "This setting determines the thickness of the outline. "
-        "A value of 0.0 will not show any outline, while a value of 1.0 will "
-        "cover the whole point.",
+        "This setting determines the thickness of the outline. A value of 0 will "
+        "not show any outline, while a value of 1 will cover the whole point.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -455,7 +453,7 @@ RenderablePointCloud::ColorSettings::ColorSettings(const ghoul::Dictionary& dict
     : properties::PropertyOwner({ "Coloring", "Coloring", "" })
     , pointColor(PointColorInfo, glm::vec3(1.f), glm::vec3(0.f), glm::vec3(1.f))
     , enableOutline(EnableOutlineInfo, false)
-    , outlineColor(OutlineColorInfo, glm::vec3(0.23f), glm::vec3(0.f), glm::vec3(1.0))
+    , outlineColor(OutlineColorInfo, glm::vec3(0.23f), glm::vec3(0.f), glm::vec3(1.f))
     , outlineWeight(OutlineWeightInfo, 0.2f, 0.f, 1.f)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
@@ -475,18 +473,15 @@ RenderablePointCloud::ColorSettings::ColorSettings(const ghoul::Dictionary& dict
     pointColor.setViewOption(properties::Property::ViewOptions::Color);
     addProperty(pointColor);
 
-    if (hasColoring) {
-        const Parameters::ColorSettings settings = *p.coloring;
-        enableOutline = settings.enableOutline.value_or(enableOutline);
-        addProperty(enableOutline);
+    enableOutline = p.coloring->enableOutline.value_or(enableOutline);
+    addProperty(enableOutline);
 
-        outlineColor.setViewOption(properties::Property::ViewOptions::Color);
-        outlineColor = settings.outlineColor.value_or(outlineColor);
-        addProperty(outlineColor);
+    outlineColor.setViewOption(properties::Property::ViewOptions::Color);
+    outlineColor = p.coloring->outlineColor.value_or(outlineColor);
+    addProperty(outlineColor);
 
-        outlineWeight = settings.outlineWeight.value_or(outlineWeight);
-        addProperty(outlineWeight);
-    }
+    outlineWeight = p.coloring->outlineWeight.value_or(outlineWeight);
+    addProperty(outlineWeight);
 
 }
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -231,22 +231,27 @@ namespace {
 
     constexpr openspace::properties::Property::PropertyInfo EnableOutlineInfo = {
         "EnableOutline",
-        "Outline Enabled",
-        "Enables the outline for each data point",
+        "Enable Point Outline",
+        "This setting determines if each point should have an outline or not. "
+        "An outline is only applied when rendering as colored points "
+        "(not when using textures).",
         openspace::properties::Property::Visibility::User
     };
 
     constexpr openspace::properties::Property::PropertyInfo OutlineColorInfo = {
         "OutlineColor",
         "Outline Color",
-        "Sets the color of the outline.",
+        "This value defines the color of the outline. "
+        "Darker colors will be less visible if Additive Blending is enabled.",
         openspace::properties::Property::Visibility::User
     };
 
     constexpr openspace::properties::Property::PropertyInfo OutlineWeightInfo = {
         "OutlineWeight",
         "Outline Weight",
-        "Determines how thick the outline is.",
+        "This setting determines the thickness of the outline. "
+        "A value of 0.0 will not show any outline, while a value of 1.0 will "
+        "cover the whole point.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.h
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.h
@@ -132,6 +132,9 @@ protected:
         explicit ColorSettings(const ghoul::Dictionary& dictionary);
         properties::Vec3Property pointColor;
         std::unique_ptr<ColorMappingComponent> colorMapping;
+        properties::BoolProperty enableOutline;
+        properties::Vec3Property outlineColor;
+        properties::FloatProperty outlineWeight;
     };
     ColorSettings _colorSettings;
 
@@ -162,7 +165,7 @@ protected:
         right, fadeInValue, hasSpriteTexture, spriteTexture, useColormap, colorMapTexture,
         cmapRangeMin, cmapRangeMax, nanColor, useNanColor, hideOutsideRange,
         enableMaxSizeControl, aboveRangeColor, useAboveRangeColor, belowRangeColor,
-        useBelowRangeColor, hasDvarScaling
+        useBelowRangeColor, hasDvarScaling, enableOutline, outlineColor, outlineWeight
     ) _uniformCache;
 
     std::string _dataFile;

--- a/modules/base/shaders/pointcloud/billboardpoint_fs.glsl
+++ b/modules/base/shaders/pointcloud/billboardpoint_fs.glsl
@@ -49,6 +49,9 @@ uniform sampler1D colorMapTexture;
 uniform float cmapRangeMin;
 uniform float cmapRangeMax;
 uniform bool hideOutsideRange;
+uniform bool enableOutline;
+uniform vec3 outlineColor;
+uniform float outlineWeight;
 
 uniform float fadeInValue;
 
@@ -80,24 +83,28 @@ Fragment getFragment() {
     discard;
   }
 
-   if (!hasSpriteTexture) {
-    // Moving the origin to the center
-    vec2 st = (texCoord - vec2(0.5)) * 2.0;
-    if (length(st) > 1.0) {
+  // Moving the origin to the center and calculating the length
+  float lengthFromCenter = length((texCoord - vec2(0.5)) * 2.0);
+  if (!hasSpriteTexture) {
+    if (lengthFromCenter > 1.0) {
       discard;
     }
   }
 
   vec4 fullColor = vec4(1.0);
-  if (hasSpriteTexture) {
-    fullColor = texture(spriteTexture, texCoord);
-  }
-
   if (useColorMap) {
-    fullColor *= sampleColorMap(gs_colorParameter);
+    fullColor = sampleColorMap(gs_colorParameter);
   }
   else {
-    fullColor.rgb *= color;
+    fullColor.rgb = color;
+  }
+
+  if (hasSpriteTexture) {
+    fullColor *= texture(spriteTexture, texCoord);
+  } else if (enableOutline) {
+    if (lengthFromCenter > (1.0 - outlineWeight)) {
+      fullColor.rgb = outlineColor;
+    }
   }
 
   fullColor.a *= opacity * fadeInValue;

--- a/modules/base/shaders/pointcloud/billboardpoint_fs.glsl
+++ b/modules/base/shaders/pointcloud/billboardpoint_fs.glsl
@@ -101,10 +101,8 @@ Fragment getFragment() {
 
   if (hasSpriteTexture) {
     fullColor *= texture(spriteTexture, texCoord);
-  } else if (enableOutline) {
-    if (lengthFromCenter > (1.0 - outlineWeight)) {
-      fullColor.rgb = outlineColor;
-    }
+  } else if (enableOutline && (lengthFromCenter > (1.0 - outlineWeight))) {
+    fullColor.rgb = outlineColor;
   }
 
   fullColor.a *= opacity * fadeInValue;


### PR DESCRIPTION
Added support for an outline when rendering data as points.
The outline can be enabled/disabled and both thickness and color can be set via GUI and `Assets`.

Additive blending with border
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/2abee825-3bc0-45f0-a02b-b61f7ee24664)


Standard blending with border
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/7f4b2c44-6b06-4213-af8c-b67d80f2a398)


Uniform color with border
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/9fbdff74-0caf-4088-b1d0-f4fd271d1e4a)


Uniform color without border
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/01582330-bebf-4f06-80d6-e28fb6d98a3c)


Changed outline color
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/046036a8-399a-4c4c-b416-9ebc35ef6fa6)

Changed outline weight (thickness)
![image](https://github.com/OpenSpace/OpenSpace/assets/9076357/82be7a2a-e213-4b40-9cac-4258a52e2faf)
