### PR TITLE
Add the ability to specifiy local Sun position for the RenderableGlobe and RenderableAtmosphere

### DIFF
--- a/modules/atmosphere/rendering/atmospheredeferredcaster.cpp
+++ b/modules/atmosphere/rendering/atmospheredeferredcaster.cpp
@@ -382,8 +382,8 @@ void AtmosphereDeferredcaster::preRaycast(const RenderData& data, const Deferred
             invModelMatrix * glm::dvec4(data.camera.eyePositionVec3(), 1.0);
         program.setUniform(_uniformCache.camPosObj, glm::dvec3(camPosObjCoords));
 
-        SceneGraphNode* node = sceneGraph()->sceneGraphNode("Sun");
-        const glm::dvec3 sunPosWorld = node ? node->worldPosition() : glm::dvec3(0.0);
+        const glm::dvec3 sunPosWorld =
+            _sunNode ? _sunNode->worldPosition() : glm::dvec3(0.0);
 
         glm::dvec3 sunPosObj;
         // Sun following camera position
@@ -574,7 +574,8 @@ void AtmosphereDeferredcaster::setParameters(float atmosphereRadius, float plane
                                              glm::vec3 ozoneExtinctionCoefficients,
                                              glm::vec3 mieScatteringCoefficients,
                                              glm::vec3 mieExtinctionCoefficients,
-                                             bool sunFollowing, float sunAngularSize)
+                                             bool sunFollowing, float sunAngularSize,
+                                             SceneGraphNode* sunNode)
 {
     _atmosphereRadius = atmosphereRadius;
     _atmospherePlanetRadius = planetRadius;
@@ -592,6 +593,8 @@ void AtmosphereDeferredcaster::setParameters(float atmosphereRadius, float plane
     _mieExtinctionCoeff = std::move(mieExtinctionCoefficients);
     _sunFollowingCameraEnabled = sunFollowing;
     _sunAngularSize = sunAngularSize;
+    // sunNode may be nullptr in which the position is to be interpreted to be (0,0,0)
+    _sunNode = sunNode;
 }
 
 void AtmosphereDeferredcaster::setHardShadows(bool enabled) {

--- a/modules/atmosphere/rendering/atmospheredeferredcaster.cpp
+++ b/modules/atmosphere/rendering/atmospheredeferredcaster.cpp
@@ -382,8 +382,10 @@ void AtmosphereDeferredcaster::preRaycast(const RenderData& data, const Deferred
             invModelMatrix * glm::dvec4(data.camera.eyePositionVec3(), 1.0);
         program.setUniform(_uniformCache.camPosObj, glm::dvec3(camPosObjCoords));
 
-        const glm::dvec3 sunPosWorld =
-            _sunNode ? _sunNode->worldPosition() : glm::dvec3(0.0);
+        // For the lighting we use the provided node, or the Sun
+        SceneGraphNode* node =
+            _lightSourceNode ? _lightSourceNode : sceneGraph()->sceneGraphNode("Sun");
+        const glm::dvec3 sunPosWorld = node ? node->worldPosition() : glm::dvec3(0.0);
 
         glm::dvec3 sunPosObj;
         // Sun following camera position
@@ -575,7 +577,7 @@ void AtmosphereDeferredcaster::setParameters(float atmosphereRadius, float plane
                                              glm::vec3 mieScatteringCoefficients,
                                              glm::vec3 mieExtinctionCoefficients,
                                              bool sunFollowing, float sunAngularSize,
-                                             SceneGraphNode* sunNode)
+                                             SceneGraphNode* lightSourceNode)
 {
     _atmosphereRadius = atmosphereRadius;
     _atmospherePlanetRadius = planetRadius;
@@ -593,8 +595,8 @@ void AtmosphereDeferredcaster::setParameters(float atmosphereRadius, float plane
     _mieExtinctionCoeff = std::move(mieExtinctionCoefficients);
     _sunFollowingCameraEnabled = sunFollowing;
     _sunAngularSize = sunAngularSize;
-    // sunNode may be nullptr in which the position is to be interpreted to be (0,0,0)
-    _sunNode = sunNode;
+    // The light source may be nullptr which we interpret to mean a position of (0,0,0)
+    _lightSourceNode = lightSourceNode;
 }
 
 void AtmosphereDeferredcaster::setHardShadows(bool enabled) {

--- a/modules/atmosphere/rendering/atmospheredeferredcaster.h
+++ b/modules/atmosphere/rendering/atmospheredeferredcaster.h
@@ -88,7 +88,7 @@ public:
         float mieHeightScale, float miePhaseConstant, float sunRadiance,
         glm::vec3 rayScatteringCoefficients, glm::vec3 ozoneExtinctionCoefficients,
         glm::vec3 mieScatteringCoefficients, glm::vec3 mieExtinctionCoefficients,
-        bool sunFollowing, float sunAngularSize);
+        bool sunFollowing, float sunAngularSize, SceneGraphNode* sunNode);
 
     void setHardShadows(bool enabled);
 
@@ -142,6 +142,7 @@ private:
     float _miePhaseConstant = 0.f;
     float _sunRadianceIntensity = 5.f;
     float _sunAngularSize = 0.3f;
+    SceneGraphNode* _sunNode = nullptr;
 
     glm::vec3 _rayleighScatteringCoeff = glm::vec3(0.f);
     glm::vec3 _ozoneExtinctionCoeff = glm::vec3(0.f);

--- a/modules/atmosphere/rendering/atmospheredeferredcaster.h
+++ b/modules/atmosphere/rendering/atmospheredeferredcaster.h
@@ -88,7 +88,7 @@ public:
         float mieHeightScale, float miePhaseConstant, float sunRadiance,
         glm::vec3 rayScatteringCoefficients, glm::vec3 ozoneExtinctionCoefficients,
         glm::vec3 mieScatteringCoefficients, glm::vec3 mieExtinctionCoefficients,
-        bool sunFollowing, float sunAngularSize, SceneGraphNode* sunNode);
+        bool sunFollowing, float sunAngularSize, SceneGraphNode* lightSourceNode);
 
     void setHardShadows(bool enabled);
 
