### PR TITLE
Update Lua script documentation for `openspace.navigation` and `openspace.pathnavigation`

### DIFF
--- a/data/assets/util/joysticks/joystick_helper.asset
+++ b/data/assets/util/joysticks/joystick_helper.asset
@@ -9,7 +9,7 @@ local function bindLocalRoll(name, axis)
     -- We only want to store the current state in the first mode that is enabled, otherwise we will overwrite the backup
     if not Joystick.State.IsInRollMode then
       -- Save current axis state
-      Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
+      Joystick.State.Axis = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
     end
 
     -- Set new axis state
@@ -23,7 +23,7 @@ local function bindGlobalRoll(name, axis)
     -- We only want to store the current state in the first mode that is enabled, otherwise we will overwrite the backup
     if not Joystick.State.IsInRollMode then
       -- Save current axis state
-      Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
+      Joystick.State.Axis = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
     end
 
     -- Set new axis state
@@ -35,7 +35,7 @@ end
 local function permaBindLocalRoll(name, axis)
   return [[
     -- Save current axis state
-    Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
+    Joystick.State.Axis = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
 
     -- Set new axis state
     openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "LocalRoll", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity)
@@ -45,7 +45,7 @@ end
 local function permaBindGlobalRoll(name, axis)
   return [[
     -- Save current axis state
-    Joystick.State.Axis.Type, Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity, Joystick.State.Axis.PropertyUri, Joystick.State.Axis.MinValue, Joystick.State.Axis.MaxValue, Joystick.State.Axis.IsRemote = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
+    Joystick.State.Axis = openspace.navigation.joystickAxis("]] .. name .. "\", " .. axis .. [[)
 
     -- Set new axis state
     openspace.navigation.bindJoystickAxis("]] .. name .. "\", " .. axis .. [[, "GlobalRoll", Joystick.State.Axis.Inverted, Joystick.State.Axis.JoystickType, Joystick.State.Axis.Sticky, Joystick.State.Axis.Flip, Joystick.State.Axis.Sensitivity)

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -204,7 +204,6 @@ namespace {
     global::navigationHandler->orbitalNavigator().startRetargetAnchor();
 }
 
-// @TODO: consider adding enum types for axis type and joysticktype
 /**
  * Bind an axis of a joystick to be used as a certain type, and optionally define
  * detailed settings for the axis.
@@ -280,8 +279,6 @@ namespace {
     );
 }
 
-// @TODO: Should this be a concrete Type in the documentation? Could also be used in bind
-// joystick functions above//
 struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
     // The current type of axis binding
     std::string type;
@@ -324,10 +321,6 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
     // actions)
     std::optional<bool> isRemote;
 };
-
-// @TODO: How to create a reference to the above object as the return type?
-// Should we really create documentation for the JoyStickCameraStates::AxisInfomation
-// struct instead?
 
 /**
  * Return all the information bound to a certain joystick axis.

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -25,12 +25,13 @@
 namespace {
 
 /**
- * Set the camera position by loading a navigation state from file. The file should be in
- * json format, such as the output files of `saveNavigationState`.
+ * Set the camera position by loading a [NavigationState](#core_navigation_state) from
+ * file. The file should be in json format, such as the output files of
+ * `saveNavigationState`.
  *
  * \param filePath the path to the file, including the file name (and extension, if it is
  *                 anything other than `.navstate`)
- * \param useTimeStamp if true, and the provided navigation state includes a timestamp,
+ * \param useTimeStamp if true, and the provided NavigationState includes a timestamp,
  *                     the time will be set as well.
  */
 [[codegen::luawrap]] void loadNavigationState(std::string filePath,
@@ -47,17 +48,16 @@ namespace {
 }
 
 /**
- * Return the current navigation state as a Lua table.
+ * Return the current [NavigationState](#core_navigation_state) as a Lua table.
  *
  * By default, the reference frame will be picked based on whether the orbital navigator is
  * currently following the anchor node rotation. If it is, the anchor will be chosen as
  * reference frame. If not, the reference frame will be set to the scene graph root.
  *
  * \param frame the identifier of an optional scene graph node to use as reference frame
- *              for the navigation state
+ *              for the NavigationState
  *
- * \return a Lua table representing the current [navigation state](#core_navigation_state)
- *         of the camera
+ * \return a Lua table representing the current NavigationState of the camera
  */
 [[codegen::luawrap]] ghoul::Dictionary getNavigationState(
                                                          std::optional<std::string> frame)
@@ -82,11 +82,10 @@ namespace {
 }
 
 /**
- * Set the camera position from a provided navigation state.
+ * Set the camera position from a provided [NavigationState](#core_navigation_state).
  *
- * \param navigationState a table describing the [NavigationState](#core_navigation_state)
- *                        to set
- * \param useTimeStamp if true, and the provided navigation state includes a timestamp,
+ * \param navigationState a table describing the NavigationState to set
+ * \param useTimeStamp if true, and the provided NavigationState includes a timestamp,
  *                     the time will be set as well
  */
 [[codegen::luawrap]] void setNavigationState(ghoul::Dictionary navigationState,
@@ -104,16 +103,17 @@ namespace {
 }
 
 /**
- * Save the current navigation state to a file with the path given by the first argument.
+ * Save the current [NavigationState](#core_navigation_state) to a file with the path
+ * given by the first argument.
  *
  * By default, the reference frame will be picked based on whether the orbital navigator
  * is currently following the anchor node rotation. If it is, the anchor will be chosen as
  * reference frame. If not, the reference frame will be set to the scene graph root.
  *
- * \param path the file path for where to save the navigation state, including the file
+ * \param path the file path for where to save the NavigationState, including the file
  *             name. If no extension is added, the file is saved as a `.navstate` file.
  * \param frame the identifier of the scene graph node which coordinate system should be
- *              used as a reference frame for the navigation state.
+ *              used as a reference frame for the NavigationState.
  */
 [[codegen::luawrap]] void saveNavigationState(std::string path, std::string frame = "") {
     if (path.empty()) {

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -470,15 +470,15 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
 /**
  * Directly add to the global rotation of the camera (around the focus node).
  *
- * \param v1 the value to add in the x-direction (a positive value rotates to the
- *           right and a negative value to the left)
- * \param v2 the value to add in the y-direction (a positive value rotates the focus
- *           upwards and a negative value downwards)
+ * \param xValue the value to add in the x-direction (a positive value rotates to the
+ *               right and a negative value to the left)
+ * \param yValue the value to add in the y-direction (a positive value rotates the focus
+ *               upwards and a negative value downwards)
  */
-[[codegen::luawrap]] void addGlobalRotation(double v1, double v2) {
+[[codegen::luawrap]] void addGlobalRotation(double xValue, double yValue) {
     using namespace openspace;
     global::navigationHandler->orbitalNavigator().scriptStates().addGlobalRotation(
-        glm::dvec2(v1, v2)
+        glm::dvec2(xValue, yValue)
     );
 }
 
@@ -486,15 +486,15 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
  * Directly adds to the local rotation of the camera (around the camera's current
  * position).
  *
- * \param v1 the value to add in the x-direction (a positive value rotates to the
- *           left and a negative value to the right)
- * \param v2 the value to add in the y-direction (a positive value rotates the camera
- *           upwards and a negative value downwards)
+ * \param xValue the value to add in the x-direction (a positive value rotates to the
+ *               left and a negative value to the right)
+ * \param yValue the value to add in the y-direction (a positive value rotates the camera
+ *               upwards and a negative value downwards)
  */
-[[codegen::luawrap]] void addLocalRotation(double v1, double v2) {
+[[codegen::luawrap]] void addLocalRotation(double xValue, double yValue) {
     using namespace openspace;
     global::navigationHandler->orbitalNavigator().scriptStates().addLocalRotation(
-        glm::dvec2(v1, v2)
+        glm::dvec2(xValue, yValue)
     );
 }
 
@@ -506,14 +506,14 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
  * A positive value moves the camera closer to the focus, and a negative value moves the
  * camera further away.
  *
- * \param v the value to add
+ * \param value the value to add
  */
-[[codegen::luawrap]] void addTruckMovement(double v) {
+[[codegen::luawrap]] void addTruckMovement(double value) {
     using namespace openspace;
     // @TODO: Note that the x value isn't actually used and the code in the navigation
     // handlers for these should be cleaned up. The same goes for the roll funcitons below
     global::navigationHandler->orbitalNavigator().scriptStates().addTruckMovement(
-        glm::dvec2(0.0, v)
+        glm::dvec2(0.0, value)
     );
 }
 
@@ -521,12 +521,12 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
  * Directly adds to the local roll of the camera. This is the rotation around the camera's
  * forward/view direction.
  *
- * \param v the value to add
+ * \param value the value to add
  */
-[[codegen::luawrap]] void addLocalRoll(double v) {
+[[codegen::luawrap]] void addLocalRoll(double value) {
     using namespace openspace;
     global::navigationHandler->orbitalNavigator().scriptStates().addLocalRoll(
-        glm::dvec2(v, 0.0)
+        glm::dvec2(value, 0.0)
     );
 }
 
@@ -535,12 +535,12 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
  * between the focus node and the camera (not always the same as the camera view
  * direction)
  *
- * \param v the value to add
+ * \param value the value to add
  */
-[[codegen::luawrap]] void addGlobalRoll(double v) {
+[[codegen::luawrap]] void addGlobalRoll(double value) {
     using namespace openspace;
     global::navigationHandler->orbitalNavigator().scriptStates().addGlobalRoll(
-        glm::dvec2(v, 0.0)
+        glm::dvec2(value, 0.0)
     );
 }
 

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -26,10 +26,10 @@ namespace {
 
 /**
  * Set the camera position by loading a navigation state from file. The file should be in
- * json format, such as the output files of saveNavigationState.
+ * json format, such as the output files of `saveNavigationState`.
  *
  * \param filePath the path to the file, including the file name (and extension, if it is
- *                 anything alse than `.navstate`)
+ *                 anything other than `.navstate`)
  * \param useTimeStamp if true, and the provided navigation state includes a timestamp,
  *                     the time will be set as well.
  */
@@ -49,14 +49,14 @@ namespace {
 /**
  * Return the current navigation state as a Lua table.
  *
- * By default, the reference frame will picked based on whether the orbital navigator is
+ * By default, the reference frame will be picked based on whether the orbital navigator is
  * currently following the anchor node rotation. If it is, the anchor will be chosen as
  * reference frame. If not, the reference frame will be set to the scene graph root.
  *
  * \param frame the identifier of an optional scene graph node to use as reference frame
  *              for the navigation state
  *
- * \return a Lua table representing the current [ navigation state](#core_navigation_state)
+ * \return a Lua table representing the current [navigation state](#core_navigation_state)
  *         of the camera
  */
 [[codegen::luawrap]] ghoul::Dictionary getNavigationState(
@@ -106,14 +106,14 @@ namespace {
 /**
  * Save the current navigation state to a file with the path given by the first argument.
  *
- * By default, the reference frame will picked based on whether the orbital navigator is
- * currently following the anchor node rotation. If it is, the anchor will be chosen as
+ * By default, the reference frame will be picked based on whether the orbital navigator
+ * is currently following the anchor node rotation. If it is, the anchor will be chosen as
  * reference frame. If not, the reference frame will be set to the scene graph root.
  *
- * \param path the file path for to where to save the navigation state, including the file
- *             name. If no extnesion is added, the file is saved as a .navstate file.
+ * \param path the file path for where to save the navigation state, including the file
+ *             name. If no extension is added, the file is saved as a `.navstate` file.
  * \param frame the identifier of the scene graph node which coordinate system should be
- *              used as a reference frame for the navigation state
+ *              used as a reference frame for the navigation state.
  */
 [[codegen::luawrap]] void saveNavigationState(std::string path, std::string frame = "") {
     if (path.empty()) {
@@ -137,8 +137,9 @@ namespace {
 }
 
 /**
- * Picks the next node from the interesting nodes out of the profile and selects that. If
- * the current anchor is not an interesting node, the first will be selected
+ * Picks the next node from the interesting nodes out of the profile and selects that.
+ * If the current anchor is not an interesting node, the first node in the list will be
+ * selected.
  */
 [[codegen::luawrap]] void targetNextInterestingAnchor() {
     using namespace openspace;
@@ -169,8 +170,9 @@ namespace {
 }
 
 /**
- * Picks the next node from the interesting nodes out of the profile and selects that. If
- * the current anchor is not an interesting node, the first will be selected
+ * Picks the previous node from the interesting nodes out of the profile and selects that.
+ * If the current anchor is not an interesting node, the first node in the list will be
+ * selected.
  */
 [[codegen::luawrap]] void targetPreviousInterestingAnchor() {
     using namespace openspace;
@@ -204,25 +206,18 @@ namespace {
 
 // @TODO: consider adding enum types for axis type and joysticktype
 /**
- * Bind an axis of a joystick to be used as a certain type.
- *
- * There are also some extra settings that control the behavior:
- * - If `isInverted` is `true`, the axis value is inverted.
- * - `joystickType` decides if the joystick behaves more like a joystick
- * or a trigger, where the first is the default.
- * - If `isSticky` is `true, the value is calculated relative to the previous value.
- * - If`'shouldFlip` is true, then the camera movement for the axis is reversed.
- * - Finally, if `sensitivity` is given then that value will affect the sensitivity of
- * the axis together with the global sensitivity.
+ * Bind an axis of a joystick to be used as a certain type, and optionally define
+ * detailed settings for the axis.
  *
  * \param joystickName the name for the joystick or game controller that should be bound
  * \param axis the axis of the joystick that should be bound
  * \param axisType the type of movement that the axis should be mapped to
- * \param shouldInvert if the joystick movement should be inverted or not
- * \param joystickType what type of joystick or axis this is. Either
- *                     `\"JoystickLike\"` or `\"TriggerLike\"`
- * \param isSticky if true, the value is calculated relative to the previous value,
- *                 if false the the value is used as is
+ * \param shouldInvert decides if the joystick axis movement should be inverted or not
+ * \param joystickType what type of joystick or axis this is. Decides if the joystick
+ *                     behaves more like a joystick or a trigger. Either `"JoystickLike"`
+ *                     or `"TriggerLike"`, where `"JoystickLike"` is default
+ * \param isSticky if true, the value is calculated relative to the previous value.
+ *                 If false, the value is used as is
  * \param shouldFlip reverses the movement of the camera that the joystick produces
  * \param sensitivity sensitivity for this axis, in addition to the global sensitivity
  */
@@ -263,8 +258,8 @@ namespace {
  * \param min the minimum value that this axis can set for the property
  * \param max the maximum value that this axis can set for the property
  * \param shouldInvert if the joystick movement should be inverted or not
- * \param isRemote if true, the property change will also be executed on connected nodes
- *                 if false, the property change will only affect the master node
+ * \param isRemote if true, the property change will also be executed on connected nodes.
+ *                 If false, the property change will only affect the master node
  */
 [[codegen::luawrap]] void bindJoystickAxisProperty(std::string joystickName, int axis,
                                                    std::string propertyUri,
@@ -325,7 +320,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
     std::optional<float> maxValue;
 
     // If a property is bound to this axis, this says whether the property changes should
-    // be forwarded to other connected nodes or session (similarly to \"isLocal\" for
+    // be forwarded to other connected nodes or sessions (similarly to \"isLocal\" for
     // actions)
     std::optional<bool> isRemote;
 };
@@ -341,7 +336,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
  *                     which to find the information
  * \param axis the joystick axis for which to find the information
  *
- * \return Information about the joystick axis
+ * \return an object with information about the joystick axis
  */
 [[codegen::luawrap]] ghoul::Dictionary joystickAxis(std::string joystickName, int axis) {
     using namespace openspace;
@@ -404,7 +399,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
     return deadzone;
 }
 
-/***
+/**
  * Bind a Lua script to one of the buttons for a joystick.
  *
  * \param joystickName the name for the joystick or game controller
@@ -414,8 +409,8 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
  * \param action the action for when the script should be executed. This defaults to
  *               `"Press"`, which means that the script is run when the user presses the
  *               button. Alternatives are `"Idle"` (if the button is unpressed and has
- *               been unpressed since last frame), `"Repeat"` (if the button has been
- *               pressed since longer than last frame), and `"Release"` (f the button was
+ *               been unpressed since the last frame), `"Repeat"` (if the button has been
+ *               pressed since longer than the last frame), and `"Release"` (if the button was
  *               released since the last frame)
  * \param isRemote a value saying whether the command is going to be executable
  *                 locally or remotely, where the latter is the default
@@ -571,7 +566,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
 }
 
 /**
- * Return the complete list of connected joysticks
+ * Return the complete list of connected joysticks.
  *
  * \return a list of joystick names
  */
@@ -581,7 +576,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
 }
 
 /**
- * Return the distance to the current focus node
+ * Return the distance to the current focus node.
  *
  * \return the distance, in meters
  */
@@ -595,7 +590,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
 }
 
 /**
- * Return the distance to the current focus node's bounding sphere
+ * Return the distance to the current focus node's bounding sphere.
  *
  * \return the distance, in meters
  */
@@ -611,7 +606,7 @@ struct [[codegen::Dictionary(JoystickAxis)]] JoystickAxis {
 }
 
 /**
- * Return the distance to the current focus node's interaction sphere
+ * Return the distance to the current focus node's interaction sphere.
  *
  * \return the distance, in meters
  */

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -56,7 +56,8 @@ namespace {
  * \param frame the identifier of an optional scene graph node to use as reference frame
  *              for the navigation state
  *
- * \return a Lua table representing the current navigation state of the camera
+ * \return a Lua table representing the current [ navigation state](#core_navigation_state)
+ *         of the camera
  */
 [[codegen::luawrap]] ghoul::Dictionary getNavigationState(
                                                          std::optional<std::string> frame)

--- a/src/navigation/pathnavigator_lua.inl
+++ b/src/navigation/pathnavigator_lua.inl
@@ -62,7 +62,6 @@ namespace {
     openspace::global::navigationHandler->pathNavigator().skipToEnd();
 }
 
-// @TODO: Split this up into two functions and then document (to remove the confusion)
 /**
  * Move the camera to the node with the specified identifier. The optional double
  * specifies the duration of the motion, in seconds. If the optional bool is set to true
@@ -118,7 +117,6 @@ namespace {
     }
 }
 
-// @TODO: Split this up into two functions and then document (to remove the confusion)
 /**
  * Move the camera to the node with the specified identifier. The second argument is the
  * desired target height above the target node's bounding sphere, in meters. The optional

--- a/src/navigation/pathnavigator_lua.inl
+++ b/src/navigation/pathnavigator_lua.inl
@@ -286,7 +286,7 @@ namespace {
 
 /**
  * Fly linearly to a specific distance in relation to the focus node, given as a relative
- * value based on the size of the objects rather than in meters.
+ * value based on the size of the object rather than in meters.
  *
  * \param distance The distance to fly to, given as a multiple of the bounding sphere of
  *                 the current focus node bounding sphere. A value of 1 will result in a

--- a/src/navigation/pathnavigator_lua.inl
+++ b/src/navigation/pathnavigator_lua.inl
@@ -24,32 +24,45 @@
 
 namespace {
 
-// Returns true if a camera path is currently running, and false otherwise.
+/**
+ * Returns true if a camera path is currently running, and false otherwise.
+ *
+ * \return Whether a camera path is currently active, or not
+ */
 [[codegen::luawrap]] bool isFlying() {
     using namespace openspace;
     return global::openSpaceEngine->currentMode() == OpenSpaceEngine::Mode::CameraPath;
 }
 
-// Continue playing a paused camera path.
+/**
+ * Continue playing a paused camera path.
+ */
 [[codegen::luawrap]] void continuePath() {
     openspace::global::navigationHandler->pathNavigator().continuePath();
 }
 
-// Pause a playing camera path.
+/**
+ * Pause a playing camera path.
+ */
 [[codegen::luawrap]] void pausePath() {
     openspace::global::navigationHandler->pathNavigator().pausePath();
 }
 
-// Stops a path, if one is being played.
+/**
+ * Stops a path, if one is being played.
+ */
 [[codegen::luawrap]] void stopPath() {
     openspace::global::navigationHandler->pathNavigator().abortPath();
 }
 
-// Immediately skips to the end of the current camera path, if one is being played.
+/**
+ * Immediately skips to the end of the current camera path, if one is being played.
+ */
 [[codegen::luawrap]] void skipToEnd() {
     openspace::global::navigationHandler->pathNavigator().skipToEnd();
 }
 
+// @TODO: Split this up into two functions and then document (to remove the confusion)
 /**
  * Move the camera to the node with the specified identifier. The optional double
  * specifies the duration of the motion, in seconds. If the optional bool is set to true
@@ -105,6 +118,7 @@ namespace {
     }
 }
 
+// @TODO: Split this up into two functions and then document (to remove the confusion)
 /**
  * Move the camera to the node with the specified identifier. The second argument is the
  * desired target height above the target node's bounding sphere, in meters. The optional
@@ -156,9 +170,12 @@ namespace {
 }
 
 /**
- * Create a path to the navigation state described by the input table. The optional
- * double specifies the target duration of the motion, in seconds. Note that roll must be
- * included for the target up direction to be taken into account.
+ * Create a path to the navigation state described by the input table. Note that roll must be
+ * included for the target up direction in the navigation state to be taken into account.
+ *
+ * \param navigationState A [NavigationState](#core_navigation_state) to fly to
+ * \param duration An optional duration for the motion to take, in seconds. For example,
+ *                 a value of 5 means "fly to this position over a duration of 5 seconds"
  */
 [[codegen::luawrap]] void flyToNavigationState(ghoul::Dictionary navigationState,
                                                std::optional<double> duration)
@@ -196,8 +213,10 @@ namespace {
 }
 
 /**
- * Zoom linearly to the current focus node, using the default distance. The optional input
- * parameter specifies the duration for the motion, in seconds.
+ * Zoom linearly to the current focus node, using the default distance.
+ *
+ * \param duration An optional duration for the motion to take, in seconds. For example,
+ *                 a value of 5 means "zoom in over 5 seconds"
  */
 [[codegen::luawrap]] void zoomToFocus(std::optional<double> duration) {
     using namespace openspace;
@@ -227,9 +246,10 @@ namespace {
 }
 
 /**
- * Fly linearly to a specific distance in relation to the focus node. The distance is
- * given in meters above the bounding sphere of the current focus node. The optional input
- * parameter specifies the duration for the motion, in seconds.
+ * Fly linearly to a specific distance in relation to the focus node.
+ *
+ * \param distance The distance to fly to, in meters above the bounding sphere.
+ * \param duration An optional duration for the motion to take, in seconds.
  */
 [[codegen::luawrap]] void zoomToDistance(double distance, std::optional<double> duration)
 {
@@ -265,11 +285,14 @@ namespace {
 }
 
 /**
- * Fly linearly to a specific distance in relation to the focus node. The distance is
- * given as a multiple of the bounding sphere of the current focus node. That is, a value
- * of 1 will result in a position at a distance of one times the size of the bounding
- * sphere away from the object. The optional input parameter specifies the duration for
- * the motion, in seconds.
+ * Fly linearly to a specific distance in relation to the focus node, given as a relative
+ * value based on the size of the objects rather than in meters.
+ *
+ * \param distance The distance to fly to, given as a multiple of the bounding sphere of
+ *                 the current focus node bounding sphere. A value of 1 will result in a
+ *                 position at a distance of one times the size of the bounding
+ *                 sphere away from the object.
+ * \param duration An optional duration for the motion, in seconds.
  */
 [[codegen::luawrap]] void zoomToDistanceRelative(double distance,
                                                  std::optional<double> duration)
@@ -292,7 +315,7 @@ namespace {
     insDict.setValue("Height", distance);
     insDict.setValue("PathType", std::string("Linear"));
 
-    if (duration.has_value()) {
+  if (duration.has_value()) {
         double d = *duration;
         if (d < 0.0) {
             throw ghoul::lua::LuaError("Duration must be a positive value");
@@ -311,7 +334,9 @@ namespace {
  * Fade rendering to black, jump to the specified node, and then fade in. This is done by
  * triggering another script that handles the logic.
  *
- * If no fade duration is specified, use the property from Navigation Handler
+ * \param navigationState A [NavigationState](#core_navigation_state) to jump to
+ * \param fadeDuration An optional duration for the fading. If not included, the
+ *                     property in Navigation Handler will be used
  */
 [[codegen::luawrap]] void jumpToNavigationState(ghoul::Dictionary navigationState,
                                                 std::optional<double> fadeDuration)
@@ -357,7 +382,9 @@ namespace {
  * Fade rendering to black, jump to the specified navigation state, and then fade in.
  * This is done by triggering another script that handles the logic.
  *
- * If no fade duration is specified, use the property from Navigation Handler
+ * \param nodeIdentifier The identifier of the scene graph node to jump to
+ * \param fadeDuration An optional duration for the fading. If not included, the
+ *                     property in Navigation Handler will be used
  */
 [[codegen::luawrap]] void jumpTo(std::string nodeIdentifier,
                                  std::optional<double> fadeDuration)
@@ -382,10 +409,15 @@ namespace {
     }
 }
 
-// Create a camera path as described by the lua table input argument.
-[[codegen::luawrap]] void createPath(ghoul::Dictionary path) {
+/**
+ * Create a camera path as described by the instruction in the input argument.
+ *
+ * \param pathInstruction A table representing a [PathInstruction](#core_path_instruction),
+ *                        that describes a camera path to be created
+ */
+[[codegen::luawrap]] void createPath(ghoul::Dictionary pathInstruction) {
     using namespace openspace;
-    global::navigationHandler->pathNavigator().createPath(path);
+    global::navigationHandler->pathNavigator().createPath(pathInstruction);
     if (global::navigationHandler->pathNavigator().hasCurrentPath()) {
         global::navigationHandler->pathNavigator().startPath();
     }


### PR DESCRIPTION
To try to take advantage of new documentation functionalities 

To avoid writing really confusing documentation I have also changed the input parameters of:
* `openspace.navigation.addLocalRoll`
* `openspace.navigation.addGlobalRoll`
* `openspace.navigation.addTruckMovement`
to use 1 parameter instead of 2 (where one was not used in the end)

and tried to fix a gnarly return value for the `openspace.navigation.joystickaxis` function. 
❗ **However, documented structs are not supported as return values in codegen, so this needs some discussion** ❗ 