### PR TITLE
Apply the hue, value, saturation, and gamma values from the renderengine to screenspace renderables.  Change the screenspace's own gamma value into an offset

### DIFF
--- a/include/openspace/rendering/screenspacerenderable.h
+++ b/include/openspace/rendering/screenspacerenderable.h
@@ -61,7 +61,14 @@ public:
     ScreenSpaceRenderable(const ghoul::Dictionary& dictionary);
     virtual ~ScreenSpaceRenderable() override;
 
-    virtual void render(float blackoutFactor);
+    struct RenderData {
+        float blackoutFactor;
+        float hue;
+        float value;
+        float saturation;
+        float gamma;
+    };
+    virtual void render(const RenderData& renderData);
 
     virtual bool initialize();
     virtual bool initializeGL();
@@ -102,7 +109,7 @@ protected:
     glm::vec3 raeToCartesian(const glm::vec3& rae) const;
     glm::vec3 cartesianToRae(const glm::vec3& cartesian) const;
 
-    void draw(const glm::mat4& modelTransform, float blackoutFactor);
+    void draw(const glm::mat4& modelTransform, const RenderData& renderData);
 
     virtual void bindTexture() = 0;
     virtual void unbindTexture();
@@ -135,14 +142,14 @@ protected:
     properties::Vec3Property _borderColor;
 
     properties::FloatProperty _scale;
-    properties::FloatProperty _gamma;
+    properties::FloatProperty _gammaOffset;
     properties::Vec3Property _multiplyColor;
     properties::Vec4Property _backgroundColor;
     properties::TriggerProperty _delete;
 
     glm::ivec2 _objectSize = glm::ivec2(0);
-    UniformCache(color, opacity, blackoutFactor, mvpMatrix, tex, backgroundColor, gamma,
-        borderColor, borderWidth) _uniformCache;
+    UniformCache(color, opacity, blackoutFactor, hue, value, saturation, mvpMatrix, tex,
+        backgroundColor, gamma, borderColor, borderWidth) _uniformCache;
     std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
 };
 

--- a/modules/base/rendering/screenspaceframebuffer.cpp
+++ b/modules/base/rendering/screenspaceframebuffer.cpp
@@ -104,7 +104,7 @@ bool ScreenSpaceFramebuffer::deinitializeGL() {
     return true;
 }
 
-void ScreenSpaceFramebuffer::render(float blackoutFactor) {
+void ScreenSpaceFramebuffer::render(const RenderData& renderData) {
     const glm::vec2& resolution = global::windowDelegate->currentDrawBufferResolution();
     const glm::vec4& size = _size.value();
 
@@ -144,7 +144,7 @@ void ScreenSpaceFramebuffer::render(float blackoutFactor) {
             glm::vec3((1.f / xratio), (1.f / yratio), 1.f)
         );
         const glm::mat4 modelTransform = globalRotation*translation*localRotation*scale;
-        draw(modelTransform, blackoutFactor);
+        draw(modelTransform, renderData);
     }
 }
 

--- a/modules/base/rendering/screenspaceframebuffer.h
+++ b/modules/base/rendering/screenspaceframebuffer.h
@@ -53,7 +53,7 @@ public:
 
     bool initializeGL() override;
     bool deinitializeGL() override;
-    void render(float blackoutFactor) override;
+    void render(const RenderData& renderData) override;
     bool isReady() const override;
 
     void setSize(glm::vec4 size);

--- a/modules/base/shaders/screenspace_fs.glsl
+++ b/modules/base/shaders/screenspace_fs.glsl
@@ -23,6 +23,7 @@
  ****************************************************************************************/
 
 #include "fragment.glsl"
+#include "hdr.glsl"
 #include "PowerScaling/powerScaling_fs.hglsl"
 
 in vec2 vs_st;
@@ -33,6 +34,9 @@ uniform vec3 color = vec3(1.0);
 uniform float opacity = 1.0;
 uniform float blackoutFactor = 1.0;
 uniform vec4 backgroundColor = vec4(0.0);
+uniform float hue;
+uniform float value;
+uniform float saturation;
 uniform float gamma = 1.0;
 uniform vec2 borderWidth = vec2(0.1);
 uniform vec3 borderColor = vec3(0.0);
@@ -57,6 +61,15 @@ Fragment getFragment() {
   }
 
   frag.depth = vs_depth;
-  frag.color.rgb = pow(frag.color.rgb, vec3(1.0/(gamma))) * blackoutFactor;
+
+  vec3 hsvColor = rgb2hsv(frag.color.rgb);
+  hsvColor.x = (hsvColor.x + hue);
+  if (hsvColor.x > 360.0) {
+    hsvColor -= 360.0;
+  }
+  hsvColor.y = clamp(hsvColor.y * saturation, 0.0, 1.0);
+  hsvColor.z = clamp(hsvColor.z * value, 0.0, 1.0);
+
+  frag.color.rgb = gammaCorrection(hsv2rgb(hsvColor), gamma) * blackoutFactor;
   return frag;
 }

