### PR TITLE
Fix faulty computation of sun position in atmosphere

### DIFF
--- a/modules/atmosphere/rendering/atmospheredeferredcaster.cpp
+++ b/modules/atmosphere/rendering/atmospheredeferredcaster.cpp
@@ -381,13 +381,11 @@ void AtmosphereDeferredcaster::preRaycast(const RenderData& data, const Deferred
         const glm::dvec3 sunPosWorld = node ? node->worldPosition() : glm::dvec3(0.0);
 
         glm::dvec3 sunPosObj;
-        // Sun following camera position
         if (_sunFollowingCameraEnabled) {
-            sunPosObj = invModelMatrix * glm::dvec4(data.camera.eyePositionVec3(), 1.0);
+            sunPosObj = camPosObjCoords;
         }
         else {
-            sunPosObj = invModelMatrix *
-                glm::dvec4((sunPosWorld - data.modelTransform.translation) * 1000.0, 1.0);
+            sunPosObj = invModelMatrix * glm::dvec4(sunPosWorld, 1.0);
         }
 
         // Sun Position in Object Space


### PR DESCRIPTION
Fixes a problem where the light source direction was erroneously computed for the atmosphere. It was not noticeable in our solar system but led to errors when adding an atmosphere to an exoplanet system. 

Reported in support slack
https://openspacesupport.slack.com/archives/C04TY4ZKXV2/p1714145171752719

To test it, you can try loading the assets below, that add an exoplanet system with an atmosphere
[kepler36.zip](https://github.com/OpenSpace/OpenSpace/files/15272781/kepler36.zip)
