### PR TITLE
Updating the star rendering

### DIFF
--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -76,12 +76,12 @@ local SunStar = {
   Renderable = {
     Type = "RenderableStars",
     File = sunspeck .. "sunstar.speck",
-    GlareTexture = textures .. "halo.png",
-    --ShapeTexture = textures .. "disc.png",
+    Halo = {
+      Texture = textures .. "halo.png"
+    },
     ColorMap = colormaps .. "colorbv.cmap",
     MagnitudeExponent = 6.2,
     SizeComposition = "Distance Modulus",
-    RenderMethod = "Texture Based", -- or PSF
     FadeInDistances = { 0.0001, 0.1 },
     RenderableType = "PostDeferredTransparent",
     DataMapping = {

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -32,11 +32,11 @@ local Stars = {
   Renderable = {
     Type = "RenderableStars",
     File = speck .. "stars.speck",
-    Glare = {
+    Halo = {
       Texture = textures .. "halo.png",
       PartialOpacity = 0.875
     },
-    Highlight = {
+    Glare = {
       Texture = textures .. "glare.png",
       PartialOpacity = 5.0,
       Scale = 0.7

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -34,15 +34,15 @@ local Stars = {
     File = speck .. "stars.speck",
     Halo = {
       Texture = textures .. "halo.png",
-      Multiplier = 0.55,
-      Size = 0.95
+      Multiplier = 0.65
     },
     Glare = {
       Texture = textures .. "glare.png",
-      Multiplier = 5.0,
-      Scale = 0.4
+      Multiplier = 15.0,
+      Gamma = 1.66,
+      Scale = 0.18
     },
-    MagnitudeExponent = 6.25,
+    MagnitudeExponent = 6.325,
     ColorMap = colormaps .. "colorbv.cmap",
     OtherDataColorMap = colormaps .. "viridis.cmap",
     SizeComposition = "Distance Modulus",

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -32,13 +32,19 @@ local Stars = {
   Renderable = {
     Type = "RenderableStars",
     File = speck .. "stars.speck",
-    Texture = textures .. "halo.png",
-    --ShapeTexture = textures .. "disc.png",
+    Glare = {
+      Texture = textures .. "halo.png",
+      PartialOpacity = 0.875
+    },
+    Highlight = {
+      Texture = textures .. "glare.png",
+      PartialOpacity = 5.0,
+      Scale = 0.7
+    },
+    MagnitudeExponent = 6.2,
     ColorMap = colormaps .. "colorbv.cmap",
     OtherDataColorMap = colormaps .. "viridis.cmap",
-    MagnitudeExponent = 6.2,
     SizeComposition = "Distance Modulus",
-    RenderMethod = "Texture Based", -- or PSF
     DataMapping = {
       Bv = "colorb_v",
       Luminance = "lum",
@@ -70,7 +76,7 @@ local SunStar = {
   Renderable = {
     Type = "RenderableStars",
     File = sunspeck .. "sunstar.speck",
-    Texture = textures .. "halo.png",
+    GlareTexture = textures .. "halo.png",
     --ShapeTexture = textures .. "disc.png",
     ColorMap = colormaps .. "colorbv.cmap",
     MagnitudeExponent = 6.2,
@@ -101,11 +107,11 @@ local SunStar = {
 
 asset.onInitialize(function()
   openspace.addSceneGraphNode(Stars)
-  openspace.addSceneGraphNode(SunStar)
+  -- openspace.addSceneGraphNode(SunStar)
 end)
 
 asset.onDeinitialize(function()
-  openspace.removeSceneGraphNode(SunStar)
+  -- openspace.removeSceneGraphNode(SunStar)
   openspace.removeSceneGraphNode(Stars)
 end)
 

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -131,7 +131,7 @@ asset.export(SunStar)
 
 asset.meta = {
   Name = "Stars",
-  Version = "2.1",
+  Version = "3.0",
   Description = "Digital Universe asset for the stars",
   Author = "Brian Abbott (AMNH)",
   URL = "https://www.amnh.org/research/hayden-planetarium/digital-universe",

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -78,12 +78,20 @@ local SunStar = {
     Type = "RenderableStars",
     File = sunspeck .. "sunstar.speck",
     Halo = {
-      Texture = textures .. "halo.png"
+      Texture = textures .. "halo.png",
+      Multiplier = 0.55,
+      Gamma = 1.1,
+      Size = 0.95
     },
+    Glare = {
+      Texture = textures .. "glare.png",
+      Multiplier = 1.0,
+      Scale = 0.1
+    },
+    MagnitudeExponent = 6.25,
     ColorMap = colormaps .. "colorbv.cmap",
-    MagnitudeExponent = 6.2,
     SizeComposition = "Distance Modulus",
-    FadeInDistances = { 0.0001, 0.1 },
+    FadeInDistances = { 0.0075, 0.1 },
     RenderableType = "PostDeferredTransparent",
     DataMapping = {
       Bv = "colorb_v",

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -34,11 +34,11 @@ local Stars = {
     File = speck .. "stars.speck",
     Halo = {
       Texture = textures .. "halo.png",
-      PartialOpacity = 0.875
+      Multiplier = 0.875
     },
     Glare = {
       Texture = textures .. "glare.png",
-      PartialOpacity = 5.0,
+      Multiplier = 5.0,
       Scale = 0.7
     },
     MagnitudeExponent = 6.2,

--- a/data/assets/scene/digitaluniverse/stars.asset
+++ b/data/assets/scene/digitaluniverse/stars.asset
@@ -34,14 +34,15 @@ local Stars = {
     File = speck .. "stars.speck",
     Halo = {
       Texture = textures .. "halo.png",
-      Multiplier = 0.875
+      Multiplier = 0.55,
+      Size = 0.95
     },
     Glare = {
       Texture = textures .. "glare.png",
       Multiplier = 5.0,
-      Scale = 0.7
+      Scale = 0.4
     },
-    MagnitudeExponent = 6.2,
+    MagnitudeExponent = 6.25,
     ColorMap = colormaps .. "colorbv.cmap",
     OtherDataColorMap = colormaps .. "viridis.cmap",
     SizeComposition = "Distance Modulus",
@@ -107,11 +108,11 @@ local SunStar = {
 
 asset.onInitialize(function()
   openspace.addSceneGraphNode(Stars)
-  -- openspace.addSceneGraphNode(SunStar)
+  openspace.addSceneGraphNode(SunStar)
 end)
 
 asset.onDeinitialize(function()
-  -- openspace.removeSceneGraphNode(SunStar)
+  openspace.removeSceneGraphNode(SunStar)
   openspace.removeSceneGraphNode(Stars)
 end)
 

--- a/data/assets/scene/milkyway/gaia/apogee.asset
+++ b/data/assets/scene/milkyway/gaia/apogee.asset
@@ -30,8 +30,9 @@ local GaiaAbundanceApogee = {
     OtherData = "FeH",
     MagnitudeExponent = 7.25,
     SizeComposition = "Distance Modulus",
-    RenderMethod = "Texture Based",
-    Texture = textures .. "halo.png",
+    Halo = {
+      Texture = textures .. "halo.png"
+    },
     ColorRange = { { -0.8, 0.6 } },
     -- ShapeTexture = textures .. "disc.png",
     ColorMap = colormaps .. "colorbv.cmap",

--- a/data/assets/scene/milkyway/gaia/galah.asset
+++ b/data/assets/scene/milkyway/gaia/galah.asset
@@ -26,11 +26,12 @@ local GaiaAbundanceGalah = {
     Type = "RenderableStars",
     Enabled = false,
     File = speck .. "GaiaAbundGalah.speck",
-    Texture = textures .. "halo.png",
+    Halo = {
+      Texture = textures .. "halo.png"
+    },
     -- ShapeTexture = textures .. "disc.png",
     MagnitudeExponent = 7.25,
     SizeComposition = "Distance Modulus",
-    RenderMethod = "Texture Based",
     ColorOption = "Other Data",
     OtherData = "FeH",
     ColorMap = colormaps .. "colorbv.cmap",

--- a/data/assets/scene/milkyway/objects/orionnebula/cluster.asset
+++ b/data/assets/scene/milkyway/objects/orionnebula/cluster.asset
@@ -16,11 +16,12 @@ local OrionClusterStars = {
   Renderable = {
     Type = "RenderableStars",
     File = sync .. "oricluster.speck",
-    Texture = sync .. "halo.png",
+    Halo = {
+      Texture = sync .. "halo.png"
+    },
     ColorMap = sync .. "colorbv.cmap",
     MagnitudeExponent = 5.02,
     SizeComposition = "Distance Modulus",
-    RenderMethod = "Texture Based",
     DataMapping = {
       Bv = "colorb_v",
       Luminance = "lum",

--- a/data/assets/scene/milkyway/stars/denver.asset
+++ b/data/assets/scene/milkyway/stars/denver.asset
@@ -25,11 +25,12 @@ local Object = {
   Renderable = {
     Type = "RenderableStars",
     File = speck .. "denver_stars.speck",
-    Texture = textures .. "halo.png",
+    Halo = {
+      Texture = textures .. "halo.png"
+    },
     ColorMap = colorLUT .. "denver_colorbv.cmap",
     MagnitudeExponent = 6.2,
     SizeComposition = "Distance Modulus",
-    RenderMethod = "Texture Based", -- or PSF
     DataMapping = {
       Bv = "colorb_v",
       Luminance = "lum",

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -849,6 +849,7 @@ void RenderableStars::update(const UpdateData&) {
         std::vector<float> slice = createDataSlice(ColorOption(value));
 
         glBindVertexArray(_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, _vbo);
         glBufferData(
             GL_ARRAY_BUFFER,
             slice.size() * sizeof(GLfloat),
@@ -872,7 +873,7 @@ void RenderableStars::update(const UpdateData&) {
             GL_FLOAT,
             GL_FALSE,
             stride,
-            nullptr // = offsetof(ColorVBOLayout, position)
+            nullptr
         );
 
         glEnableVertexAttribArray(bvLumAbsMagAttrib);
@@ -946,6 +947,7 @@ void RenderableStars::update(const UpdateData&) {
                     stride,
                     reinterpret_cast<void*>(offsetof(OtherDataLayout, value))
                 );
+                break;
         }
 
         glBindVertexArray(0);

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -452,14 +452,14 @@ RenderableStars::RenderableStars(const ghoul::Dictionary& dictionary)
     , _halo{
         properties::PropertyOwner(HaloOwnerInfo),
         properties::StringProperty(TextureInfo),
-        properties::FloatProperty(MultiplierInfo, 1.f, 0.f, 5.f),
+        properties::FloatProperty(MultiplierInfo, 1.f, 0.f, 20.f),
         properties::FloatProperty(GammaInfo, 1.f, 0.f, 5.f),
         properties::FloatProperty(ScaleInfo, 1.f, 0.f, 1.f)
     }
     , _glare{
         properties::PropertyOwner(GlareOwnerInfo),
         properties::StringProperty(TextureInfo),
-        properties::FloatProperty(MultiplierInfo, 1.f, 0.f, 5.f),
+        properties::FloatProperty(MultiplierInfo, 1.f, 0.f, 20.f),
         properties::FloatProperty(GammaInfo, 1.f, 0.f, 5.f),
         properties::FloatProperty(ScaleInfo, 1.f, 0.f, 1.f)
     }

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -114,8 +114,8 @@ private:
         std::unique_ptr<ghoul::filesystem::File> file;
     };
 
+    Texture _halo;
     Texture _glare;
-    Texture _highlight;
 
     properties::FloatProperty _magnitudeExponent;
     properties::OptionProperty _psfMultiplyOption;
@@ -131,8 +131,8 @@ private:
         modelMatrix, cameraUp, cameraViewProjectionMatrix, colorOption, magnitudeExponent,
         eyePosition, psfParamConf, lumCent, radiusCent, brightnessCent, colorTexture,
         alphaValue, psfTexture, otherDataTexture, otherDataRange, filterOutOfRange,
-        fixedColor, hasHighlight, highlightTexture, glareOpacity, highlightOpacity,
-        glareScale, highlightScale
+        fixedColor, hasGlare, glareTexture, haloOpacity, glareOpacity,
+        haloScale, glareScale
     ) _uniformCache;
 
     bool _speckFileIsDirty = true;

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -102,15 +102,26 @@ private:
     std::unique_ptr<ghoul::opengl::Texture> _otherDataColorMapTexture;
     properties::Vec3Property _fixedColor;
     properties::BoolProperty _filterOutOfRange;
-    properties::StringProperty _pointSpreadFunctionTexturePath;
-    std::unique_ptr<ghoul::opengl::Texture> _pointSpreadFunctionTexture;
-    std::unique_ptr<ghoul::filesystem::File> _pointSpreadFunctionFile;
 
+    struct Texture {
+        properties::PropertyOwner owner;
+
+        properties::StringProperty texturePath;
+        properties::FloatProperty opacity;
+        properties::FloatProperty scale;
+
+        std::unique_ptr<ghoul::opengl::Texture> texture;
+        std::unique_ptr<ghoul::filesystem::File> file;
+    };
+
+    Texture _glare;
+    Texture _highlight;
+
+    properties::FloatProperty _magnitudeExponent;
     properties::OptionProperty _psfMultiplyOption;
     properties::FloatProperty _lumCent;
     properties::FloatProperty _radiusCent;
     properties::FloatProperty _brightnessCent;
-    properties::FloatProperty _magnitudeExponent;
     properties::PropertyOwner _parametersOwner;
     properties::Vec2Property _fadeInDistances;
     properties::BoolProperty _disableFadeInDistance;
@@ -120,13 +131,13 @@ private:
         modelMatrix, cameraUp, cameraViewProjectionMatrix, colorOption, magnitudeExponent,
         eyePosition, psfParamConf, lumCent, radiusCent, brightnessCent, colorTexture,
         alphaValue, psfTexture, otherDataTexture, otherDataRange, filterOutOfRange,
-        fixedColor
+        fixedColor, hasHighlight, highlightTexture, glareOpacity, highlightOpacity,
+        glareScale, highlightScale
     ) _uniformCache;
 
     bool _speckFileIsDirty = true;
     bool _pointSpreadFunctionTextureIsDirty = true;
     bool _colorTextureIsDirty = true;
-    //bool _shapeTextureIsDirty = true;
     bool _dataIsDirty = true;
     bool _otherDataColorMapIsDirty = true;
 

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -108,6 +108,7 @@ private:
 
         properties::StringProperty texturePath;
         properties::FloatProperty multiplier;
+        properties::FloatProperty gamma;
         properties::FloatProperty scale;
 
         std::unique_ptr<ghoul::opengl::Texture> texture;
@@ -131,9 +132,10 @@ private:
     std::unique_ptr<ghoul::opengl::ProgramObject> _program;
     UniformCache(
         modelMatrix, cameraViewProjectionMatrix, cameraUp, eyePosition, colorOption,
-        magnitudeExponent, sizeComposition, lumCent, radiusCent, colorTexture, alphaValue,
+        magnitudeExponent, sizeComposition, lumCent, radiusCent, colorTexture, opacity,
         otherDataTexture, otherDataRange, filterOutOfRange, fixedColor, haloTexture,
-        haloMultiplier, haloScale, hasGlare, glareTexture, glareMultiplier, glareScale
+        haloMultiplier, haloGamma, haloScale, hasGlare, glareTexture, glareMultiplier,
+        glareGamma, glareScale
     ) _uniformCache;
 
     bool _speckFileIsDirty = true;

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -59,7 +59,6 @@ public:
 
     bool isReady() const override;
 
-    void loadPSFTexture();
     void render(const RenderData& data, RendererTasks& rendererTask) override;
     void update(const UpdateData& data) override;
 
@@ -74,6 +73,7 @@ private:
         FixedColor = 4
     };
 
+    void loadPSFTexture();
     void loadData();
     std::vector<float> createDataSlice(ColorOption option);
 
@@ -83,8 +83,9 @@ private:
     std::unique_ptr<ghoul::opengl::Texture> _colorTexture;
     std::unique_ptr<ghoul::filesystem::File> _colorTextureFile;
 
-    properties::PropertyOwner _dataMappingContainer;
     struct {
+        properties::PropertyOwner container;
+
         properties::StringProperty bvColor;
         properties::StringProperty luminance;
         properties::StringProperty absoluteMagnitude;
@@ -103,8 +104,8 @@ private:
     properties::Vec3Property _fixedColor;
     properties::BoolProperty _filterOutOfRange;
 
-    struct Texture {
-        properties::PropertyOwner owner;
+    struct TextureComponent {
+        properties::PropertyOwner container;
 
         properties::StringProperty texturePath;
         properties::FloatProperty opacity;
@@ -114,25 +115,28 @@ private:
         std::unique_ptr<ghoul::filesystem::File> file;
     };
 
-    Texture _halo;
-    Texture _glare;
+    TextureComponent _halo;
+    TextureComponent _glare;
+
+    struct {
+        properties::PropertyOwner container;
+        properties::OptionProperty sizeComposition;
+        properties::FloatProperty lumCent;
+        properties::FloatProperty radiusCent;
+        properties::FloatProperty brightnessCent;
+    } _parameters;
 
     properties::FloatProperty _magnitudeExponent;
-    properties::OptionProperty _psfMultiplyOption;
-    properties::FloatProperty _lumCent;
-    properties::FloatProperty _radiusCent;
-    properties::FloatProperty _brightnessCent;
-    properties::PropertyOwner _parametersOwner;
     properties::Vec2Property _fadeInDistances;
-    properties::BoolProperty _disableFadeInDistance;
+    properties::BoolProperty _enableFadeInDistance;
 
     std::unique_ptr<ghoul::opengl::ProgramObject> _program;
     UniformCache(
-        modelMatrix, cameraUp, cameraViewProjectionMatrix, colorOption, magnitudeExponent,
-        eyePosition, psfParamConf, lumCent, radiusCent, brightnessCent, colorTexture,
-        alphaValue, psfTexture, otherDataTexture, otherDataRange, filterOutOfRange,
-        fixedColor, hasGlare, glareTexture, haloOpacity, glareOpacity,
-        haloScale, glareScale
+        modelMatrix, cameraViewProjectionMatrix, cameraUp, eyePosition, colorOption,
+        magnitudeExponent, sizeComposition, lumCent, radiusCent, brightnessCent,
+        colorTexture, alphaValue, otherDataTexture, otherDataRange, filterOutOfRange,
+        fixedColor, haloTexture, haloOpacity, haloScale, hasGlare, glareTexture,
+        glareOpacity, glareScale
     ) _uniformCache;
 
     bool _speckFileIsDirty = true;
@@ -149,7 +153,6 @@ private:
     float _staticFilterReplacementValue = 0.f;
 
     GLuint _vao = 0;
-    GLuint _vbo = 0;
 };
 
 } // namespace openspace

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -60,7 +60,6 @@ public:
     bool isReady() const override;
 
     void loadPSFTexture();
-    void renderPSFToTexture();
     void render(const RenderData& data, RendererTasks& rendererTask) override;
     void update(const UpdateData& data) override;
 
@@ -107,24 +106,12 @@ private:
     std::unique_ptr<ghoul::opengl::Texture> _pointSpreadFunctionTexture;
     std::unique_ptr<ghoul::filesystem::File> _pointSpreadFunctionFile;
 
-    properties::OptionProperty _psfMethodOption;
     properties::OptionProperty _psfMultiplyOption;
     properties::FloatProperty _lumCent;
     properties::FloatProperty _radiusCent;
     properties::FloatProperty _brightnessCent;
     properties::FloatProperty _magnitudeExponent;
-    properties::PropertyOwner _spencerPSFParamOwner;
-    properties::FloatProperty _p0Param;
-    properties::FloatProperty _p1Param;
-    properties::FloatProperty _p2Param;
-    properties::FloatProperty _spencerAlphaConst;
-    properties::PropertyOwner _moffatPSFParamOwner;
-    properties::FloatProperty _FWHMConst;
-    properties::FloatProperty _moffatBetaConst;
-    properties::OptionProperty _renderingMethodOption;
-    properties::PropertyOwner _userProvidedTextureOwner;
     properties::PropertyOwner _parametersOwner;
-    properties::PropertyOwner _moffatMethodOwner;
     properties::Vec2Property _fadeInDistances;
     properties::BoolProperty _disableFadeInDistance;
 
@@ -152,10 +139,6 @@ private:
 
     GLuint _vao = 0;
     GLuint _vbo = 0;
-    GLuint _psfVao = 0;
-    GLuint _psfVbo = 0;
-    GLuint _psfTexture = 0;
-    GLuint _convolvedTexture = 0;
 };
 
 } // namespace openspace

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -119,7 +119,7 @@ private:
 
     struct {
         properties::PropertyOwner container;
-        properties::OptionProperty sizeComposition;
+        properties::OptionProperty method;
         properties::FloatProperty lumCent;
         properties::FloatProperty radiusCent;
     } _parameters;
@@ -150,6 +150,7 @@ private:
     float _staticFilterReplacementValue = 0.f;
 
     GLuint _vao = 0;
+    GLuint _vbo = 0;
 };
 
 } // namespace openspace

--- a/modules/space/rendering/renderablestars.h
+++ b/modules/space/rendering/renderablestars.h
@@ -89,7 +89,6 @@ private:
         properties::StringProperty bvColor;
         properties::StringProperty luminance;
         properties::StringProperty absoluteMagnitude;
-        properties::StringProperty apparentMagnitude;
         properties::StringProperty vx;
         properties::StringProperty vy;
         properties::StringProperty vz;
@@ -108,7 +107,7 @@ private:
         properties::PropertyOwner container;
 
         properties::StringProperty texturePath;
-        properties::FloatProperty opacity;
+        properties::FloatProperty multiplier;
         properties::FloatProperty scale;
 
         std::unique_ptr<ghoul::opengl::Texture> texture;
@@ -123,7 +122,6 @@ private:
         properties::OptionProperty sizeComposition;
         properties::FloatProperty lumCent;
         properties::FloatProperty radiusCent;
-        properties::FloatProperty brightnessCent;
     } _parameters;
 
     properties::FloatProperty _magnitudeExponent;
@@ -133,10 +131,9 @@ private:
     std::unique_ptr<ghoul::opengl::ProgramObject> _program;
     UniformCache(
         modelMatrix, cameraViewProjectionMatrix, cameraUp, eyePosition, colorOption,
-        magnitudeExponent, sizeComposition, lumCent, radiusCent, brightnessCent,
-        colorTexture, alphaValue, otherDataTexture, otherDataRange, filterOutOfRange,
-        fixedColor, haloTexture, haloOpacity, haloScale, hasGlare, glareTexture,
-        glareOpacity, glareScale
+        magnitudeExponent, sizeComposition, lumCent, radiusCent, colorTexture, alphaValue,
+        otherDataTexture, otherDataRange, filterOutOfRange, fixedColor, haloTexture,
+        haloMultiplier, haloScale, hasGlare, glareTexture, glareMultiplier, glareScale
     ) _uniformCache;
 
     bool _speckFileIsDirty = true;

--- a/modules/space/shaders/star_fs.glsl
+++ b/modules/space/shaders/star_fs.glsl
@@ -32,7 +32,7 @@ flat in float ge_speed;
 flat in float gs_screenSpaceDepth;
 
 uniform sampler1D colorTexture;
-uniform sampler2D psfTexture;
+uniform sampler2D haloTexture;
 uniform float alphaValue;
 uniform vec3 fixedColor;
 uniform int colorOption;
@@ -76,6 +76,7 @@ vec4 otherDataValue() {
 
 Fragment getFragment() {
   vec4 color = vec4(0.0);
+
   switch (colorOption) {
     case ColorOptionColor:
       color = bv2rgb(ge_bv);
@@ -104,7 +105,7 @@ Fragment getFragment() {
 
   vec2 scaledCoordsHalo = shiftedCoords / haloScale;
   vec2 unshiftedCoordsHalo = (scaledCoordsHalo + 1.0) / 2.0;
-  float textureColor = texture(psfTexture, unshiftedCoordsHalo).a * haloOpacity;
+  float textureColor = texture(haloTexture, unshiftedCoordsHalo).a * haloOpacity;
   if (hasGlare) {
     vec2 scaledCoordsGlare = shiftedCoords / glareScale;
     vec2 unshiftedCoordsGlare = (scaledCoordsGlare + 1.0) / 2.0;

--- a/modules/space/shaders/star_fs.glsl
+++ b/modules/space/shaders/star_fs.glsl
@@ -33,7 +33,7 @@ flat in float gs_screenSpaceDepth;
 
 uniform sampler1D colorTexture;
 uniform sampler2D haloTexture;
-uniform float alphaValue;
+uniform float opacity;
 uniform vec3 fixedColor;
 uniform int colorOption;
 uniform sampler1D otherDataTexture;
@@ -41,11 +41,13 @@ uniform vec2 otherDataRange;
 uniform bool filterOutOfRange;
 
 uniform float haloMultiplier;
+uniform float haloGamma;
 uniform float haloScale;
 
 uniform bool hasGlare;
 uniform sampler2D glareTexture;
 uniform float glareMultiplier;
+uniform float glareGamma;
 uniform float glareScale;
 
 // keep in sync with renderablestars.h:ColorOption enum
@@ -105,15 +107,17 @@ Fragment getFragment() {
 
   vec2 scaledCoordsHalo = shiftedCoords / haloScale;
   vec2 unshiftedCoordsHalo = (scaledCoordsHalo + 1.0) / 2.0;
-  float textureColor = texture(haloTexture, unshiftedCoordsHalo).a * haloMultiplier;
+  float haloValue = texture(haloTexture, unshiftedCoordsHalo).a;
+  float alpha = pow(haloValue, haloGamma) * haloMultiplier;
   if (hasGlare) {
     vec2 scaledCoordsGlare = shiftedCoords / glareScale;
     vec2 unshiftedCoordsGlare = (scaledCoordsGlare + 1.0) / 2.0;
-    float glare = texture(glareTexture, unshiftedCoordsGlare).a * glareMultiplier;
-    textureColor += glare;
+    float glareValue = texture(glareTexture, unshiftedCoordsGlare).a;
+    float glare = pow(glareValue, glareGamma) * glareMultiplier;
+    alpha += glare;
   }
 
-  vec4 fullColor = vec4(color.rgb, textureColor * alphaValue);
+  vec4 fullColor = vec4(color.rgb, alpha * opacity);
 
   if (fullColor.a < 0.001) {
     discard;

--- a/modules/space/shaders/star_fs.glsl
+++ b/modules/space/shaders/star_fs.glsl
@@ -40,13 +40,13 @@ uniform sampler1D otherDataTexture;
 uniform vec2 otherDataRange;
 uniform bool filterOutOfRange;
 
+uniform float haloOpacity;
+uniform float haloScale;
+
+uniform bool hasGlare;
+uniform sampler2D glareTexture;
 uniform float glareOpacity;
 uniform float glareScale;
-
-uniform bool hasHighlight;
-uniform sampler2D highlightTexture;
-uniform float highlightOpacity;
-uniform float highlightScale;
 
 // keep in sync with renderablestars.h:ColorOption enum
 const int ColorOptionColor = 0;
@@ -102,14 +102,14 @@ Fragment getFragment() {
 
   vec2 shiftedCoords = (texCoords - 0.5) * 2;
 
-  vec2 scaledCoordsGlare = shiftedCoords / glareScale;
-  vec2 unshiftedCoordsGlare = (scaledCoordsGlare + 1.0) / 2.0;
-  float textureColor = texture(psfTexture, unshiftedCoordsGlare).a * glareOpacity;
-  if (hasHighlight) {
-    vec2 scaledCoordsHighlight = shiftedCoords / highlightScale;
-    vec2 unshiftedCoordsHighlight = (scaledCoordsHighlight + 1.0) / 2.0;
-    float highlight = texture(highlightTexture, unshiftedCoordsHighlight).a * highlightOpacity;
-    textureColor += highlight;
+  vec2 scaledCoordsHalo = shiftedCoords / haloScale;
+  vec2 unshiftedCoordsHalo = (scaledCoordsHalo + 1.0) / 2.0;
+  float textureColor = texture(psfTexture, unshiftedCoordsHalo).a * haloOpacity;
+  if (hasGlare) {
+    vec2 scaledCoordsGlare = shiftedCoords / glareScale;
+    vec2 unshiftedCoordsGlare = (scaledCoordsGlare + 1.0) / 2.0;
+    float glare = texture(glareTexture, unshiftedCoordsGlare).a * glareOpacity;
+    textureColor += glare;
   }
 
   vec4 fullColor = vec4(color.rgb, textureColor * alphaValue);

--- a/modules/space/shaders/star_fs.glsl
+++ b/modules/space/shaders/star_fs.glsl
@@ -40,12 +40,12 @@ uniform sampler1D otherDataTexture;
 uniform vec2 otherDataRange;
 uniform bool filterOutOfRange;
 
-uniform float haloOpacity;
+uniform float haloMultiplier;
 uniform float haloScale;
 
 uniform bool hasGlare;
 uniform sampler2D glareTexture;
-uniform float glareOpacity;
+uniform float glareMultiplier;
 uniform float glareScale;
 
 // keep in sync with renderablestars.h:ColorOption enum
@@ -105,11 +105,11 @@ Fragment getFragment() {
 
   vec2 scaledCoordsHalo = shiftedCoords / haloScale;
   vec2 unshiftedCoordsHalo = (scaledCoordsHalo + 1.0) / 2.0;
-  float textureColor = texture(haloTexture, unshiftedCoordsHalo).a * haloOpacity;
+  float textureColor = texture(haloTexture, unshiftedCoordsHalo).a * haloMultiplier;
   if (hasGlare) {
     vec2 scaledCoordsGlare = shiftedCoords / glareScale;
     vec2 unshiftedCoordsGlare = (scaledCoordsGlare + 1.0) / 2.0;
-    float glare = texture(glareTexture, unshiftedCoordsGlare).a * glareOpacity;
+    float glare = texture(glareTexture, unshiftedCoordsGlare).a * glareMultiplier;
     textureColor += glare;
   }
 

--- a/modules/space/shaders/star_ge.glsl
+++ b/modules/space/shaders/star_ge.glsl
@@ -42,7 +42,7 @@ flat out float gs_screenSpaceDepth;
 uniform float magnitudeExponent;
 uniform dvec3 eyePosition;
 uniform dvec3 cameraUp;
-uniform int psfParamConf;
+uniform int sizeComposition;
 uniform float lumCent;
 uniform float radiusCent;
 uniform float brightnessCent;
@@ -50,7 +50,6 @@ uniform dmat4 cameraViewProjectionMatrix;
 uniform dmat4 modelMatrix;
 
 const double PARSEC = 3.08567756E16;
-//const double PARSEC = 3.08567782E16;
 
 // FRAGILE
 // All of these values have to be synchronized with the values in the optionproperty
@@ -111,19 +110,8 @@ double scaleForApparentMagnitude(dvec3 dpos, float absMag) {
   double distanceToStarInMeters = length(dpos - eyePosition);
   double distanceToCenterInMeters = length(eyePosition);
   float distanceToStarInParsecs = float(distanceToStarInMeters/PARSEC);
-  //float appMag = absMag + 5*log(distanceToStarInParsecs) - 5.0;
   float appMag = absMag + 5.0 * (log(distanceToStarInParsecs/10.0)/log(2.0));
-  //appMag = vs_bvLumAbsMagAppMag[0].w;
-
-  //scaleMultiply = (30.623 - appMag) * pow(10.0, magnitudeExponent + 7.0);// *
-  //float(distanceToStarInMeters/distanceToCenterInMeters);
-
   return (-appMag + 50.0) * pow(10.0, magnitudeExponent + 7.5);
-  // return log(35.f + appMag) *  pow(10.0, magnitudeExponent + 6.5f);
-  // return exp((35.f - appMag) * 0.2) * pow(10.0, magnitudeExponent + 2.5f);
-  // return appMag * pow(10.0, magnitudeExponent + 8.5f);
-  // return exp((-30.0 - appMag) * 0.45) * pow(10.0, magnitudeExponent + 8.f);
-  // return pow(10.0, (appMag - absMag)*(1.0/5.0) + 1.0) * pow(10.0, magnitudeExponent + 3.f);
 }
 
 double scaleForDistanceModulus(float absMag) {
@@ -142,36 +130,36 @@ void main() {
 
   double scaleMultiply = 1.0;
 
-  if (psfParamConf == SizeCompositionOptionAppBrightness) {
+  if (sizeComposition == SizeCompositionOptionAppBrightness) {
     float luminance = vs_bvLumAbsMagAppMag[0].y;
 
     scaleMultiply = scaleForApparentBrightness(dpos.xyz, luminance);
   }
-  else if (psfParamConf == SizeCompositionOptionLumSize) {
+  else if (sizeComposition == SizeCompositionOptionLumSize) {
     float bv = vs_bvLumAbsMagAppMag[0].x;
     float luminance = vs_bvLumAbsMagAppMag[0].y;
     float absMagnitude = vs_bvLumAbsMagAppMag[0].z;
 
     scaleMultiply = scaleForLuminositySize(bv, luminance, absMagnitude);
   }
-  else if (psfParamConf == SizeCompositionOptionLumSizeAppBrightness) {
+  else if (sizeComposition == SizeCompositionOptionLumSizeAppBrightness) {
     float bv = vs_bvLumAbsMagAppMag[0].x;
     float luminance = vs_bvLumAbsMagAppMag[0].y;
     float absMagnitude = vs_bvLumAbsMagAppMag[0].z;
 
     scaleMultiply = scaleForLuminositySizeAppBrightness(dpos.xyz, bv, luminance, absMagnitude);
   }
-  else if (psfParamConf == SizeCompositionOptionLumSizeAbsMagnitude) {
+  else if (sizeComposition == SizeCompositionOptionLumSizeAbsMagnitude) {
     float absMagnitude = vs_bvLumAbsMagAppMag[0].z;
 
     scaleMultiply = scaleForAbsoluteMagnitude(absMagnitude);
   }
-  else if (psfParamConf == SizeCompositionOptionLumSizeAppMagnitude) {
+  else if (sizeComposition == SizeCompositionOptionLumSizeAppMagnitude) {
     float absMagnitude = vs_bvLumAbsMagAppMag[0].z;
 
     scaleMultiply = scaleForApparentMagnitude(dpos.xyz, absMagnitude);
   }
-  else if (psfParamConf == SizeCompositionOptionLumSizeDistanceModulus) {
+  else if (sizeComposition == SizeCompositionOptionLumSizeDistanceModulus) {
     float absMagnitude = vs_bvLumAbsMagAppMag[0].z;
 
     scaleMultiply = scaleForDistanceModulus(absMagnitude);
@@ -207,7 +195,7 @@ void main() {
   EmitVertex();
 
   gl_Position = lowerRight;
-  texCoords = vec2(1.0,0.0);
+  texCoords = vec2(1.0, 0.0);
   EmitVertex();
 
   gl_Position = upperLeft;

--- a/modules/space/shaders/star_vs.glsl
+++ b/modules/space/shaders/star_vs.glsl
@@ -25,17 +25,17 @@
 #version __CONTEXT__
 
 in vec3 in_position;
-in vec4 in_bvLumAbsMagAppMag;
+in vec3 in_bvLumAbsMag;
 in vec3 in_velocity;
 in float in_speed;
 
-out vec4 vs_bvLumAbsMagAppMag;
+out vec3 vs_bvLumAbsMag;
 out vec3 vs_velocity;
 out float vs_speed;
 
 
 void main() {
-  vs_bvLumAbsMagAppMag = in_bvLumAbsMagAppMag;
+  vs_bvLumAbsMag = in_bvLumAbsMag;
   vs_velocity = in_velocity;
   vs_speed = in_speed;
 


### PR DESCRIPTION
This changes the RenderableStars to render two textures (a halo + a glare) on top of each other. Each texture component is configurable separately.  This change also has a few quality of life features in the code to remove double negations, etc.