### PR TITLE
Fix loading of cached data values

### DIFF
--- a/src/data/dataloader.cpp
+++ b/src/data/dataloader.cpp
@@ -281,6 +281,7 @@ std::optional<Dataset> loadCachedFile(const std::filesystem::path& path) {
 
             // If we have a comment, we need to extract its length's worth of characters
             // from the buffer
+            // @TODO replace this with std::move as well?
             std::memcpy(e.comment->data(), &commentBuffer[commentIdx], e.comment->size());
 
             // and then advance the index

--- a/src/data/dataloader.cpp
+++ b/src/data/dataloader.cpp
@@ -272,7 +272,8 @@ std::optional<Dataset> loadCachedFile(const std::filesystem::path& path) {
     int valuesIdx = 0;
     for (Dataset::Entry& e : result.entries) {
         e.data.resize(nValues);
-        std::memcpy(e.data.data(), entriesBuffer.data() + valuesIdx, nValues);
+        auto startOfCopy = entriesBuffer.begin() + valuesIdx;
+        std::move(startOfCopy, startOfCopy + nValues, e.data.begin());
         valuesIdx += nValues;
 
         if (e.comment.has_value()) {


### PR DESCRIPTION
The `std::memcopy` approach here does not work for std:vectors of floats (it will essentially only work for `char` like things, if I understand the internet correctly. However, a general consensus seems tot be to avoid `std::memcopy` in combination with `std::vector`)