### PR TITLE
Issue/3286: renderableOrbitalKepler - optimization of point and trail rendering

### DIFF
--- a/modules/space/CMakeLists.txt
+++ b/modules/space/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SHADER_FILES
   shaders/debrisVizPoints_gs.glsl
   shaders/debrisVizPoints_vs.glsl
   shaders/debrisVizTrails_fs.glsl
+  shaders/debrisVizTrails_gs.glsl
   shaders/debrisVizTrails_vs.glsl
   shaders/fluxnodes_fs.glsl
   shaders/fluxnodes_vs.glsl

--- a/modules/space/rendering/renderableorbitalkepler.cpp
+++ b/modules/space/rendering/renderableorbitalkepler.cpp
@@ -403,8 +403,8 @@ void RenderableOrbitalKepler::initializeGL() {
         _trailProgram->uniformLocation("modelViewTransform");
     _uniformTrailCache.projection =
         _trailProgram->uniformLocation("projectionTransform");
-    _uniformTrailCache.colorFadeCutoffPoint =
-        _trailProgram->uniformLocation("colorFadeCutoffPoint");
+    _uniformTrailCache.colorFadeCutoffValue =
+        _trailProgram->uniformLocation("colorFadeCutoffValue");
     _uniformTrailCache.trailFadeExponent =
         _trailProgram->uniformLocation("trailFadeExponent");
     _uniformTrailCache.inGameTime = _trailProgram->uniformLocation("inGameTime");
@@ -574,7 +574,7 @@ void RenderableOrbitalKepler::render(const RenderData& data, RendererTasks&) {
         // on the distance from the head of the trail to the part that's being rendered.
         // Value is passed as uniform due to it being used in both geometry and fragment
         // shader.
-        _trailProgram->setUniform(_uniformTrailCache.colorFadeCutoffPoint, 0.05f);
+        _trailProgram->setUniform(_uniformTrailCache.colorFadeCutoffValue, 0.05f);
 
         glLineWidth(_appearance.trailWidth);
 

--- a/modules/space/rendering/renderableorbitalkepler.cpp
+++ b/modules/space/rendering/renderableorbitalkepler.cpp
@@ -123,8 +123,9 @@ namespace {
 
     constexpr openspace::properties::Property::PropertyInfo TrailFadeInfo = {
         "TrailFade",
-        "Trail Fade Factor",
-        "Determines how fast the trail fades out.",
+        "Trail Fade",
+        "Determines how fast the trail fades out. A smaller number shows less of the "
+        "trail and a larger number shows more.",
         openspace::properties::Property::Visibility::User
     };
 
@@ -378,7 +379,8 @@ void RenderableOrbitalKepler::initializeGL() {
            return global::renderEngine->buildRenderProgram(
                "OrbitalKeplerTrails",
                absPath("${MODULE_SPACE}/shaders/debrisVizTrails_vs.glsl"),
-               absPath("${MODULE_SPACE}/shaders/debrisVizTrails_fs.glsl")
+               absPath("${MODULE_SPACE}/shaders/debrisVizTrails_fs.glsl"),
+               absPath("${MODULE_SPACE}/shaders/debrisVizTrails_gs.glsl")
            );
        }
    );
@@ -401,7 +403,8 @@ void RenderableOrbitalKepler::initializeGL() {
         _trailProgram->uniformLocation("modelViewTransform");
     _uniformTrailCache.projection =
         _trailProgram->uniformLocation("projectionTransform");
-    _uniformTrailCache.trailFade = _trailProgram->uniformLocation("trailFade");
+    _uniformTrailCache.trailFadeExponent = _trailProgram->uniformLocation("trailFadeExponent");
+    _uniformTrailCache.colorFadeCutoffPoint = _trailProgram->uniformLocation("colorFadeCutoffPoint");
     _uniformTrailCache.inGameTime = _trailProgram->uniformLocation("inGameTime");
     _uniformTrailCache.color = _trailProgram->uniformLocation("color");
     _uniformTrailCache.opacity = _trailProgram->uniformLocation("opacity");
@@ -562,7 +565,9 @@ void RenderableOrbitalKepler::render(const RenderData& data, RendererTasks&) {
         const float fade = pow(
             _appearance.trailFade.maxValue() - _appearance.trailFade, 2.f
         );
-        _trailProgram->setUniform(_uniformTrailCache.trailFade, fade);
+        _trailProgram->setUniform(_uniformTrailCache.trailFadeExponent, fade);
+
+        _trailProgram->setUniform(_uniformTrailCache.colorFadeCutoffPoint, 0.05f);
 
         glLineWidth(_appearance.trailWidth);
 

--- a/modules/space/rendering/renderableorbitalkepler.cpp
+++ b/modules/space/rendering/renderableorbitalkepler.cpp
@@ -403,8 +403,10 @@ void RenderableOrbitalKepler::initializeGL() {
         _trailProgram->uniformLocation("modelViewTransform");
     _uniformTrailCache.projection =
         _trailProgram->uniformLocation("projectionTransform");
-    _uniformTrailCache.trailFadeExponent = _trailProgram->uniformLocation("trailFadeExponent");
-    _uniformTrailCache.colorFadeCutoffPoint = _trailProgram->uniformLocation("colorFadeCutoffPoint");
+    _uniformTrailCache.colorFadeCutoffPoint =
+        _trailProgram->uniformLocation("colorFadeCutoffPoint");
+    _uniformTrailCache.trailFadeExponent =
+        _trailProgram->uniformLocation("trailFadeExponent");
     _uniformTrailCache.inGameTime = _trailProgram->uniformLocation("inGameTime");
     _uniformTrailCache.color = _trailProgram->uniformLocation("color");
     _uniformTrailCache.opacity = _trailProgram->uniformLocation("opacity");
@@ -567,6 +569,11 @@ void RenderableOrbitalKepler::render(const RenderData& data, RendererTasks&) {
         );
         _trailProgram->setUniform(_uniformTrailCache.trailFadeExponent, fade);
 
+        // 0.05 is the "alpha value" for which the trail should no longer be rendered.
+        // The value that's compared to 0.05 is calculated in the shader and depends
+        // on the distance from the head of the trail to the part that's being rendered.
+        // Value is passed as uniform due to it being used in both geometry and fragment
+        // shader.
         _trailProgram->setUniform(_uniformTrailCache.colorFadeCutoffPoint, 0.05f);
 
         glLineWidth(_appearance.trailWidth);

--- a/modules/space/rendering/renderableorbitalkepler.cpp
+++ b/modules/space/rendering/renderableorbitalkepler.cpp
@@ -256,14 +256,14 @@ RenderableOrbitalKepler::Appearance::Appearance()
     })
     , color(ColorInfo, glm::vec3(1.f), glm::vec3(0.f), glm::vec3(1.f))
     , trailWidth(TrailWidthInfo, 2.f, 1.f, 20.f)
-    , pointSizeExponent(PointSizeExponentInfo, 1.0f, 0.f, 25.f)
+    , pointSizeExponent(PointSizeExponentInfo, 1.0f, 0.f, 11.f)
     , renderingModes(
         RenderingModeInfo,
         properties::OptionProperty::DisplayType::Dropdown
     )
     , trailFade(TrailFadeInfo, 20.f, 0.f, 30.f)
-    , enableMaxSize(EnableMaxSizeInfo, false)
-    , maxSize(MaxSizeInfo, 1.f, 0.f, 45.f)
+    , enableMaxSize(EnableMaxSizeInfo, true)
+    , maxSize(MaxSizeInfo, 5.f, 0.f, 45.f)
     , enableOutline(EnableOutlineInfo, true)
     , outlineColor(OutlineColorInfo, glm::vec3(0.f), glm::vec3(0.f), glm::vec3(1.f))
     , outlineWidth(OutlineWidthInfo, 0.2f, 0.f, 1.f)

--- a/modules/space/rendering/renderableorbitalkepler.h
+++ b/modules/space/rendering/renderableorbitalkepler.h
@@ -112,7 +112,7 @@ private:
     RenderableOrbitalKepler::Appearance _appearance;
 
     // Line cache
-    UniformCache(modelView, projection, trailFade, inGameTime, color, opacity)
+    UniformCache(modelView, projection, trailFadeExponent, colorFadeCutoffPoint, inGameTime, color, opacity)
         _uniformTrailCache;
     
     // Point cache

--- a/modules/space/rendering/renderableorbitalkepler.h
+++ b/modules/space/rendering/renderableorbitalkepler.h
@@ -112,7 +112,7 @@ private:
     RenderableOrbitalKepler::Appearance _appearance;
 
     // Line cache
-    UniformCache(modelView, projection, trailFadeExponent, colorFadeCutoffPoint,
+    UniformCache(modelView, projection, trailFadeExponent, colorFadeCutoffValue,
         inGameTime, color, opacity)
         _uniformTrailCache;
     

--- a/modules/space/rendering/renderableorbitalkepler.h
+++ b/modules/space/rendering/renderableorbitalkepler.h
@@ -112,7 +112,8 @@ private:
     RenderableOrbitalKepler::Appearance _appearance;
 
     // Line cache
-    UniformCache(modelView, projection, trailFadeExponent, colorFadeCutoffPoint, inGameTime, color, opacity)
+    UniformCache(modelView, projection, trailFadeExponent, colorFadeCutoffPoint,
+        inGameTime, color, opacity)
         _uniformTrailCache;
     
     // Point cache
@@ -126,4 +127,3 @@ private:
 } // namespace openspace
 
 #endif // __OPENSPACE_MODULE_SPACE___RENDERABLEORBITALKEPLER___H__
-

--- a/modules/space/shaders/debrisVizPoints_fs.glsl
+++ b/modules/space/shaders/debrisVizPoints_fs.glsl
@@ -27,7 +27,6 @@
 in float projectionViewDepth;
 in vec4 viewSpace;
 in vec2 texCoord;
-flat in int skip;
 
 uniform bool enableOutline;
 uniform vec3 outlineColor;
@@ -38,10 +37,6 @@ uniform float opacity;
 Fragment getFragment() {
   Fragment frag;
   
-  if (skip == 1) {
-    discard;
-  }
-
   // Only draw circle instead of entire quad
   vec2 st = (texCoord - vec2(0.5)) * 2.0;
   if (length(st) > 1.0) {

--- a/modules/space/shaders/debrisVizPoints_gs.glsl
+++ b/modules/space/shaders/debrisVizPoints_gs.glsl
@@ -45,6 +45,10 @@ out vec4 viewSpace;
 out vec2 texCoord;
 
 void main() {
+  // cFrac is how far along the trail orbit the head of the trail is.
+  // v0Frac and v1Frac are how far the two vertices that creates the current line strip
+  // are along the trail orbit. The variables span between 0 and 1, where 0 is the
+  // beginning of the trail and 1 is the end of the trail (a full orbit).
   float cFrac = currentRevolutionFraction[0];
   float v0Frac = vertexRevolutionFraction[0];
   float v1Frac = vertexRevolutionFraction[1];

--- a/modules/space/shaders/debrisVizPoints_gs.glsl
+++ b/modules/space/shaders/debrisVizPoints_gs.glsl
@@ -27,8 +27,8 @@
 #include "PowerScaling/powerScalingMath.hglsl"
 
 layout(lines) in;
-flat in double currentRevolutionFraction[];
-flat in double vertexRevolutionFraction[];
+flat in float currentRevolutionFraction[];
+flat in float vertexRevolutionFraction[];
 
 uniform dmat4 modelTransform;
 uniform dmat4 viewTransform;
@@ -43,103 +43,91 @@ layout(triangle_strip, max_vertices = 4) out;
 out float projectionViewDepth;
 out vec4 viewSpace;
 out vec2 texCoord;
-flat out int skip;
-
-dvec4 dz_normalization(dvec4 dv_in) {
-  dvec4 dv_out = dv_in;
-  dv_out.z = 0;
-  return dv_out;
-}
 
 void main() {
-  skip = 0;
-  
-  double cFrac = currentRevolutionFraction[0];
-  double v0Frac = vertexRevolutionFraction[0];
-  double v1Frac = vertexRevolutionFraction[1];
+  float cFrac = currentRevolutionFraction[0];
+  float v0Frac = vertexRevolutionFraction[0];
+  float v1Frac = vertexRevolutionFraction[1];
+
+  // Only create/emit vertices for segments where the head of the trail falls within
   if (cFrac >= v0Frac && cFrac <= v1Frac) {
 
-    // Interpolate position of point
-    double dFrac = abs(cFrac - v0Frac);
-    double vFrac = abs(v1Frac - v0Frac);
-    double percentage = dFrac / vFrac;
-
-    dvec4 v0Weighted = (1.0 - percentage) * gl_in[0].gl_Position;
-    dvec4 v1Weighted = (percentage) * gl_in[1].gl_Position;
-
-    dvec4 pos = v0Weighted + v1Weighted;
+    // Interpolate position of current position of the trail head
+    float dFrac = abs(cFrac - v0Frac);
+    float vFrac = abs(v1Frac - v0Frac);
+    float percentage = dFrac / vFrac;
+    
+    vec4 v0Weighted = (1.0 - percentage) * gl_in[0].gl_Position;
+    vec4 v1Weighted = (percentage) * gl_in[1].gl_Position;
+    vec4 pos = v0Weighted + v1Weighted;
     // ==========================
 
+    // Cast to float based data types
+    mat4 modelTrans = mat4(modelTransform);
+    mat4 viewTrans = mat4(viewTransform);
+    vec3 camPosWorld = vec3(cameraPositionWorld);
+
     // Calculate current vertex position to world space
-    dvec4 vertPosWorldSpace = modelTransform * pos;
+    vec4 vertPosWorldSpace = modelTrans * pos;
 
     // Calculate new axis for plane
-    dvec3 normal = normalize(cameraPositionWorld - vertPosWorldSpace.xyz);
-    dvec3 right = normalize(cross(cameraUpWorld, normal));
-    dvec3 up = normalize(cross(normal, right));
+    vec3 normal = vec3(normalize(camPosWorld - vertPosWorldSpace.xyz));
+    vec3 right = normalize(cross(vec3(cameraUpWorld), normal));
+    vec3 up = normalize(cross(normal, right));
 
     // Calculate size of points
-    double initialSize = pow(10.0, pointSizeExponent);
+    float initialSize = pow(10.0, pointSizeExponent);
     right *= initialSize;
     up *= initialSize;
 
-    double opp = length(right);
-    double adj = length(cameraPositionWorld.xyz - vertPosWorldSpace.xyz);
+    float opp = length(right);
+    float adj = length(camPosWorld - vertPosWorldSpace.xyz);
     float angle = atan(float(opp/adj));
     float maxAngle = radians(maxSize * 0.5);
 
     // Controls the point size
     if (enableMaxSize && (angle > maxAngle) && (adj > 0.0)) {
-      double correction = (adj * tan(maxAngle)) / opp;
+      float correction = (adj * tan(maxAngle)) / opp;
       right *= correction;
       up *= correction;
     }
 
-    // Calculate and set corners of the quad
-    dvec4 p0World = vertPosWorldSpace + (dvec4(up-right, 0.0));
-    dvec4 p1World = vertPosWorldSpace + (dvec4(-right-up,0.0));
-    dvec4 p2World = vertPosWorldSpace + (dvec4(right+up, 0.0));
-    dvec4 p3World = vertPosWorldSpace + (dvec4(right-up, 0.0));
+    // Calculate and set corners of the new quad
+    vec4 p0World = vertPosWorldSpace + vec4(up-right, 0.0);
+    vec4 p1World = vertPosWorldSpace + vec4(-right-up,0.0);
+    vec4 p2World = vertPosWorldSpace + vec4(right+up, 0.0);
+    vec4 p3World = vertPosWorldSpace + vec4(right-up, 0.0);
 
-    dmat4 ViewProjectionTransform = dmat4(projectionTransform) * viewTransform;
+    mat4 ViewProjectionTransform = projectionTransform * viewTrans;
 
     // Set some additional out parameters
-    viewSpace = z_normalization(
-      vec4(projectionTransform * viewTransform * modelTransform * pos)
-    );
+    viewSpace = z_normalization(projectionTransform * viewTrans * modelTrans * pos);
     projectionViewDepth = viewSpace.w;
 
-    //left-top
-    vec4 p0Screen = vec4(dz_normalization(ViewProjectionTransform * p0World));
+    // left-top
+    vec4 p0Screen = z_normalization(ViewProjectionTransform * p0World);
     gl_Position = p0Screen;
     texCoord = vec2(0.0, 0.0);
     EmitVertex();
 
-    //left-bot
-    vec4 p1Screen = vec4(dz_normalization(ViewProjectionTransform * p1World));
+    // left-bot
+    vec4 p1Screen = z_normalization(ViewProjectionTransform * p1World);
     gl_Position = p1Screen;
     texCoord = vec2(1.0, 0.0);
     EmitVertex();
 
-    //right-top
-    vec4 p2Screen = vec4(dz_normalization(ViewProjectionTransform * p2World));
+    // right-top
+    vec4 p2Screen = z_normalization(ViewProjectionTransform * p2World);
     gl_Position = p2Screen;
     texCoord = vec2(0.0, 1.0);
     EmitVertex();
 
-    //right-bot
-    vec4 p3Screen = vec4(dz_normalization(ViewProjectionTransform * p3World));
+    // right-bot
+    vec4 p3Screen = z_normalization(ViewProjectionTransform * p3World);
     gl_Position = p3Screen;
     texCoord = vec2(1.0, 1.0);
     EmitVertex();
-    
-    // Primitive
-    EndPrimitive();
-
   } 
-  else {
-    skip = 1;
-    EmitVertex();
-    EndPrimitive();
-  }
+
+  EndPrimitive();
 }

--- a/modules/space/shaders/debrisVizPoints_vs.glsl
+++ b/modules/space/shaders/debrisVizPoints_vs.glsl
@@ -28,21 +28,24 @@ layout (location = 0) in vec4 vertexData; // 1: x, 2: y, 3: z, 4: timeOffset,
 layout (location = 1) in vec2 orbitData; // 1: epoch, 2: period
 
 uniform double inGameTime;
-uniform dmat4 modelTransform;
 
-flat out double currentRevolutionFraction;
-flat out double vertexRevolutionFraction;
+flat out float currentRevolutionFraction;
+flat out float vertexRevolutionFraction;
 
 void main() {
   float epoch = orbitData.x;
   float period = orbitData.y;
-  double numOfRevolutions = (inGameTime - epoch) / period;
 
-  vertexRevolutionFraction = vertexData.w / period;
-  currentRevolutionFraction = numOfRevolutions - double(int(numOfRevolutions));
+  // calculate nr of periods, get fractional part to know where the vertex closest to the
+  // debris part is right now
+  double numOfRevolutions = (inGameTime - epoch) / period;
+  currentRevolutionFraction = float(numOfRevolutions - double(int(numOfRevolutions)));
   if (currentRevolutionFraction < 0.0) {
     currentRevolutionFraction += 1.0;
   }
+
+  // Same procedure for the current vertex
+  vertexRevolutionFraction = vertexData.w / period;
 
   gl_Position = vec4(vertexData.xyz, 1.0);
 }

--- a/modules/space/shaders/debrisVizTrails_fs.glsl
+++ b/modules/space/shaders/debrisVizTrails_fs.glsl
@@ -31,18 +31,11 @@ in float offsetPeriods;
 
 uniform vec3 color;
 uniform float opacity = 1.0;
-uniform float trailFade;
-
-/// Different modes - sync with renderableorbitalkepler.cpp
-// RenderingModeLines = 0
-// RenderingModePoint = 1
+uniform float trailFadeExponent;
+uniform float colorFadeCutoffPoint;
 
 Fragment getFragment() {
   Fragment frag;
-
-  float invert = 1.0;
-  float fade = 1.0;
-
   // float offsetPeriods = offset / period;
   // This is now done in the fragment shader instead to make smooth movement between
   // vertices. We want vertexDistance to be double up to this point, I think, (hence the
@@ -58,15 +51,15 @@ Fragment getFragment() {
     vertexDistance += 1.0;
   }
 
-  invert = pow((1.0 - vertexDistance), trailFade);  
-  fade = clamp(invert, 0.0, 1.0);
+  float invert = pow((1.0 - vertexDistance), trailFadeExponent);  
+  float fade = clamp(invert, 0.0, 1.0);
 
   // Currently even fully transparent lines can occlude other lines, thus we discard these
   // fragments since debris and satellites are rendered so close to each other
-  if (fade < 0.05) {
+  if (fade < colorFadeCutoffPoint) {
     discard;
   }
-  
+
   // Use additive blending for some values to make the discarding less abrupt
   if (fade < 0.15) {
     frag.blend = BLEND_MODE_ADDITIVE;

--- a/modules/space/shaders/debrisVizTrails_fs.glsl
+++ b/modules/space/shaders/debrisVizTrails_fs.glsl
@@ -32,7 +32,7 @@ in float offsetPeriods;
 uniform vec3 color;
 uniform float opacity = 1.0;
 uniform float trailFadeExponent;
-uniform float colorFadeCutoffPoint;
+uniform float colorFadeCutoffValue;
 
 Fragment getFragment() {
   Fragment frag;
@@ -56,7 +56,7 @@ Fragment getFragment() {
 
   // Currently even fully transparent lines can occlude other lines, thus we discard these
   // fragments since debris and satellites are rendered so close to each other
-  if (fade < colorFadeCutoffPoint) {
+  if (fade < colorFadeCutoffValue) {
     discard;
   }
 

--- a/modules/space/shaders/debrisVizTrails_gs.glsl
+++ b/modules/space/shaders/debrisVizTrails_gs.glsl
@@ -36,7 +36,7 @@ out float offsetPeriods;
 out vec4 viewSpacePosition;
 
 uniform float trailFadeExponent;
-uniform float colorFadeCutoffPoint;
+uniform float colorFadeCutoffValue;
 
 void main() {
   // cFrac is how far along the trail orbit the head of the trail is.
@@ -65,7 +65,7 @@ void main() {
   float fade = clamp(invert, 0.0, 1.0);
 
   // Only emit vertices for line segments where both vertices should be rendered
-  if ((fade > colorFadeCutoffPoint) || (vd0 < vd1)) {
+  if ((fade > colorFadeCutoffValue) || (vd0 < vd1)) {
     gl_Position = gl_in[0].gl_Position;
     viewSpaceDepth = gl_Position.w;
     periodFraction = cFrac;

--- a/modules/space/shaders/debrisVizTrails_gs.glsl
+++ b/modules/space/shaders/debrisVizTrails_gs.glsl
@@ -43,7 +43,7 @@ void main() {
   float v0Frac = vertexRevolutionFraction[0];
   float v1Frac = vertexRevolutionFraction[1];
 
-  // Distance between current recolution fraction and revolution factor for
+  // Distance between current revolution fraction and revolution fraction for
   // vertex0 and vertex1
   float vd0 = cFrac - v0Frac;
   if (vd0 < 0.0) {

--- a/modules/space/shaders/debrisVizTrails_gs.glsl
+++ b/modules/space/shaders/debrisVizTrails_gs.glsl
@@ -39,6 +39,10 @@ uniform float trailFadeExponent;
 uniform float colorFadeCutoffPoint;
 
 void main() {
+  // cFrac is how far along the trail orbit the head of the trail is.
+  // v0Frac and v1Frac are how far the two vertices that creates the current line strip
+  // are along the trail orbit. The variables span between 0 and 1, where 0 is the
+  // beginning of the trail and 1 is the end of the trail (a full orbit).
   float cFrac = currentRevolutionFraction[0];
   float v0Frac = vertexRevolutionFraction[0];
   float v1Frac = vertexRevolutionFraction[1];

--- a/modules/space/shaders/debrisVizTrails_gs.glsl
+++ b/modules/space/shaders/debrisVizTrails_gs.glsl
@@ -43,7 +43,8 @@ void main() {
   float v0Frac = vertexRevolutionFraction[0];
   float v1Frac = vertexRevolutionFraction[1];
 
-  // Distance between current recolution fraction and revolution factor for vertex0 and vertex1
+  // Distance between current recolution fraction and revolution factor for
+  // vertex0 and vertex1
   float vd0 = cFrac - v0Frac;
   if (vd0 < 0.0) {
     vd0 += 1.0;
@@ -60,7 +61,7 @@ void main() {
   float fade = clamp(invert, 0.0, 1.0);
 
   // Only emit vertices for line segments where both vertices should be rendered
-  if ( (fade > colorFadeCutoffPoint) || (vd0 < vd1) ) {
+  if ((fade > colorFadeCutoffPoint) || (vd0 < vd1)) {
     gl_Position = gl_in[0].gl_Position;
     viewSpaceDepth = gl_Position.w;
     periodFraction = cFrac;


### PR DESCRIPTION
## Trail optimization
Optimization for the trail shader was achieved by using a geometry shader to cull vertices that does not contribute to the final trail. In other words, vertices which part of the trail would be fully faded (discard by fragment shader) is now removed in geometry shader and thus less data is being processed in fragment shader.


## Point optimization
Changed nearly all calculations from double to float. Was using double as a safe-guard during development and never revisited that decision. 

## Performance statistics
Everything is compared to 0.20.0 RC1

### Trail optimization
The new implementation results in a framerate that does not fluctuate depending on how many pixels the trails cover on screen.
Test using the _Main Asteroid Belt_ at different zoom levels within the solar system

**Before:**
- 60 - 170 fps
- 16.67 - 5.88 ms

**After:**
- 156 fps
- 6.41 ms

At most it increased by 0.53 ms and at most it recued by 10.26 ms


### Point optimization
Test using the _Main Asteroid Belt_ at different zoom levels within the solar system

**Before:**
-  86 fps
- 11.63 ms

**After:**
- 167 - 176 fps
- 5.99 - 5.68 ms

At most it reduced by 9.58 ms

### Trail + Point
Using both optimizations and testing with rendering mode "Trails + Points".
Test using the _Main Asteroid Belt_ at different zoom levels within the solar system

**Before:**
-  42 - 75 fps
- 23.81 - 13.33 ms

**After:**
- 94 - 97 fps
- 10.64 - 10.31 ms

At most it reduced by 13.5 ms

##
### Test system
Intel Core 9 12900
64GB RAM
Nvidia RTX 3080 (10GB)
Screen resolution: 2560x1440