### PR TITLE
Issue/3070 - Outline/border to textured points

### DIFF
--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -327,8 +327,9 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo OutlineStyleInfo = {
         "OutlineStyle",
         "Outline Style",
-        "This setting decides the shape of points that have an outline (Round, Square, "
-        "or lust a line at the bottom).",
+        "This setting decides the shape of points that have an outline (round, square, "
+        "or lust a line at the bottom). Note that anything but \"Round\" will lead to "
+        "the point being drawed as squares.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -337,8 +337,8 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo ApplyColorMapToOutlineInfo = {
         "ApplyColorMapToOutline",
         "Apply Color Map to Outline",
-        "If true and outline is enabled, the color map will be applied to the outline "
-        "rather than the point body. Only works if color mapping is enabled.",
+        "If true and the outline is enabled, the color map will be applied to the "
+        "outline rather than the point body. Only works if color mapping is enabled.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -488,9 +488,9 @@ namespace {
             std::optional<float> outlineWeight;
 
             enum class [[codegen::map(OutlineStyle)]] OutlineStyle {
-                Round [[codegen::key("Round")]],
-                Square [[codegen::key("Square")]],
-                Bottom [[codegen::key("Bottom")]]
+                Round,
+                Square,
+                Bottom
             };
             // [[codegen::verbatim(OutlineStyleInfo.description)]]
             std::optional<OutlineStyle> outlineStyle;
@@ -598,8 +598,8 @@ RenderablePointCloud::ColorSettings::ColorSettings(const ghoul::Dictionary& dict
         if (settings.colorMapping.has_value()) {
             colorMapping = std::make_unique<ColorMappingComponent>(
                 *settings.colorMapping
-            );
-            addPropertySubOwner(colorMapping.get());
+           );
+           addPropertySubOwner(colorMapping.get());
         }
 
         enableOutline = p.coloring->enableOutline.value_or(enableOutline);

--- a/modules/base/rendering/pointcloud/renderablepointcloud.h
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.h
@@ -190,6 +190,7 @@ protected:
         properties::BoolProperty enableOutline;
         properties::Vec3Property outlineColor;
         properties::FloatProperty outlineWeight;
+        properties::OptionProperty outlineStyle;
     };
     ColorSettings _colorSettings;
 
@@ -231,7 +232,7 @@ protected:
         cmapRangeMin, cmapRangeMax, nanColor, useNanColor, hideOutsideRange,
         enableMaxSizeControl, aboveRangeColor, useAboveRangeColor, belowRangeColor,
         useBelowRangeColor, hasDvarScaling, dvarScaleFactor, enableOutline, outlineColor,
-        outlineWeight, aspectRatioScale, useOrientationData
+        outlineWeight, outlineStyle, aspectRatioScale, useOrientationData
     ) _uniformCache;
 
     std::filesystem::path _dataFile;

--- a/modules/base/rendering/pointcloud/renderablepointcloud.h
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.h
@@ -191,6 +191,7 @@ protected:
         properties::Vec3Property outlineColor;
         properties::FloatProperty outlineWeight;
         properties::OptionProperty outlineStyle;
+        properties::BoolProperty applyCmapToOutline;
     };
     ColorSettings _colorSettings;
 
@@ -232,7 +233,7 @@ protected:
         cmapRangeMin, cmapRangeMax, nanColor, useNanColor, hideOutsideRange,
         enableMaxSizeControl, aboveRangeColor, useAboveRangeColor, belowRangeColor,
         useBelowRangeColor, hasDvarScaling, dvarScaleFactor, enableOutline, outlineColor,
-        outlineWeight, outlineStyle, aspectRatioScale, useOrientationData
+        outlineWeight, outlineStyle, useCmapOutline, aspectRatioScale, useOrientationData
     ) _uniformCache;
 
     std::filesystem::path _dataFile;

--- a/modules/base/shaders/pointcloud/pointcloud_fs.glsl
+++ b/modules/base/shaders/pointcloud/pointcloud_fs.glsl
@@ -94,7 +94,7 @@ Fragment getFragment() {
   vec2 centeredTexCoords = (texCoord - vec2(0.5)) * 2.0;
   float lengthFromCenter = length(centeredTexCoords);
 
-  bool shouldBeRound = !hasSpriteTexture ||
+  bool shouldBeRound = (!hasSpriteTexture && !enableOutline) ||
     (enableOutline && outlineStyle == OutlineStyleRound);
 
   if (shouldBeRound && (lengthFromCenter > 1.0)) {

--- a/modules/base/shaders/pointcloud/pointcloud_fs.glsl
+++ b/modules/base/shaders/pointcloud/pointcloud_fs.glsl
@@ -56,6 +56,7 @@ uniform float outlineWeight;
 
 uniform float fadeInValue;
 
+uniform bool useCmapOutline;
 uniform int outlineStyle;
 
 const int OutlineStyleRound = 0;
@@ -102,10 +103,15 @@ Fragment getFragment() {
   }
 
   vec4 fullColor = vec4(color, 1.0);
+  vec4 cmapColor = vec4(1.0);
   if (useColorMap) {
-    fullColor = sampleColorMap(gs_colorParameter);
+    cmapColor = sampleColorMap(gs_colorParameter);
+    if (!useCmapOutline) {
+      fullColor = cmapColor;
+    }
   }
 
+  vec4 textureColor = vec4(1.0);
   if (hasSpriteTexture) {
     fullColor *= texture(spriteTexture, vec3(texCoord, layer));
   }
@@ -126,7 +132,11 @@ Fragment getFragment() {
     }
 
     if (pixelIsOutline) {
-      fullColor.rgb = outlineColor;
+      vec4 theOutlineColor = vec4(outlineColor, 1.0);
+      if (useColorMap && useCmapOutline) {
+        theOutlineColor = cmapColor;
+      }
+      fullColor = theOutlineColor;
     }
   }
 


### PR DESCRIPTION
Adds border in three different styles and makes it possible to apply color map på border rather than the point body. Closes #3070 

Round, Square, Bottom (with texture and color map to border instead of texture)
<img width="122" alt="image" src="https://github.com/OpenSpace/OpenSpace/assets/8808894/121bac39-7dfe-4920-97c7-099da28a7fe0">
<img width="159" alt="image" src="https://github.com/OpenSpace/OpenSpace/assets/8808894/ac6bd23d-851f-4be7-a8c4-3a71be823b7c">
<img width="154" alt="image" src="https://github.com/OpenSpace/OpenSpace/assets/8808894/3954b810-d11a-4a75-8472-995ea0aecca1">

And for points without texture (and not using color map, only the previously existing border color)
<img width="125" alt="image" src="https://github.com/OpenSpace/OpenSpace/assets/8808894/bb4d0d1c-ba5e-4621-bf9a-9fc6414d1dd7">
<img width="130" alt="image" src="https://github.com/OpenSpace/OpenSpace/assets/8808894/6a6c5fa7-4f01-4b12-aaf1-14ba93b6a82c">
<img width="114" alt="image" src="https://github.com/OpenSpace/OpenSpace/assets/8808894/52cb43b9-cf71-4983-bbf5-4ceac54faf8a">

Notice how the points change from round to square when Square or Bottom border style is chosen
