### PR TITLE
Allow sessionrecording to write a file outside of user/recordings/

### DIFF
--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -185,8 +185,10 @@ bool SessionRecording::handleRecordingFile(std::string filenameIn) {
         return false;
     }
     else if (!std::filesystem::exists(absFilename.parent_path())) {
-        LERROR(std::format("The recording filename path '{}' is not a valid location "
-            "in the filesytem", absFilename.parent_path().string()));
+        LERROR(std::format(
+            "The recording filename path '{}' is not a valid location in the filesytem",
+            absFilename.parent_path().string()
+        ));
         return false;
     }
 

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -157,11 +157,6 @@ void SessionRecording::removeTrailingPathSlashes(std::string& filename) const {
 }
 
 bool SessionRecording::handleRecordingFile(std::string filenameIn) {
-    if (isPath(filenameIn)) {
-        LERROR("Recording filename must not contain path (/) elements");
-        return false;
-    }
-
     if (_recordingDataMode == DataMode::Binary) {
         if (hasFileExtension(filenameIn, FileExtensionAscii)) {
             LERROR("Specified filename for binary recording has ascii file extension");
@@ -181,7 +176,19 @@ bool SessionRecording::handleRecordingFile(std::string filenameIn) {
         }
     }
 
-    std::filesystem::path absFilename = absPath("${RECORDINGS}/" + filenameIn);
+    std::filesystem::path absFilename = filenameIn;
+    if (absFilename.parent_path().empty() || absFilename.parent_path() == absFilename) {
+        absFilename = absPath("${RECORDINGS}/" + filenameIn);
+    }
+    else if (absFilename.parent_path().is_relative()) {
+        LERROR("If path is provided with the filename, then it must be an absolute path");
+        return false;
+    }
+    else if (!std::filesystem::exists(absFilename.parent_path())) {
+        LERROR(std::format("The recording filename path '{}' is not a valid location "
+            "in the filesytem", absFilename.parent_path().string()));
+        return false;
+    }
 
     if (std::filesystem::is_regular_file(absFilename)) {
         LERROR(std::format(


### PR DESCRIPTION
User can now specify a path with the intended filename when starting a recording. If no path is provided, the file is saved to user/recordings/.
This can be done from either the frontend UI or via `openspace.sessionRecording.startRecording`.
The path must be an _absolute_ path to an existing directory in the filesytem, and the user must have write permissions to it.
The file would have to be played-back using `openspace.sessionRecording.startPlayback`, becuase the UI only lists files that reside in the user/recordings/ directory.