### PR TITLE
Add the ability to convert TLE files to SPICE kernels and apply change to ISS

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -20,6 +20,15 @@ local omm = asset.resource({
   SecondsUntilResync = 24 * 60 * 60
 })
 
+local tle = asset.resource({
+  Name = "Satellite TLE Data (ISS)",
+  Type = "UrlSynchronization",
+  Identifier = "satellite_tle_data_iss",
+  Url = "https://www.celestrak.com/NORAD/elements/gp.php?CATNR=25544&FORMAT=tle",
+  Filename = "ISS.txt",
+  SecondsUntilResync = 24 * 60 * 60
+})
+
 
 local IssPosition = {
   Identifier = "ISSPosition",
@@ -27,10 +36,14 @@ local IssPosition = {
   BoundingSphere = 54.5, -- half the width
   Transform = {
     Translation = {
-      Type = "GPTranslation",
-      Observer = transforms.EarthInertial.Identifier,
-      File = omm .. "ISS.txt",
-      Format = "OMM"
+      Type = "SpiceTranslation",
+      Target = "<<patched in onInitialize>>",
+      Observer = coreKernels.ID.Earth,
+      Frame = coreKernels.Frame.J2000
+      -- Type = "GPTranslation",
+      -- Observer = transforms.EarthInertial.Identifier,
+      -- File = omm .. "ISS.txt",
+      -- Format = "OMM"
     },
     Rotation = {
       Type = "SpiceRotation",
@@ -80,6 +93,33 @@ local IssTrail = {
   Renderable = {
     Type = "RenderableTrailOrbit",
     Translation = {
+      Type = "SpiceTranslation",
+      Target = "<<patched in onInitialize>>",
+      Observer = coreKernels.ID.Earth,
+      Frame = coreKernels.Frame.J2000
+      -- Type = "GPTranslation",
+      -- Observer = transforms.EarthInertial.Identifier,
+      -- File = omm .. "ISS.txt",
+      -- Format = "OMM"
+    },
+    RenderBinMode = "PostDeferredTransparent",
+    Color = { 0.9, 0.6715, 0.0 },
+    Fade = 1.5,
+    Resolution = 320
+  },
+  Tag = { "earth_satellite", "ISS" },
+  GUI = {
+    Name = "ISS Trail",
+    Path = "/Solar System/Planets/Earth/Satellites/ISS"
+  }
+}
+
+local IssTrailold = {
+  Identifier = "ISS_trailOLD",
+  Parent = transforms.EarthInertial.Identifier,
+  Renderable = {
+    Type = "RenderableTrailOrbit",
+    Translation = {
       Type = "GPTranslation",
       Observer = transforms.EarthInertial.Identifier,
       File = omm .. "ISS.txt",
@@ -92,7 +132,7 @@ local IssTrail = {
   },
   Tag = { "earth_satellite", "ISS" },
   GUI = {
-    Name = "ISS Trail",
+    Name = "ISS Trail old",
     Path = "/Solar System/Planets/Earth/Satellites/ISS"
   }
 }
@@ -138,18 +178,32 @@ local FocusIss = {
 asset.onInitialize(function()
   local i = openspace.space.readKeplerFile(omm .. "ISS.txt", "OMM")
   IssTrail.Renderable.Period = i[1].Period / (60 * 60 * 24)
+  IssTrailold.Renderable.Period = i[1].Period / (60 * 60 * 24)
+
+  -- Convert the TLE file into a SPICE kernel
+  local id, startTime, endTime = openspace.spice.convertTLEtoSPK(
+    tle .. "ISS.txt",
+    openspace.absPath("${TEMPORARY}/ISS.bsp")
+  )
+  openspace.spice.loadKernel(openspace.absPath("${TEMPORARY}/ISS.bsp"))
+  IssPosition.Transform.Translation.Target = tostring(id);
+  IssTrail.Renderable.Translation.Target = tostring(id);
 
   openspace.addSceneGraphNode(IssPosition)
   openspace.addSceneGraphNode(IssModel)
   openspace.addSceneGraphNode(IssTrail)
+  openspace.addSceneGraphNode(IssTrailold)
 
   openspace.setPropertyValueSingle("Scene.ISS.Rotation.yAxisInvertObject", true)
   openspace.action.registerAction(FocusIss)
 end)
 
 asset.onDeinitialize(function()
+  openspace.spice.unloadKernel(openspace.absPath("${TEMPORARY}/ISS.bsp"))
+
   openspace.action.removeAction(FocusIss)
 
+  openspace.removeSceneGraphNode(IssTrailold)
   openspace.removeSceneGraphNode(IssTrail)
   openspace.removeSceneGraphNode(IssModel)
   openspace.removeSceneGraphNode(IssPosition)

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -11,6 +11,13 @@ local models = asset.resource({
   Version = 3
 })
 
+local kernels = asset.resource({
+  Name = "ISS Kernels",
+  Type = "HttpSynchronization",
+  Identifier = "iss_kernels",
+  Version = 1
+})
+
 local omm = asset.resource({
   Name = "Satellite OMM Data (ISS)",
   Type = "UrlSynchronization",
@@ -35,21 +42,7 @@ local IssPosition = {
   Parent = transforms.EarthInertial.Identifier,
   BoundingSphere = 54.5, -- half the width
   Transform = {
-    Translation = {
-      Type = "SpiceTranslation",
-      Target = "<<patched in onInitialize>>",
-      Observer = coreKernels.ID.Earth,
-      Frame = coreKernels.Frame.J2000
-      -- Type = "GPTranslation",
-      -- Observer = transforms.EarthInertial.Identifier,
-      -- File = omm .. "ISS.txt",
-      -- Format = "OMM"
-    },
-    Rotation = {
-      Type = "SpiceRotation",
-      SourceFrame = coreKernels.Frame.Galactic,
-      DestinationFrame = coreKernels.Frame.J2000
-    }
+    Translation = {}, -- This translation is provided in the onInitialize
   },
   Tag = { "earth_satellite", "ISS" },
   GUI = {
@@ -64,11 +57,9 @@ local IssModel = {
   Parent = IssPosition.Identifier,
   Transform = {
     Rotation = {
-      Type = "FixedRotation",
-      Attached = "ISS",
-      XAxis = { 0.01, -1.0, 0.56 },
-      XAxisOrthogonal = true,
-      YAxis = transforms.EarthInertial.Identifier
+      Type = "SpiceRotation",
+      SourceFrame = "ISS",
+      DestinationFrame = coreKernels.Frame.J2000
     }
   },
   Renderable = {
@@ -92,16 +83,7 @@ local IssTrail = {
   Parent = transforms.EarthInertial.Identifier,
   Renderable = {
     Type = "RenderableTrailOrbit",
-    Translation = {
-      Type = "SpiceTranslation",
-      Target = "<<patched in onInitialize>>",
-      Observer = coreKernels.ID.Earth,
-      Frame = coreKernels.Frame.J2000
-      -- Type = "GPTranslation",
-      -- Observer = transforms.EarthInertial.Identifier,
-      -- File = omm .. "ISS.txt",
-      -- Format = "OMM"
-    },
+    Translation = {}, -- This translation is provided in the onInitialize
     RenderBinMode = "PostDeferredTransparent",
     Color = { 0.9, 0.6715, 0.0 },
     Fade = 1.5,
@@ -110,29 +92,6 @@ local IssTrail = {
   Tag = { "earth_satellite", "ISS" },
   GUI = {
     Name = "ISS Trail",
-    Path = "/Solar System/Planets/Earth/Satellites/ISS"
-  }
-}
-
-local IssTrailold = {
-  Identifier = "ISS_trailOLD",
-  Parent = transforms.EarthInertial.Identifier,
-  Renderable = {
-    Type = "RenderableTrailOrbit",
-    Translation = {
-      Type = "GPTranslation",
-      Observer = transforms.EarthInertial.Identifier,
-      File = omm .. "ISS.txt",
-      Format = "OMM"
-    },
-    RenderBinMode = "PostDeferredTransparent",
-    Color = { 0.9, 0.6715, 0.0 },
-    Fade = 1.5,
-    Resolution = 320
-  },
-  Tag = { "earth_satellite", "ISS" },
-  GUI = {
-    Name = "ISS Trail old",
     Path = "/Solar System/Planets/Earth/Satellites/ISS"
   }
 }
@@ -175,35 +134,33 @@ local FocusIss = {
 }
 
 
+local kernelFile
 asset.onInitialize(function()
+  local translation, kernel = openspace.space.tleToSpiceTranslation(tle .. "ISS.txt")
+  kernelFile = kernel -- Store the path for the deinitialize function
+  openspace.spice.loadKernel(kernelFile)
+  IssPosition.Transform.Translation = translation;
+  IssTrail.Renderable.Translation = translation;
+
+  openspace.spice.loadKernel(kernels .. "iss.tf")
+
   local i = openspace.space.readKeplerFile(omm .. "ISS.txt", "OMM")
   IssTrail.Renderable.Period = i[1].Period / (60 * 60 * 24)
-  IssTrailold.Renderable.Period = i[1].Period / (60 * 60 * 24)
 
-  -- Convert the TLE file into a SPICE kernel
-  local id, startTime, endTime = openspace.spice.convertTLEtoSPK(
-    tle .. "ISS.txt",
-    openspace.absPath("${TEMPORARY}/ISS.bsp")
-  )
-  openspace.spice.loadKernel(openspace.absPath("${TEMPORARY}/ISS.bsp"))
-  IssPosition.Transform.Translation.Target = tostring(id);
-  IssTrail.Renderable.Translation.Target = tostring(id);
 
   openspace.addSceneGraphNode(IssPosition)
   openspace.addSceneGraphNode(IssModel)
   openspace.addSceneGraphNode(IssTrail)
-  openspace.addSceneGraphNode(IssTrailold)
 
-  openspace.setPropertyValueSingle("Scene.ISS.Rotation.yAxisInvertObject", true)
   openspace.action.registerAction(FocusIss)
 end)
 
 asset.onDeinitialize(function()
-  openspace.spice.unloadKernel(openspace.absPath("${TEMPORARY}/ISS.bsp"))
+  openspace.spice.unloadKernel(kernels .. "iss.tf")
+  openspace.spice.unloadKernel(kernelFile)
 
   openspace.action.removeAction(FocusIss)
 
-  openspace.removeSceneGraphNode(IssTrailold)
   openspace.removeSceneGraphNode(IssTrail)
   openspace.removeSceneGraphNode(IssModel)
   openspace.removeSceneGraphNode(IssPosition)
@@ -217,7 +174,7 @@ asset.export(IssPosition)
 
 asset.meta = {
   Name = "ISS",
-  Version = "2.0",
+  Version = "3.0",
   Description = [[Model and Trail for ISS. Model from NASA 3D models, trail from
     Celestrak.]],
   Author = "OpenSpace Team",

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -136,6 +136,11 @@ local FocusIss = {
 
 local kernelFile
 asset.onInitialize(function()
+  -- In order to get the orientation of the ISS correctly, we need to have its position
+  -- available as a SPICE object. We don't want to just convert the TLE file once as we
+  -- want it to update with every startup.
+  -- For this reason we convert the TLE file into a type 10 SPICE kernel and since we are
+  -- already doing that, we can also get a more accurate position for free, too
   local translation, kernel = openspace.space.tleToSpiceTranslation(tle .. "ISS.txt")
   kernelFile = kernel -- Store the path for the deinitialize function
   openspace.spice.loadKernel(kernelFile)

--- a/include/openspace/util/spicemanager.h
+++ b/include/openspace/util/spicemanager.h
@@ -1122,6 +1122,12 @@ private:
      */
     void loadLeapSecondsSpiceKernel();
 
+    /**
+     * Loads pre defined geophysical constants kernel (geophysical.ker)
+     */
+    void loadGeophysicalConstantsKernel();
+
+
     /// A list of all loaded kernels
     std::vector<KernelInformation> _loadedKernels;
 

--- a/modules/space/scripts/spice.lua
+++ b/modules/space/scripts/spice.lua
@@ -1,0 +1,46 @@
+openspace.space.documentation = {
+  {
+    Name = "tleToSpiceTranslation",
+    Arguments = { tlePath = "String" },
+    Return = "{ Translation, SpiceKernel }",
+    Documentation = [[
+        Takes the provided TLE file, converts it into a SPICE kernel and returns a
+        SpiceTranslation instance that can be used to access the information in the TLE
+        file using SPICE's superior integral solver.
+
+        The second return value is the spice kernel that should be loaded and unloaded by
+        whoever called this function.
+    ]]
+  }
+}
+
+openspace.space.tleToSpiceTranslation = function(tlePath)
+  --
+  -- First we have to create a name for the temporary file
+  --
+
+  -- We first pass the path through the absPath function to both get rid of path tokens,
+  -- but more importantly harmonize the path separators so we don't have to deal with
+  -- / and \ variants
+  tlePath = openspace.absPath(tlePath)
+
+  -- We don't have a function to return the file component so we extract the directory
+  -- and remove as many characters as it is long instead
+  local dirComponent = openspace.directoryForPath(tlePath)
+  -- +2 because the sub function is inclusive and we have a trailing \ or / at the end
+  local filename = tlePath:sub(dirComponent:len() + 2, tlePath:len())
+  local temporaryFile = openspace.absPath("${TEMPORARY}/" .. filename .. ".bsp")
+  -- Now the temporary file for, for example ISS.txt will be the solution for:
+  -- ${TEMPORARY}/ISS.txt.bsp
+
+  local id = openspace.spice.convertTLEtoSPK(tlePath, temporaryFile)
+
+  local translation = {
+    Type = "SpiceTranslation",
+    Target = tostring(id),
+    Observer = "Earth",
+    Frame = "J2000"
+  }
+
+  return translation, temporaryFile
+end

--- a/modules/space/spacemodule.cpp
+++ b/modules/space/spacemodule.cpp
@@ -45,6 +45,7 @@
 #include <openspace/util/coordinateconversion.h>
 #include <openspace/util/factorymanager.h>
 #include <openspace/util/spicemanager.h>
+#include <ghoul/filesystem/filesystem.h>
 #include <ghoul/misc/assert.h>
 #include <ghoul/misc/templatefactory.h>
 
@@ -138,11 +139,14 @@ std::vector<documentation::Documentation> SpaceModule::documentations() const {
 
 scripting::LuaLibrary SpaceModule::luaLibrary() const {
     return {
-        "space",
-        {
+        .name = "space",
+        .functions = {
             codegen::lua::ConvertFromRaDec,
             codegen::lua::ConvertToRaDec,
             codegen::lua::ReadKeplerFile
+        },
+        .scripts = {
+            absPath("${MODULE_SPACE}/scripts/spice.lua")
         }
     };
 }

--- a/src/util/spicemanager.cpp
+++ b/src/util/spicemanager.cpp
@@ -156,6 +156,7 @@ SpiceManager::SpiceManager() {
     errprt_c("SET", 0, const_cast<char*>("NONE"));
 
     loadLeapSecondsSpiceKernel();
+    loadGeophysicalConstantsKernel();
 }
 
 SpiceManager::~SpiceManager() {
@@ -1525,6 +1526,140 @@ DELTET/DELTA_AT        = ( 10,   @1972-JAN-1
     std::filesystem::remove(file);
 }
 
+void SpiceManager::loadGeophysicalConstantsKernel() {
+    constexpr std::string_view GeoPhysicalConstantsKernelSource = R"(
+KPL/PCK
+
+      The SPK creations applications (mkspk, mkspk_c) require the data in
+      this kernel to produce Type 10 SPK segments based upon the Two-Line
+      element sets available from NORAD/SPACETRACK. The data applies ONLY
+      to the Two-Line Element sets and only to the SGP4 implementations
+      included in the SPICE library [1][2]. The SPK application copies 
+      this data to the constants partition of the Type 10 segment, so the
+      user has no need for the kernel after creation of the corresponding
+      SPK.
+
+      Bill Taber (JPL)
+      Edward Wright (JPL)
+
+      The assigned values are taken from the Spacetrack #3 report, referred
+      to as WGS721 in Vallado [2]. It is possible to edit this file
+      to use the high accuracy WGS-72 values (WGS72) or the WGS-84
+      values (WGS84). The KE parameter value for WGS72 and WGS84
+      is calculated from the MU and ER values. The lists include MU only
+      for the calculation of KE.
+
+      MU, the standard gravitational parameter, in cubic kilometer per
+      second squared.
+
+      WGS721 (STR#3 values) [1]
+
+         ER =    6378.135
+
+         J2   =    0.001082616
+         J3   =   -0.00000253881
+         J4   =   -0.00000165597
+
+         KE   =    0.0743669161
+
+
+      WGS72 [2]
+
+         MU   =  398600.8
+         ER   =  6378.135
+
+         J2   =   0.001082616
+         J3   =  -0.00000253881
+         J4   =  -0.00000165597
+
+         KE   =  60.0D0/DSQRT(ER**3/MU)
+              =  0.074366916133173
+
+
+      WGS84 [2]
+
+         MU   =  398600.5
+         ER   =  6378.137
+
+         J2   =   0.00108262998905
+         J3   =  -0.00000253215306
+         J4   =  -0.00000161098761
+
+         KE   =  60.0D0/DSQRT(ER**3/MU)
+              =  0.074366853168714
+
+
+      The BODY399_Jn values are un-normalized zonal harmonic values
+      for the earth. These numbers are dimensionless.
+
+\begindata
+
+      BODY399_J2 =    1.082616D-3
+      BODY399_J3 =   -2.53881D-6
+      BODY399_J4 =   -1.65597D-6
+
+\begintext
+
+      The next item is the square root of GM for the earth given
+      in units of earth-radii**1.5/Minute
+
+\begindata
+
+      BODY399_KE =    7.43669161D-2
+
+\begintext
+
+      The next two items define the top and bottom of the atmospheric
+      drag model, distance above the surface in kilometers, used by
+      the type 10 ephemeris type.
+
+\begindata
+
+      BODY399_QO =  120.0D0
+      BODY399_SO =   78.0D0
+
+\begintext
+
+      The equatorial radius of the earth in kilometers as used by
+      the TLE propagator.
+
+\begindata
+
+      BODY399_ER = 6378.135D0
+
+\begintext
+
+      The value of AE is the number of distance units per earth
+      radii used by the NORAD state propagation software. Don't
+      change this value.
+
+\begindata
+
+      BODY399_AE = 1.0D0
+
+\begintext
+
+References:
+
+   [1] Hoots, F. R., and Roehrich, R., l. 1980. "Spacetrack Report #3, Models
+       for Propagation of the NORAD Element Sets." U.S. Air Force, CO.
+
+   [2] Vallado, David, Crawford, Paul, Hujsak, Richard,
+       and Kelso, T.S. 2006. Revisiting Spacetrack Report #3. Paper
+       AIAA 2006-6753 presented at the AIAA/AAS Astrodynamics
+       Specialist Conference, August 21-24, 2006. Keystone, CO.
+)";
+
+      std::filesystem::path path = std::filesystem::temp_directory_path();
+      std::filesystem::path file = path / "geophysical.ker";
+      {
+          std::ofstream f(file);
+          f << GeoPhysicalConstantsKernelSource;
+      }
+      loadKernel(file.string());
+      std::filesystem::remove(file);
+}
+
 void SpiceManager::setExceptionHandling(UseException useException) {
     _useExceptions = useException;
 }
@@ -1543,6 +1678,7 @@ scripting::LuaLibrary SpiceManager::luaLibrary() {
             codegen::lua::SpiceBodies,
             codegen::lua::RotationMatrix,
             codegen::lua::Position,
+            codegen::lua::ConvertTLEtoSPK
         }
     };
 }

--- a/src/util/spicemanager_lua.inl
+++ b/src/util/spicemanager_lua.inl
@@ -138,13 +138,11 @@ namespace {
  * The last parameter is only used if there are multiple craft specified in the provided
  * TLE file and is selecting which (0-based index) of the list to create a kernel from.
  *
- * This function returns the SPICE ID of the object for which the kernel was created, and
- * the start and end time for the time period covered by the kernel
+ * This function returns the SPICE ID of the object for which the kernel was created
  */
-[[codegen::luawrap]] std::tuple<int, std::string, std::string> convertTLEtoSPK(
-                                                                std::filesystem::path tle,
-                                                                std::filesystem::path spk,
-                                                                int elementToExtract = 0)
+[[codegen::luawrap]] int convertTLEtoSPK(std::filesystem::path tle,
+                                         std::filesystem::path spk,
+                                         int elementToExtract = 0)
 {
     // Code adopted from
     // https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/getelm_c.html
@@ -229,10 +227,10 @@ namespace {
     std::array<SpiceDouble, 10> elems;
     getelm_c(1950, TLEColumnWidth, spiceLines, &epoch, elems.data());
 
+    // The size of a type SPK10 spice kernel is not affected by the time validity, so we
+    // just pick the greatest one
     SpiceDouble first = -std::numeric_limits<double>::max();
     SpiceDouble last = std::numeric_limits<double>::max();
-    //SpiceDouble first = epoch - 150 * 365 * spd_c();
-    //SpiceDouble last = epoch + 150 * 365 * spd_c();
 
     // Extract the body id
     std::vector<std::string> tokens = ghoul::tokenizeString(line2, ' ');
@@ -277,10 +275,7 @@ namespace {
 
     spkcls_c(handle);
 
-    std::string startTime = openspace::SpiceManager::ref().dateFromEphemerisTime(first);
-    std::string endTime = openspace::SpiceManager::ref().dateFromEphemerisTime(last);
-
-    return { bodyId, startTime, endTime };
+    return bodyId;
 }
 
 #include "spicemanager_lua_codegen.cpp"

--- a/src/util/spicemanager_lua.inl
+++ b/src/util/spicemanager_lua.inl
@@ -22,6 +22,8 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
+#include <ghoul/misc/stringhelper.h>
+
 namespace {
 
 /**
@@ -129,6 +131,156 @@ namespace {
         ephemerisTime
     );
     return position;
+}
+
+/**
+ * This function converts a TLE file into SPK format and saves it at the provided path.
+ * The last parameter is only used if there are multiple craft specified in the provided
+ * TLE file and is selecting which (0-based index) of the list to create a kernel from.
+ *
+ * This function returns the SPICE ID of the object for which the kernel was created, and
+ * the start and end time for the time period covered by the kernel
+ */
+[[codegen::luawrap]] std::tuple<int, std::string, std::string> convertTLEtoSPK(
+                                                                std::filesystem::path tle,
+                                                                std::filesystem::path spk,
+                                                                int elementToExtract = 0)
+{
+    // Code adopted from
+    // https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/getelm_c.html
+    SpiceInt n = 0;
+
+    //
+    // First exact the constants required by a type 10 SPK kernel.
+    //
+
+    std::array<double, 8> constants;
+    // J2 gravitational harmonic for Earth
+    bodvcd_c(399, "J2", 1, &n, &constants[0]);
+
+    // J3 gravitational harmonic for Earth
+    bodvcd_c(399, "J3", 1, &n, &constants[1]);
+
+    // J4 gravitational harmonic for Earth
+    bodvcd_c(399, "J4", 1, &n, &constants[2]);
+
+    // Square root of the GM for Earth
+    bodvcd_c(399, "KE", 1, &n, &constants[3]);
+
+    // High altitude bound for atmospheric model
+    bodvcd_c(399, "QO", 1, &n, &constants[4]);
+
+    // Low altitude bound for atmospheric model
+    bodvcd_c(399, "SO", 1, &n, &constants[5]);
+
+    // Equatorial radius of the Earth
+    bodvcd_c(399, "ER", 1, &n, &constants[6]);
+
+    // Distance units/earth radius
+    bodvcd_c(399, "AE", 1, &n, &constants[7]);
+
+    //
+    // Load the TLE file
+    //
+    std::ifstream f = std::ifstream(tle);
+    std::string contents = std::string(
+        std::istreambuf_iterator<char>(f),
+        std::istreambuf_iterator<char>()
+    );
+
+    // The TLE files returned by Celestrak are of the 3-line variant where the first line
+    // contains a human-readable name for the spacecraft
+
+    std::vector<std::string> lines = ghoul::tokenizeString(contents, '\n');
+    const size_t nElements = lines.size() / 3;
+    if (elementToExtract > nElements) {
+        throw ghoul::RuntimeError(fmt::format(
+            "Error loading {}. Element number {} requested, but only {} found",
+            tle, nElements, elementToExtract
+        ));
+    }
+
+    constexpr int TLEColumnWidth = 70;
+
+    // It should be 70, but we're removing the \n character at the end in the tokenization
+    std::string line1 = lines[3 * elementToExtract + 1];
+    if (line1.size() != TLEColumnWidth - 1) {
+        throw ghoul::RuntimeError(fmt::format(
+            "Illformed TLE file {}, expected {} characters per line, got {}",
+            tle, TLEColumnWidth, line1.size()
+        ));
+    }
+    std::string line2 = lines[3 * elementToExtract + 2];
+    if (line2.size() != TLEColumnWidth - 1) {
+        throw ghoul::RuntimeError(fmt::format(
+            "Illformed TLE file {}, expected {} characters per line, got {}",
+            tle, TLEColumnWidth, line2.size()
+        ));
+    }
+
+    // Copy the lines into a format that SPICE understands
+    SpiceChar spiceLines[2][TLEColumnWidth];
+    std::strcpy(spiceLines[0], line1.c_str());
+    std::strcpy(spiceLines[1], line2.c_str());
+
+
+    // Convert the Two Line Elements lines to the element sets
+    SpiceDouble epoch;
+    std::array<SpiceDouble, 10> elems;
+    getelm_c(1950, TLEColumnWidth, spiceLines, &epoch, elems.data());
+
+    SpiceDouble first = -std::numeric_limits<double>::max();
+    SpiceDouble last = std::numeric_limits<double>::max();
+    //SpiceDouble first = epoch - 150 * 365 * spd_c();
+    //SpiceDouble last = epoch + 150 * 365 * spd_c();
+
+    // Extract the body id
+    std::vector<std::string> tokens = ghoul::tokenizeString(line2, ' ');
+    if (tokens.size() < 2) {
+        throw ghoul::RuntimeError(fmt::format(
+            "Error parsing TLE file {}. Expected 8-9 elements in the second row, got {}",
+            tle, tokens.size()
+        ));
+    }
+    // Earth-orbiting spacecraft usually lack a DSN identification code, so the NAIF ID
+    // is derived from the tracking ID assigned to it by NORAD via:
+    //   NAIF ID = -100000 - NORAD ID
+    int bodyId = -100000 - std::stoi(tokens[1]);
+
+
+    // Write the elements to a new SPK file
+    const SpiceInt nCommentCharacters = 0;
+    std::string internalFileName = fmt::format("Type 10 SPK for {}", tle);
+    std::string segmentId = "Segment";
+
+    if (std::filesystem::exists(spk)) {
+        std::filesystem::remove(spk);
+    }
+
+    std::string outFile = spk.string();
+    SpiceInt handle;
+    spkopn_c(outFile.c_str(), internalFileName.c_str(), nCommentCharacters, &handle);
+
+    spkw10_c(
+        handle,
+        bodyId,
+        399,
+        "J2000",
+        first,
+        last,
+        segmentId.c_str(),
+        constants.data(),
+        1,
+        elems.data(),
+        &epoch
+    );
+
+    spkcls_c(handle);
+
+    std::string startTime = openspace::SpiceManager::ref().dateFromEphemerisTime(first);
+    std::string endTime = openspace::SpiceManager::ref().dateFromEphemerisTime(last);
+
+    return { bodyId, startTime, endTime };
 }
 
 #include "spicemanager_lua_codegen.cpp"


### PR DESCRIPTION
Adds two new SPICE functions `openspace.space.convertTLEtoSPK` and `openspace.space.tleToSpiceTranslation`.  The first converts a TLE file into a type 10 SPK kernel t hat can be used for a `SpiceTranslation`.  The second function uses the former to create a kernel and then returns back a fully formed `SpiceTranslation` table that can be used in an asset.

This also hardcoded loads a geophysical constants kernel needed for SPK10 kernels to work.

This PR also applies those changes to the ISS to both fix its position for a longer time (fixes #1578) and use a new dynamic frame kernel to have a correct orientation for the ISS (fixes #1783)