### PR TITLE
Add/update documentation and add example of `RenderableTravelSpeed`

### DIFF
--- a/data/assets/examples/renderable/renderabletravelspeed/renderabletravelspeed.asset
+++ b/data/assets/examples/renderable/renderabletravelspeed/renderabletravelspeed.asset
@@ -1,0 +1,27 @@
+-- This example creates a speed indicator, as a line that travels with the speed of
+-- light from the parent node (Earth) to the target node (the Moon). By default, the
+-- length of the line is set to match the distance traveled over 1 second.
+
+local earthAsset = asset.require("scene/solarsystem/planets/earth/earth")
+local moonAsset = asset.require("scene/solarsystem/planets/earth/moon/moon")
+
+local Node = {
+  Identifier = "RenderableTravelSpeed_example",
+  Parent = earthAsset.Earth.Identifier,
+  Renderable = {
+    Type = "RenderableTravelSpeed",
+    Target = moonAsset.Moon.Identifier
+  },
+   GUI = {
+    Path = "/Examples/RenderableTravelSpeed",
+    Name = "Speed Indicator"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/modules/space/rendering/renderabletravelspeed.cpp
+++ b/modules/space/rendering/renderabletravelspeed.cpp
@@ -42,22 +42,23 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo SpeedInfo = {
         "TravelSpeed",
         "Speed of travel",
-        "The speed of light is the default value.",
+        "A value for how fast the speed indicator should travel, in meters per second. "
+        "The default value is the speed of light.",
         openspace::properties::Property::Visibility::NoviceUser
     };
 
     constexpr openspace::properties::Property::PropertyInfo TargetInfo = {
         "TargetNode",
         "Target object",
-        "This value sets which scene graph node to target with the light speed "
-        "indicator.",
+        "The identifier of the scene graph node to target with the speed indicator. The "
+        "speed indicator will travel from the parent node to this scene graph node.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
     constexpr openspace::properties::Property::PropertyInfo LineColorInfo = {
         "Color",
         "Color",
-        "This value determines the RGB color for the line.",
+        "An RGB color for the line.",
         openspace::properties::Property::Visibility::NoviceUser
     };
 
@@ -71,19 +72,32 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo IndicatorLengthInfo = {
         "IndicatorLength",
         "Indicator Length",
-        "This value specifies the length of the light indicator set in light seconds.",
+        "The length of the speed indicator line, given in seconds. The length will be "
+        "computed as the speed times this value. For example, a value of 1 will make it "
+        "as long as the distance it would travel over one second.",
         openspace::properties::Property::Visibility::User
     };
 
     constexpr openspace::properties::Property::PropertyInfo FadeLengthInfo = {
         "FadeLength",
         "Fade Length",
-        "This value specifies the length of the faded tail of the light indicator "
-        "set in light seconds.",
+        "The length of the faded tail of the speed indicator, given in seconds. The "
+        "length of the tail will be computed as the speed times this value. For example, "
+        "a value of 1 will make it as long as the distance it would travel over one "
+        "second. A linear fade will be applied over this distance to create the tail.",
         openspace::properties::Property::Visibility::User
     };
 
-    struct [[codegen::Dictionary(RenderableLightTravel)]] Parameters {
+    // This renderable can be used to visualize a certain travel speed, using a line that
+    // moves in the provided speed from a start object to a target. The start position
+    // will be set from the Parent scene graph node, and the end position is set from the
+    // provided target. Per default, the speed is set to the speed of light.
+    //
+    // The length of the travelling line is set based on the travel speed and can be used
+    // to show more information related to the distance travelled. For example, a length
+    // of 1 shows how far an object would move over a duration of one second based on the
+    // selected speed.
+    struct [[codegen::Dictionary(RenderableTravelSpeed)]] Parameters {
         // [[codegen::verbatim(TargetInfo.description)]]
         std::string target;
 
@@ -121,7 +135,7 @@ RenderableTravelSpeed::RenderableTravelSpeed(const ghoul::Dictionary& dictionary
         distanceconstants::LightSecond
       )
     , _indicatorLength(IndicatorLengthInfo, 1.f, 0.f, 360.f)
-    , _fadeLength(FadeLengthInfo, 1.f, 0.f, 360.f)
+    , _fadeLength(FadeLengthInfo, 0.f, 0.f, 360.f)
     , _lineWidth(LineWidthInfo, 2.f, 1.f, 20.f)
     , _lineColor(LineColorInfo, glm::vec3(1.f), glm::vec3(0.f), glm::vec3(1.f))
 {
@@ -133,7 +147,6 @@ RenderableTravelSpeed::RenderableTravelSpeed(const ghoul::Dictionary& dictionary
     _lineColor = p.color.value_or(_lineColor);
     _lineColor.setViewOption(properties::Property::ViewOptions::Color);
     addProperty(_lineColor);
-
 
     _lineWidth = p.lineWidth.value_or(_lineWidth);
     addProperty(_lineWidth);
@@ -150,7 +163,7 @@ RenderableTravelSpeed::RenderableTravelSpeed(const ghoul::Dictionary& dictionary
         if (SceneGraphNode* n = sceneGraphNode(_targetName);  n) {
             _targetNode = n;
             _targetPosition = _targetNode->worldPosition();
-            _lightTravelTime =
+            _travelTime =
                 glm::distance(_targetPosition, _sourcePosition) / _travelSpeed;
             calculateDirectionVector();
             reinitiateTravel();
@@ -165,7 +178,7 @@ RenderableTravelSpeed::RenderableTravelSpeed(const ghoul::Dictionary& dictionary
 void RenderableTravelSpeed::initialize() {
     _targetNode = sceneGraphNode(_targetName);
     if (_targetNode == nullptr) {
-        throw ghoul::RuntimeError("Could not find targetNode");
+        throw ghoul::RuntimeError("Could not find Target Node");
     }
 }
 
@@ -243,7 +256,7 @@ void RenderableTravelSpeed::updateVertexData() {
 
 void RenderableTravelSpeed::reinitiateTravel() {
     _initiationTime = global::timeManager->time().j2000Seconds();
-    _arrivalTime = _initiationTime + _lightTravelTime;
+    _arrivalTime = _initiationTime + _travelTime;
 }
 
 bool RenderableTravelSpeed::isReady() const{
@@ -253,7 +266,7 @@ bool RenderableTravelSpeed::isReady() const{
 void RenderableTravelSpeed::update(const UpdateData& data) {
     if (_initiationTime == -1.0) {
         _initiationTime = data.time.j2000Seconds();
-        _arrivalTime = _initiationTime + _lightTravelTime;
+        _arrivalTime = _initiationTime + _travelTime;
     }
 
     _targetPosition = _targetNode->worldPosition();
@@ -261,7 +274,7 @@ void RenderableTravelSpeed::update(const UpdateData& data) {
     ghoul_assert(mySGNPointer, "Renderable have to be owned by scene graph node");
     _sourcePosition = mySGNPointer->worldPosition();
 
-    _lightTravelTime = glm::distance(_targetPosition, _sourcePosition) / _travelSpeed;
+    _travelTime = glm::distance(_targetPosition, _sourcePosition) / _travelSpeed;
 
     const double currentTime = data.time.j2000Seconds();
     // Unless we've reached the target

--- a/modules/space/rendering/renderabletravelspeed.h
+++ b/modules/space/rendering/renderabletravelspeed.h
@@ -76,7 +76,7 @@ private:
 
     glm::dvec3 _sourcePosition;
     glm::dvec3 _targetPosition;
-    double _lightTravelTime;
+    double _travelTime;
     glm::dvec3 _directionVector;
     double _initiationTime = -1.0;
     double _arrivalTime;


### PR DESCRIPTION
Update some faulty and outdated documentation, add some new one and make a minimal example. 

Note that we have a orientation problem for the travel speed indicator, so it won't actually reach the correct object due to being affected by the transformation of the parent node.  Will make an issue for this