### PR TITLE
Update post synchronization from range-based to index-based for loop closes #3163

### DIFF
--- a/src/engine/syncengine.cpp
+++ b/src/engine/syncengine.cpp
@@ -69,8 +69,8 @@ void SyncEngine::preSynchronization(IsMaster isMaster) {
 void SyncEngine::postSynchronization(IsMaster isMaster) {
     ZoneScoped;
 
-    for (Syncable* syncable : _syncables) {
-        syncable->postSync(isMaster);
+    for (size_t i = 0; i < _syncables.size(); i++) {
+        _syncables[i]->postSync(isMaster);
     }
 }
 

--- a/src/engine/syncengine.cpp
+++ b/src/engine/syncengine.cpp
@@ -61,14 +61,18 @@ void SyncEngine::decodeSyncables(std::vector<std::byte> data) {
 void SyncEngine::preSynchronization(IsMaster isMaster) {
     ZoneScoped;
 
-    for (Syncable* syncable : _syncables) {
-        syncable->preSync(isMaster);
+    // We use a raw for-loop because a syncable can add to the `_syncables` list which
+    // can invalidate the pointers of a range-based for-loop
+    for (size_t i = 0; i < _syncables.size(); i++) {
+        _syncables[i]->preSync(isMaster);
     }
 }
 
 void SyncEngine::postSynchronization(IsMaster isMaster) {
     ZoneScoped;
 
+    // We use a raw for-loop because a syncable can add to the `_syncables` list which
+    // can invalidate the pointers of a range-based for-loop
     for (size_t i = 0; i < _syncables.size(); i++) {
         _syncables[i]->postSync(isMaster);
     }


### PR DESCRIPTION
closes #3163 and #3257 

The issue is that as we are iterating the syncables in post-synchronization the video player adds a new `syncable` to the `syncEngine` which invalidates the range-based for loop due to vector capacity change. Either we go with this solution of changing it to an index-based for loop (should probably change it in e.g., pre-synchronization as well?) or we add the `syncable` to some queue which we process at the next frame for example. 