@@ -142,7 +142,7 @@ private:
     float _miePhaseConstant = 0.f;
     float _sunRadianceIntensity = 5.f;
     float _sunAngularSize = 0.3f;
-    SceneGraphNode* _sunNode = nullptr;
+    SceneGraphNode* _lightSourceNode = nullptr;
 
     glm::vec3 _rayleighScatteringCoeff = glm::vec3(0.f);
     glm::vec3 _ozoneExtinctionCoeff = glm::vec3(0.f);

--- a/modules/atmosphere/rendering/renderableatmosphere.cpp
+++ b/modules/atmosphere/rendering/renderableatmosphere.cpp
@@ -30,6 +30,7 @@
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/globals.h>
 #include <openspace/navigation/navigationhandler.h>
+#include <openspace/query/query.h>
 #include <ghoul/misc/profiling.h>
 #include <openspace/properties/property.h>
 #include <openspace/rendering/deferredcastermanager.h>
@@ -182,6 +183,15 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
+    constexpr openspace::properties::Property::PropertyInfo SunNodeInfo = {
+        "SunNode",
+        "Name of the local Sun",
+        "This value is the name of a scene graph node that should be used as the source "
+        "of illumination for the atmosphere. If this value is not specified, the solar "
+        "system's Sun is used instead",
+        openspace::properties::Property::Visibility::AdvancedUser
+    };
+
     struct [[codegen::Dictionary(RenderableAtmosphere)]] Parameters {
         struct ShadowGroup {
             // Individual light sources
@@ -270,6 +280,9 @@ namespace {
 
         // [[codegen::verbatim(SunAngularSize.description)]]
         std::optional<float> sunAngularSize [[codegen::inrange(0.0, 180.0)]];
+
+        // [[codegen::verbatim(SunNodeInfo.description)]]
+        std::optional<std::string> sunNode;
     };
 #include "renderableatmosphere_codegen.cpp"
 
@@ -311,6 +324,7 @@ RenderableAtmosphere::RenderableAtmosphere(const ghoul::Dictionary& dictionary)
     , _sunFollowingCameraEnabled(EnableSunOnCameraPositionInfo, false)
     , _hardShadowsEnabled(EclipseHardShadowsInfo, false)
     , _sunAngularSize(SunAngularSize, 0.3f, 0.f, 180.f)
+    , _sunNodeName(SunNodeInfo)
     , _atmosphereDimmingHeight(AtmosphereDimmingHeightInfo, 0.7f, 0.f, 1.f)
     , _atmosphereDimmingSunsetAngle(
         SunsetAngleInfo,
@@ -435,6 +449,30 @@ RenderableAtmosphere::RenderableAtmosphere(const ghoul::Dictionary& dictionary)
     _sunAngularSize = p.sunAngularSize.value_or(_sunAngularSize);
     _sunAngularSize.onChange(updateWithoutCalculation);
     addProperty(_sunAngularSize);
+
+    _sunNodeName.onChange([this]() {
+        if (_sunNodeName.value().empty()) {
+            _sunNode = nullptr;
+            return;
+        }
+
+        SceneGraphNode* n = sceneGraphNode(_sunNodeName);
+        if (!n) {
+            LERRORC(
+                "RenderabeAtmosphere",
+                std::format(
+                    "Could not find node '{}' as illumination for '{}'",
+                    _sunNodeName.value(), identifier()
+                )
+            );
+        }
+        else {
+            _sunNode = n;
+            _deferredCasterNeedsUpdate = true;
+        }
+    });
+    _sunNodeName = p.sunNode.value_or("");
+    addProperty(_sunNodeName);
 }
 
 void RenderableAtmosphere::deinitializeGL() {
@@ -510,7 +548,8 @@ void RenderableAtmosphere::updateAtmosphereParameters() {
         _mieScatteringCoeff,
         _mieExtinctionCoeff,
         _sunFollowingCameraEnabled,
-        _sunAngularSize
+        _sunAngularSize,
+        _sunNode
     );
     _deferredcaster->setHardShadows(_hardShadowsEnabled);
 }

--- a/modules/atmosphere/rendering/renderableatmosphere.cpp
+++ b/modules/atmosphere/rendering/renderableatmosphere.cpp
@@ -183,9 +183,9 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
-    constexpr openspace::properties::Property::PropertyInfo SunNodeInfo = {
-        "SunNode",
-        "Name of the local Sun",
+    constexpr openspace::properties::Property::PropertyInfo LightSourceNodeInfo = {
+        "LightSourceNode",
+        "Name of the light source",
         "This value is the name of a scene graph node that should be used as the source "
         "of illumination for the atmosphere. If this value is not specified, the solar "
         "system's Sun is used instead",
@@ -281,8 +281,8 @@ namespace {
         // [[codegen::verbatim(SunAngularSize.description)]]
         std::optional<float> sunAngularSize [[codegen::inrange(0.0, 180.0)]];
 
-        // [[codegen::verbatim(SunNodeInfo.description)]]
-        std::optional<std::string> sunNode;
+        // [[codegen::verbatim(LightSourceNodeInfo.description)]]
+        std::optional<std::string> lightSourceNode;
     };
 #include "renderableatmosphere_codegen.cpp"
 
@@ -324,7 +324,7 @@ RenderableAtmosphere::RenderableAtmosphere(const ghoul::Dictionary& dictionary)
     , _sunFollowingCameraEnabled(EnableSunOnCameraPositionInfo, false)
     , _hardShadowsEnabled(EclipseHardShadowsInfo, false)
     , _sunAngularSize(SunAngularSize, 0.3f, 0.f, 180.f)
-    , _sunNodeName(SunNodeInfo)
+    , _lightSourceNodeName(LightSourceNodeInfo)
     , _atmosphereDimmingHeight(AtmosphereDimmingHeightInfo, 0.7f, 0.f, 1.f)
     , _atmosphereDimmingSunsetAngle(
         SunsetAngleInfo,
@@ -450,29 +450,29 @@ RenderableAtmosphere::RenderableAtmosphere(const ghoul::Dictionary& dictionary)
     _sunAngularSize.onChange(updateWithoutCalculation);
     addProperty(_sunAngularSize);
 
-    _sunNodeName.onChange([this]() {
-        if (_sunNodeName.value().empty()) {
-            _sunNode = nullptr;
+    _lightSourceNodeName.onChange([this]() {
+        if (_lightSourceNodeName.value().empty()) {
+            _lightSourceNode = nullptr;
             return;
         }
 
-        SceneGraphNode* n = sceneGraphNode(_sunNodeName);
+        SceneGraphNode* n = sceneGraphNode(_lightSourceNodeName);
         if (!n) {
             LERRORC(
                 "RenderabeAtmosphere",
                 std::format(
                     "Could not find node '{}' as illumination for '{}'",
-                    _sunNodeName.value(), identifier()
+                    _lightSourceNodeName.value(), identifier()
                 )
             );
         }
         else {
-            _sunNode = n;
+            _lightSourceNode = n;
             _deferredCasterNeedsUpdate = true;
         }
     });
-    _sunNodeName = p.sunNode.value_or("");
-    addProperty(_sunNodeName);
+    _lightSourceNodeName = p.lightSourceNode.value_or("");
+    addProperty(_lightSourceNodeName);
 }
 
 void RenderableAtmosphere::deinitializeGL() {
@@ -549,7 +549,7 @@ void RenderableAtmosphere::updateAtmosphereParameters() {
         _mieExtinctionCoeff,
         _sunFollowingCameraEnabled,
         _sunAngularSize,
-        _sunNode
+        _lightSourceNode
     );
     _deferredcaster->setHardShadows(_hardShadowsEnabled);
 }

--- a/modules/atmosphere/rendering/renderableatmosphere.h
+++ b/modules/atmosphere/rendering/renderableatmosphere.h
@@ -97,6 +97,8 @@ private:
     properties::BoolProperty _sunFollowingCameraEnabled;
     properties::BoolProperty _hardShadowsEnabled;
     properties::FloatProperty _sunAngularSize;
+    SceneGraphNode* _sunNode = nullptr;
+    properties::StringProperty _sunNodeName;
 
     // Atmosphere dimming
     properties::FloatProperty _atmosphereDimmingHeight;

--- a/modules/atmosphere/rendering/renderableatmosphere.h
+++ b/modules/atmosphere/rendering/renderableatmosphere.h
@@ -97,8 +97,8 @@ private:
     properties::BoolProperty _sunFollowingCameraEnabled;
     properties::BoolProperty _hardShadowsEnabled;
     properties::FloatProperty _sunAngularSize;
-    SceneGraphNode* _sunNode = nullptr;
-    properties::StringProperty _sunNodeName;
+    SceneGraphNode* _lightSourceNode = nullptr;
+    properties::StringProperty _lightSourceNodeName;
 
     // Atmosphere dimming
     properties::FloatProperty _atmosphereDimmingHeight;

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -296,7 +296,7 @@ void createExoplanetSystem(const std::string& starName,
                 "SegmentsPerPatch = 64,"
                 "PerformShading = true,"
                 "Layers = {},"
-                "SunNode = '" + starIdentifier + "'"
+                "LightSourceNode = '" + starIdentifier + "'"
             "},"
             "Transform = { "
                 "Translation = " + planetKeplerTranslation + ""

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -294,8 +294,9 @@ void createExoplanetSystem(const std::string& starName,
                 "Enabled = " + enabled + ","
                 "Radii = " + std::to_string(planetRadius) + "," // in meters
                 "SegmentsPerPatch = 64,"
-                "PerformShading = false,"
-                "Layers = {}"
+                "PerformShading = true,"
+                "Layers = {},"
+                "SunNode = '" + starIdentifier + "'"
             "},"
             "Transform = { "
                 "Translation = " + planetKeplerTranslation + ""

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -181,9 +181,9 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
-    constexpr openspace::properties::Property::PropertyInfo SunNodeInfo = {
-        "SunNode",
-        "Name of the local Sun",
+    constexpr openspace::properties::Property::PropertyInfo LightSourceNodeInfo = {
+        "LightSourceNode",
+        "Name of the light source",
         "This value is the name of a scene graph node that should be used as the source "
         "of illumination for the globe. If this value is not specified, the solar "
         "system's Sun is used instead",
@@ -321,8 +321,8 @@ namespace {
         std::optional<ghoul::Dictionary> shadows
             [[codegen::reference("globebrowsing_shadows_component")]];
 
-        // [[codegen::verbatim(SunNodeInfo.description)]]
-        std::optional<std::string> sunNode;
+        // [[codegen::verbatim(LightSourceNodeInfo.description)]]
+        std::optional<std::string> lightSourceNode;
     };
 #include "renderableglobe_codegen.cpp"
 } // namespace
@@ -548,9 +548,13 @@ bool intersects(const AABB3& bb, const AABB3& o) {
  * Calculates the direction towards the local light source. If \p illumination is a
  * `nullptr`, it is interpreted to be (0,0,0)
  */
-glm::dvec3 directionToLightSource(const glm::dvec3& pos, SceneGraphNode* illumination) {
-    if (illumination) {
-        return illumination->worldPosition() - pos;
+glm::dvec3 directionToLightSource(const glm::dvec3& pos, SceneGraphNode* lightSource) {
+    // For the lighting we use the provided node, or the Sun
+    SceneGraphNode* node =
+        lightSource ? lightSource : sceneGraph()->sceneGraphNode("Sun");
+
+    if (lightSource) {
+        return lightSource->worldPosition() - pos;
     }
     else {
         const glm::dvec3 dir = length(pos) > 0.0 ? glm::normalize(-pos) : glm::dvec3(0.0);
@@ -600,7 +604,7 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     , _grid(DefaultSkirtedGridSegments, DefaultSkirtedGridSegments)
     , _leftRoot(Chunk(LeftHemisphereIndex))
     , _rightRoot(Chunk(RightHemisphereIndex))
-    , _sunNodeName(SunNodeInfo)
+    , _lightSourceNodeName(LightSourceNodeInfo)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
 
@@ -643,25 +647,25 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     addProperty(_generalProperties.useAccurateNormals);
     addProperty(_generalProperties.renderAtDistance);
 
-    _sunNodeName.onChange([this]() {
-        if (_sunNodeName.value().empty()) {
-            _sunNode = nullptr;
+    _lightSourceNodeName.onChange([this]() {
+        if (_lightSourceNodeName.value().empty()) {
+            _lightSourceNode = nullptr;
             return;
         }
 
-        SceneGraphNode* n = sceneGraphNode(_sunNodeName);
+        SceneGraphNode* n = sceneGraphNode(_lightSourceNodeName);
         if (!n) {
             LERROR(std::format(
                 "Could not find node '{}' as illumination for '{}'",
-                _sunNodeName.value(), identifier()
+                _lightSourceNodeName.value(), identifier()
             ));
         }
         else {
-            _sunNode = n;
+            _lightSourceNode = n;
         }
     });
-    _sunNodeName = p.sunNode.value_or("");
-    addProperty(_sunNodeName);
+    _lightSourceNodeName = p.lightSourceNode.value_or("");
+    addProperty(_lightSourceNodeName);
 
     if (p.shadowGroup.has_value()) {
         std::vector<Ellipsoid::ShadowConfiguration> shadowConfArray;
@@ -1213,7 +1217,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
 
     if (nightLayersActive || waterLayersActive || _generalProperties.performShading) {
         const glm::dvec3 directionToSunWorldSpace =
-            directionToLightSource(data.modelTransform.translation, _sunNode);
+            directionToLightSource(data.modelTransform.translation, _lightSourceNode);
 
         const glm::vec3 directionToSunCameraSpace = glm::vec3(viewTransform *
             glm::dvec4(directionToSunWorldSpace, 0));
@@ -1239,7 +1243,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
 
     if (nightLayersActive || waterLayersActive || _generalProperties.performShading) {
         const glm::dvec3 directionToSunWorldSpace =
-            directionToLightSource(data.modelTransform.translation, _sunNode);
+            directionToLightSource(data.modelTransform.translation, _lightSourceNode);
 
         const glm::vec3 directionToSunCameraSpace = glm::vec3(viewTransform *
             glm::dvec4(directionToSunWorldSpace, 0));

--- a/modules/globebrowsing/src/renderableglobe.h
+++ b/modules/globebrowsing/src/renderableglobe.h
@@ -37,9 +37,10 @@
 #include <modules/globebrowsing/src/shadowcomponent.h>
 #include <modules/globebrowsing/src/skirtedgrid.h>
 #include <modules/globebrowsing/src/tileindex.h>
+#include <openspace/properties/scalar/boolproperty.h>
 #include <openspace/properties/scalar/floatproperty.h>
 #include <openspace/properties/scalar/intproperty.h>
-#include <openspace/properties/scalar/boolproperty.h>
+#include <openspace/properties/stringproperty.h>
 #include <ghoul/misc/memorypool.h>
 #include <ghoul/opengl/uniformcache.h>
 #include <cstddef>
@@ -287,6 +288,9 @@ private:
 
         std::array<GPULayerGroup, LayerManager::NumLayerGroups> gpuLayerGroups;
     } _localRenderer;
+
+    SceneGraphNode* _sunNode = nullptr;
+    properties::StringProperty _sunNodeName;
 
     bool _shadersNeedRecompilation = true;
     bool _lodScaleFactorDirty = true;

--- a/modules/globebrowsing/src/renderableglobe.h
+++ b/modules/globebrowsing/src/renderableglobe.h
@@ -289,8 +289,8 @@ private:
         std::array<GPULayerGroup, LayerManager::NumLayerGroups> gpuLayerGroups;
     } _localRenderer;
 
-    SceneGraphNode* _sunNode = nullptr;
-    properties::StringProperty _sunNodeName;
+    SceneGraphNode* _lightSourceNode = nullptr;
+    properties::StringProperty _lightSourceNodeName;
 
     bool _shadersNeedRecompilation = true;
     bool _lodScaleFactorDirty = true;


### PR DESCRIPTION
Note that for planets with atmospheres, the SunNode has to be specified for _both_ the globe and the atmosphere separately

 - Closes #1745
 - Closes #2243