--- a/modules/skybrowser/include/screenspaceskybrowser.h
+++ b/modules/skybrowser/include/screenspaceskybrowser.h
@@ -43,7 +43,7 @@ public:
     bool initializeGL() override;
     bool deinitializeGL() override;
     glm::mat4 scaleMatrix() override;
-    void render(float blackoutFactor) override;
+    void render(const RenderData& renderData) override;
     void update() override;
 
     float opacity() const noexcept override;

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -320,7 +320,7 @@ bool ScreenSpaceSkyBrowser::deinitializeGL() {
     return true;
 }
 
-void ScreenSpaceSkyBrowser::render(float blackoutFactor) {
+void ScreenSpaceSkyBrowser::render(const RenderData& renderData) {
     WwtCommunicator::render();
 
     if (!_isHidden) {
@@ -329,7 +329,7 @@ void ScreenSpaceSkyBrowser::render(float blackoutFactor) {
             translationMatrix() *
             localRotationMatrix() *
             scaleMatrix();
-        draw(mat, blackoutFactor);
+        draw(mat, renderData);
     }
 
     // Render the display copies
@@ -353,7 +353,7 @@ void ScreenSpaceSkyBrowser::render(float blackoutFactor) {
                 glm::translate(glm::mat4(1.f), coordinates) *
                 localRotation *
                 scaleMatrix();
-            draw(mat, blackoutFactor);
+            draw(mat, renderData);
         }
     }
 }

--- a/modules/video/include/screenspacevideo.h
+++ b/modules/video/include/screenspacevideo.h
@@ -43,7 +43,7 @@ public:
     bool initializeGL() override;
     bool deinitializeGL() override;
     void update() override;
-    void render(float blackoutFactor) override;
+    void render(const RenderData& renderData) override;
 
     static documentation::Documentation Documentation();
 

--- a/modules/video/src/screenspacevideo.cpp
+++ b/modules/video/src/screenspacevideo.cpp
@@ -76,9 +76,9 @@ void ScreenSpaceVideo::update() {
     }
 }
 
