### PR TITLE
Added extra file extensions for spice kernels

### DIFF
--- a/src/util/spicemanager.cpp
+++ b/src/util/spicemanager.cpp
@@ -261,11 +261,17 @@ SpiceManager::KernelHandle SpiceManager::loadKernel(std::filesystem::path filePa
     }
 
     const std::filesystem::path fileExtension = filePath.extension();
-    if (fileExtension == ".bc" || fileExtension == ".BC") {
-        findCkCoverage(filePath); // binary ck kernel
+    if (fileExtension == ".bc" ||
+        fileExtension == ".BC" ||
+        fileExtension == ".ck" ||
+        fileExtension == ".CK") {
+            findCkCoverage(filePath); // binary ck kernel
     }
-    else if (fileExtension == ".bsp" || fileExtension == ".BSP") {
-        findSpkCoverage(filePath); // binary spk kernel
+    else if (fileExtension == ".bsp" ||
+            fileExtension == ".BSP" ||
+            fileExtension == ".spk" ||
+            fileExtension == ".SPK") {
+            findSpkCoverage(filePath); // spk kernel
     }
 
     const KernelHandle kernelId = ++_lastAssignedKernel;

--- a/src/util/spicemanager.cpp
+++ b/src/util/spicemanager.cpp
@@ -271,7 +271,7 @@ SpiceManager::KernelHandle SpiceManager::loadKernel(std::filesystem::path filePa
             fileExtension == ".BSP" ||
             fileExtension == ".spk" ||
             fileExtension == ".SPK") {
-            findSpkCoverage(filePath); // spk kernel
+                findSpkCoverage(filePath); // spk kernel
     }
 
     const KernelHandle kernelId = ++_lastAssignedKernel;

--- a/src/util/spicemanager.cpp
+++ b/src/util/spicemanager.cpp
@@ -271,8 +271,9 @@ SpiceManager::KernelHandle SpiceManager::loadKernel(std::filesystem::path filePa
     else if (fileExtension == ".bsp" ||
             fileExtension == ".BSP" ||
             fileExtension == ".spk" ||
-            fileExtension == ".SPK") {
-                findSpkCoverage(filePath); // spk kernel
+            fileExtension == ".SPK")
+        {
+            findSpkCoverage(filePath); // spk kernel
     }
 
     const KernelHandle kernelId = ++_lastAssignedKernel;

--- a/src/util/spicemanager.cpp
+++ b/src/util/spicemanager.cpp
@@ -264,8 +264,9 @@ SpiceManager::KernelHandle SpiceManager::loadKernel(std::filesystem::path filePa
     if (fileExtension == ".bc" ||
         fileExtension == ".BC" ||
         fileExtension == ".ck" ||
-        fileExtension == ".CK") {
-            findCkCoverage(filePath); // binary ck kernel
+        fileExtension == ".CK")
+    {
+        findCkCoverage(filePath); // binary ck kernel
     }
     else if (fileExtension == ".bsp" ||
             fileExtension == ".BSP" ||


### PR DESCRIPTION
I got some spice kernels from someone where the extension was .spk 

When I tried to use them, openspace didn't find positions for the object, however when I used brief.exe and spicepy, I did get values. Turns out we only will read positions if the file name ends in .bsp, so I thought since I had to dig into the code to figure this out, maybe we could help any users that this happens to in the future. 