### PR TITLE
Add asset setting to skip first data point in RenderablePointCloud

### DIFF
--- a/data/assets/scene/digitaluniverse/tully.asset
+++ b/data/assets/scene/digitaluniverse/tully.asset
@@ -35,6 +35,7 @@ local TullyGalaxies = {
     },
     Opacity = 0.99,
     File = speck .. "tully.speck",
+    SkipFirstDataPoint = true,
     Texture = {
       File = textures .. "point3A.png"
     },

--- a/modules/base/rendering/pointcloud/renderableinterpolatedpoints.cpp
+++ b/modules/base/rendering/pointcloud/renderableinterpolatedpoints.cpp
@@ -304,6 +304,14 @@ RenderableInterpolatedPoints::RenderableInterpolatedPoints(
     // should be rendered. So make sure it is updated once we know the number of
     // interpolation steps
     _nDataPoints = nObjects;
+
+    if (_skipFirstDataPoint) {
+        LWARNING(
+            "Found setting to skip first data point in asset. This is not supported for "
+            "interpolated point clouds. Ignoring"
+        );
+        _skipFirstDataPoint = false;
+    }
 }
 
 void RenderableInterpolatedPoints::initializeShadersAndGlExtras() {

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -372,6 +372,9 @@ namespace {
         // [[codegen::verbatim(UseAdditiveBlendingInfo.description)]]
         std::optional<bool> useAdditiveBlending;
 
+        // If true, skip the first data point in the loaded dataset
+        std::optional<bool> skipFirstDataPoint;
+
         enum class [[codegen::map(openspace::DistanceUnit)]] Unit {
             Meter [[codegen::key("m")]],
             Kilometer [[codegen::key("Km")]],
@@ -701,6 +704,8 @@ RenderablePointCloud::RenderablePointCloud(const ghoul::Dictionary& dictionary)
 
     _useCaching = p.useCaching.value_or(true);
 
+    _skipFirstDataPoint = p.skipFirstDataPoint.value_or(false);
+
     // If no scale exponent was specified, compute one that will at least show the
     // points based on the scale of the positions in the dataset
     if (!p.sizeSettings.has_value() || !p.sizeSettings->scaleExponent.has_value()) {
@@ -754,6 +759,11 @@ void RenderablePointCloud::initialize() {
         else {
             _dataset = dataloader::data::loadFile(_dataFile, _dataMapping);
         }
+
+        if (_skipFirstDataPoint) {
+            _dataset.entries.erase(_dataset.entries.begin());
+        }
+
         _nDataPoints = static_cast<unsigned int>(_dataset.entries.size());
 
         // If no scale exponent was specified, compute one that will at least show the

--- a/modules/base/rendering/pointcloud/renderablepointcloud.h
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.h
@@ -230,6 +230,7 @@ protected:
     bool _useCaching = true;
     bool _shouldComputeScaleExponent = false;
     bool _createLabelsFromDataset = false;
+    bool _skipFirstDataPoint = false;
 
     dataloader::Dataset _dataset;
     dataloader::DataMapping _dataMapping;


### PR DESCRIPTION
To hide our galaxy in the Tully datasets