-void ScreenSpaceVideo::render(float blackoutFactor) {
+void ScreenSpaceVideo::render(const RenderData& renderData) {
     if (_videoPlayer.isInitialized()) {
-        ScreenSpaceRenderable::render(blackoutFactor);
+        ScreenSpaceRenderable::render(renderData);
     }
 }
 

--- a/modules/webbrowser/include/screenspacebrowser.h
+++ b/modules/webbrowser/include/screenspacebrowser.h
@@ -68,7 +68,7 @@ public:
     bool initializeGL() override;
     bool deinitializeGL() override;
 
-    void render(float blackoutFactor) override;
+    void render(const RenderData& renderData) override;
     void update() override;
     bool isReady() const override;
 

--- a/modules/webbrowser/src/screenspacebrowser.cpp
+++ b/modules/webbrowser/src/screenspacebrowser.cpp
@@ -166,7 +166,7 @@ bool ScreenSpaceBrowser::deinitializeGL() {
     return ScreenSpaceRenderable::deinitializeGL();
 }
 
-void ScreenSpaceBrowser::render(float blackoutFactor) {
+void ScreenSpaceBrowser::render(const RenderData& renderData) {
     if (!_renderHandler->isTextureReady()) {
         return;
     }
@@ -177,7 +177,7 @@ void ScreenSpaceBrowser::render(float blackoutFactor) {
         translationMatrix() *
         localRotationMatrix() *
         scaleMatrix();
-    draw(mat, blackoutFactor);
+    draw(mat, renderData);
 }
 
 void ScreenSpaceBrowser::update() {

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -759,8 +759,15 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         glDisable(GL_DEPTH_TEST);
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        ScreenSpaceRenderable::RenderData data = {
+            .blackoutFactor = combinedBlackoutFactor(),
+            .hue = _hue / 360.f,
+            .value = _value,
+            .saturation = _saturation,
+            .gamma = _gamma
+        };
         for (ScreenSpaceRenderable* ssr : ssrs) {
-            ssr->render(combinedBlackoutFactor());
+            ssr->render(data);
         }
         glDisable(GL_BLEND);
     }

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -146,10 +146,11 @@ namespace {
         openspace::properties::Property::Visibility::NoviceUser
     };
 
-    constexpr openspace::properties::Property::PropertyInfo GammaInfo = {
-        "Gamma",
+    constexpr openspace::properties::Property::PropertyInfo GammaOffsetInfo = {
+        "GammaOffset",
         "Gamma Correction",
-        "Sets the gamma correction of the texture.",
+        "Sets the gamma correction of the texture that is applied in addition to the "
+        "global gamma value.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -223,8 +224,8 @@ namespace {
         // [[codegen::verbatim(ScaleInfo.description)]]
         std::optional<float> scale;
 
-        // [[codegen::verbatim(GammaInfo.description)]]
-        std::optional<float> gamma;
+        // [[codegen::verbatim(GammaOffsetInfo.description)]]
+        std::optional<float> gammaOffset;
 
         // [[codegen::verbatim(UsePerspectiveProjectionInfo.description)]]
         std::optional<bool> usePerspectiveProjection;
@@ -317,7 +318,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     , _borderWidth(BorderWidthInfo, 0.f, 0.f, 1000.f)
     , _borderColor(BorderColorInfo, glm::vec3(0.f), glm::vec3(0.f), glm::vec3(1.f))
     , _scale(ScaleInfo, 0.25f, 0.f, 2.f)
-    , _gamma(GammaInfo, 1.f, 0.000001f, 10.f)
+    , _gammaOffset(GammaOffsetInfo, 0.f, -1.f, 10.f)
     , _multiplyColor(MultiplyColorInfo, glm::vec3(1.f), glm::vec3(0.f), glm::vec3(1.f))
     , _backgroundColor(
         BackgroundColorInfo,
@@ -345,7 +346,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     addProperty(_faceCamera);
     addProperty(_cartesianPosition);
     addProperty(_raePosition);
-    addProperty(_gamma);
+    addProperty(_gammaOffset);
 
     // Setting spherical/euclidean onchange handler
     _useRadiusAzimuthElevation.onChange([this]() {
@@ -379,7 +380,7 @@ ScreenSpaceRenderable::ScreenSpaceRenderable(const ghoul::Dictionary& dictionary
     _backgroundColor.setViewOption(properties::Property::ViewOptions::Color);
 
     _enabled = p.enabled.value_or(_enabled);
-    _gamma = p.gamma.value_or(_gamma);
+    _gammaOffset = p.gammaOffset.value_or(_gammaOffset);
 
     _useRadiusAzimuthElevation =
         p.useRadiusAzimuthElevation.value_or(_useRadiusAzimuthElevation);
@@ -453,7 +454,7 @@ bool ScreenSpaceRenderable::deinitializeGL() {
     return true;
 }
 
-void ScreenSpaceRenderable::render(float blackoutFactor) {
+void ScreenSpaceRenderable::render(const RenderData& renderData) {
     ZoneScoped;
 
     const glm::mat4 mat =
@@ -461,7 +462,7 @@ void ScreenSpaceRenderable::render(float blackoutFactor) {
         translationMatrix() *
         localRotationMatrix() *
         scaleMatrix();
-    draw(mat, blackoutFactor);
+    draw(mat, renderData);
 }
 
 bool ScreenSpaceRenderable::isReady() const {
@@ -640,7 +641,9 @@ glm::mat4 ScreenSpaceRenderable::translationMatrix() {
     return glm::translate(glm::mat4(1.f), translation);
 }
 
-void ScreenSpaceRenderable::draw(const glm::mat4& modelTransform, float blackoutFactor) {
+void ScreenSpaceRenderable::draw(const glm::mat4& modelTransform,
+                                 const RenderData& renderData)
+{
     glDisable(GL_CULL_FACE);
 
     _shader->activate();
@@ -654,10 +657,13 @@ void ScreenSpaceRenderable::draw(const glm::mat4& modelTransform, float blackout
     _shader->setUniform(_uniformCache.opacity, opacity());
     _shader->setUniform(
         _uniformCache.blackoutFactor,
-        _renderDuringBlackout ? 1.f : blackoutFactor
+        _renderDuringBlackout ? 1.f : renderData.blackoutFactor
     );
+    _shader->setUniform(_uniformCache.hue, renderData.hue);
+    _shader->setUniform(_uniformCache.value, renderData.value);
+    _shader->setUniform(_uniformCache.saturation, renderData.saturation);
+    _shader->setUniform(_uniformCache.gamma, renderData.gamma + _gammaOffset);
     _shader->setUniform(_uniformCache.backgroundColor, _backgroundColor);
-    _shader->setUniform(_uniformCache.gamma, _gamma);
     _shader->setUniform(_uniformCache.borderWidth, borderUV);
     _shader->setUniform(_uniformCache.borderColor, _borderColor);
     _shader->setUniform(

--- a/src/rendering/screenspacerenderable.cpp
+++ b/src/rendering/screenspacerenderable.cpp
@@ -148,7 +148,7 @@ namespace {
 
     constexpr openspace::properties::Property::PropertyInfo GammaOffsetInfo = {
         "GammaOffset",
-        "Gamma Correction",
+        "Gamma Correction Offset",
         "Sets the gamma correction of the texture that is applied in addition to the "
         "global gamma value.",
         openspace::properties::Property::Visibility::AdvancedUser


### PR DESCRIPTION
Closes #3055