### PR TITLE
Feature/examples naming

### DIFF
--- a/data/assets/examples/animation.asset
+++ b/data/assets/examples/animation.asset
@@ -34,8 +34,8 @@ local AnimationLoop = {
     }
   },
   GUI = {
-    Name = "Animated Model example (LoopFromStart)",
-    Path = "/Example",
+    Name = "Animated Model (LoopFromStart)",
+    Path = "/Examples",
     Description = "Simple animated box model with the animation mode 'LoopFromStart'"
   }
 }
@@ -61,8 +61,8 @@ local AnimationLoopInf = {
     }
   },
   GUI = {
-    Name = "Animated Model example (LoopInfinitely)",
-    Path = "/Example",
+    Name = "Animated Model (LoopInfinitely)",
+    Path = "/Examples",
     Description = "Simple animated box model with the animation mode 'LoopInfinitely'"
   }
 }
@@ -88,8 +88,8 @@ local AnimationOnce = {
     }
   },
   GUI = {
-    Name = "Animated Model example (Once)",
-    Path = "/Example",
+    Name = "Animated Model (Once)",
+    Path = "/Examples",
     Description = "Simple animated box model with the animation mode 'Once'"
   }
 }
@@ -115,8 +115,8 @@ local AnimationBounceInf = {
     }
   },
   GUI = {
-    Name = "Animated Model example (BounceInfinitely)",
-    Path = "/Example",
+    Name = "Animated Model (BounceInfinitely)",
+    Path = "/Examples",
     Description = "Simple animated box model with the animation mode 'BounceInfinitely'"
   }
 }
@@ -142,8 +142,8 @@ local AnimationBounce = {
     }
   },
   GUI = {
-    Name = "Animated Model example (BounceFromStart)",
-    Path = "/Example",
+    Name = "Animated Model (BounceFromStart)",
+    Path = "/Examples",
     Description = "Simple animated box model with the animation mode 'BounceFromStart'"
   }
 }

--- a/data/assets/examples/approachevents.asset
+++ b/data/assets/examples/approachevents.asset
@@ -48,8 +48,8 @@ local Model = {
   OnRecede = { "os.example.generic" },
   OnExit = { "os.example.generic" },
   GUI = {
-    Name = "Example Event Model",
-    Path = "/Example"
+    Name = "Event Model",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/audio/audio_playback_advanced.asset
+++ b/data/assets/examples/audio/audio_playback_advanced.asset
@@ -13,35 +13,35 @@ local panleft = {
   Identifier = "os.examples.PanLeft",
   Name = "Example Audio Pan Left",
   Command = [[openspace.audio.set3dSourcePosition("Advanced_Example_Sound_1", { -1, 0, 0 })]],
-  GuiPath = "/Example/Audio"
+  GuiPath = "/Examples/Audio"
 }
 
 local pancenter = {
   Identifier = "os.examples.PanCenter",
   Name = "Example Audio Pan Center",
   Command = [[openspace.audio.set3dSourcePosition("Advanced_Example_Sound_1", { 0, 0, 0 })]],
-  GuiPath = "/Example/Audio"
+  GuiPath = "/Examples/Audio"
 }
 
 local panright = {
   Identifier = "os.examples.PanRight",
   Name = "Example Audio Pan Right",
   Command = [[openspace.audio.set3dSourcePosition("Advanced_Example_Sound_1", { 1, 0, 0 })]],
-  GuiPath = "/Example/Audio"
+  GuiPath = "/Examples/Audio"
 }
 
 local lowvolume = {
   Identifier = "os.examples.LowVolume",
   Name = "Example Audio Volume Low",
   Command = [[openspace.audio.setVolume("Advanced_Example_Sound_1", 0.15)]],
-  GuiPath = "/Example/Audio"
+  GuiPath = "/Examples/Audio"
 }
 
 local fullvolume = {
   Identifier = "os.examples.FullVolume",
   Name = "Example Audio Volume Full",
   Command = [[openspace.audio.setVolume("Advanced_Example_Sound_1", 1.0)]],
-  GuiPath = "/Example/Audio"
+  GuiPath = "/Examples/Audio"
 }
 
 asset.onInitialize(function()

--- a/data/assets/examples/globerotation.asset
+++ b/data/assets/examples/globerotation.asset
@@ -41,7 +41,8 @@ local ExampleGlobeRotation = {
     }
   },
   GUI = {
-    Path = "/Example"
+    Name = "GlobeRotation",
+    Path = "/Examples"
   }
 }
 
@@ -58,11 +59,12 @@ asset.export(ExampleGlobeRotation)
 
 
 asset.meta = {
-  Name = "Model Example",
+  Name = "GlobeRotation Example",
   Version = "1.0",
   Description = [[An example that demonstrates how to load a 3D model from a geometry
-    file, together with some basic functionality. The model is placed on the surface
-    of a planet using a GlobeRotation and GlobeTranslation.]],
+    file, placing it on a planetary surface and rotate it to align with the surface
+    normal using a "GlobeRotation" transform. Note that "GlobeTranslation" is needed to
+    put the model in the correct location.]],
   Author = "OpenSpace Team",
   URL = "http://openspaceproject.com",
   License = "MIT license"

--- a/data/assets/examples/globetranslation.asset
+++ b/data/assets/examples/globetranslation.asset
@@ -31,7 +31,8 @@ local ExampleFixedHeight = {
     }
   },
   GUI = {
-    Path = "/Example"
+    Name = "GlobeTranslation - Fixed Height",
+    Path = "/Examples"
   }
 }
 
@@ -55,7 +56,8 @@ local ExampleAdaptiveHeight = {
     }
   },
   GUI = {
-    Path = "/Example"
+    Name = "GlobeTranslation - Adaptive Height",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/modelshader/modelshader.asset
+++ b/data/assets/examples/modelshader/modelshader.asset
@@ -25,7 +25,7 @@ local Model = {
     GeometryFile = model .. "BoxAnimated.glb",
     ModelScale = 3E7,
     -- (malej 2023-MAY-22) Note that PerformShading should be false in this example,
-    -- these example shaders dont't contain any light calculations
+    -- since these example shaders dont't contain any light calculations
     PerformShading = false,
     VertexShader = asset.resource("model_vs.glsl"),
     FragmentShader = asset.resource("model_fs.glsl"),
@@ -36,7 +36,7 @@ local Model = {
   },
   GUI = {
     Name = "Model Shader",
-    Path = "/Example",
+    Path = "/Examples",
     Description = "Simple box model with a custom shader"
   }
 }

--- a/data/assets/examples/nodeline.asset
+++ b/data/assets/examples/nodeline.asset
@@ -13,8 +13,8 @@ local RenderableNodeLineExample = {
     LineWidth = 2
   },
   GUI = {
-    Name = "RenderableNodeLine Example",
-    Path = "/Example",
+    Name = "RenderableNodeLine - Basic",
+    Path = "/Examples",
     Description = [[Draws a line between two nodes in the scene.]]
   }
 }

--- a/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes.asset
+++ b/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes.asset
@@ -1,5 +1,5 @@
 -- Basic
--- This asset creates a SceneGraphNode that only displays coordinate axes. The 
+-- This asset creates a SceneGraphNode that only displays coordinate axes. The
 -- parent is not set which defaults to placing the axes at the center the Sun.
 
 local Node = {
@@ -12,9 +12,9 @@ local Node = {
   },
   Renderable = {
     Type = "RenderableCartesianAxes"
-  },    
+  },
   GUI = {
-    Name = "Cartesian Axes Basic",
+    Name = "RenderableCartesianAxes - Basic",
     Path = "/Examples"
   }
 }

--- a/data/assets/examples/renderable/renderableinterpolatedpoints/interpolatedpoints.asset
+++ b/data/assets/examples/renderable/renderableinterpolatedpoints/interpolatedpoints.asset
@@ -16,8 +16,8 @@ local Node = {
     NumberOfObjects = 10
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/RenderableInterpolatedPoints"
+    Name = "RenderableInterpolatedPoints - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderableinterpolatedpoints/interpolatedpoints_colormapped.asset
+++ b/data/assets/examples/renderable/renderableinterpolatedpoints/interpolatedpoints_colormapped.asset
@@ -30,8 +30,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Color Mapped",
-    Path = "/Examples/RenderableInterpolatedPoints"
+    Name = "RenderableInterpolatedPoints - Color Mapped",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderableinterpolatedpoints/interpolatedpoints_spline.asset
+++ b/data/assets/examples/renderable/renderableinterpolatedpoints/interpolatedpoints_spline.asset
@@ -22,8 +22,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Spline (Smoother)",
-    Path = "/Examples/RenderableInterpolatedPoints"
+    Name = "RenderableInterpolatedPoints - Spline",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablenodearrow/nodearrow.asset
+++ b/data/assets/examples/renderable/renderablenodearrow/nodearrow.asset
@@ -25,8 +25,8 @@ local Node = {
     Width = 900000.0
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/RenderableNodeArrow"
+    Name = "RenderableNodeArrow - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablenodearrow/nodearrow_appearance.asset
+++ b/data/assets/examples/renderable/renderablenodearrow/nodearrow_appearance.asset
@@ -27,8 +27,8 @@ local Node = {
     ArrowHeadWidthFactor = 1.0
   },
   GUI = {
-    Name = "Custom Appearance (Colored & Inverted)",
-    Path = "/Examples/RenderableNodeArrow"
+    Name = "RenderableNodeArrow - Custom Appearance (Colored & Inverted)",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablenodearrow/nodearrow_relativevalues.asset
+++ b/data/assets/examples/renderable/renderablenodearrow/nodearrow_relativevalues.asset
@@ -28,8 +28,8 @@ local Node = {
     Width = 900000.0
   },
   GUI = {
-    Name = "Relative Units",
-    Path = "/Examples/RenderableNodeArrow",
+    Name = "RenderableNodeArrow - Relative Units",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderableplaneimageonline/planeimageonline.asset
+++ b/data/assets/examples/renderable/renderableplaneimageonline/planeimageonline.asset
@@ -10,8 +10,8 @@ local Node = {
     URL = "http://data.openspaceproject.com/examples/renderableplaneimageonline.jpg"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/RenderablePlaneImageOnline"
+    Name = "RenderablePlaneImageOnline - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderableplaneimageonline/planeimageonline_billboarded.asset
+++ b/data/assets/examples/renderable/renderableplaneimageonline/planeimageonline_billboarded.asset
@@ -12,8 +12,8 @@ local Node = {
     Billboarded = true
   },
   GUI = {
-    Name = "Billboarded",
-    Path = "/Examples/RenderablePlaneImageOnline"
+    Name = "RenderablePlaneImageOnline - Billboarded",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_colormappingsettings.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_colormappingsettings.asset
@@ -52,8 +52,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Advanced Color Mapping",
-    Path = "/Examples/RenderablePointCloud/Advanced",
+    Name = "RenderablePointCloud - Advanced Color Mapping",
+    Path = "/Examples/Advanced",
     Description = [[Example of a point cloud where the range is set explicitly and
       specific colors are used for values outside the range, as well as for missing
       data values.]]

--- a/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_datamapping.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_datamapping.asset
@@ -38,8 +38,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Custom Data Mapping",
-    Path = "/Examples/RenderablePointCloud/Advanced"
+    Name = "RenderablePointCloud - Custom Data Mapping",
+    Path = "/Examples/Advanced"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_fading.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_fading.asset
@@ -18,8 +18,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Fading",
-    Path = "/Examples/RenderablePointCloud/Advanced",
+    Name = "RenderablePointCloud - Fading",
+    Path = "/Examples/Advanced",
     Description = [[Example of a point cloud with distance-based fading (the points
       are visible when the camera reaches a certain distance away from the origin)]]
   }

--- a/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_labels.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_labels.asset
@@ -28,8 +28,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Labels",
-    Path = "/Examples/RenderablePointCloud/Advanced"
+    Name = "RenderablePointCloud - Labels",
+    Path = "/Examples/Advanced"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_multitextured.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/advanced/pointcloud_multitextured.asset
@@ -27,8 +27,8 @@ local Node = {
     UseAdditiveBlending = false
   },
   GUI = {
-    Name = "Multi-Textured",
-    Path = "/Examples/RenderablePointCloud/Advanced"
+    Name = "RenderablePointCloud - Multi-Textured",
+    Path = "/Examples/Advanced"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud.asset
@@ -12,8 +12,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Fixed Color and Size",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Fixed Color and Size",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_colormapped.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_colormapped.asset
@@ -21,8 +21,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Color Mapped",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Color Mapped",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_colormapped_moresettings.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_colormapped_moresettings.asset
@@ -34,8 +34,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Color Mapped with Settings",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Color Mapped with Settings",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_maxsize.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_maxsize.asset
@@ -18,8 +18,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Max Size",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Max Size",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_outline.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_outline.asset
@@ -16,8 +16,8 @@ local Node = {
     UseAdditiveBlending = false
   },
   GUI = {
-    Name = "Outlined",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Outlined",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_outline.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_outline.asset
@@ -10,7 +10,7 @@ local Node = {
     Coloring = {
       EnableOutline = true,
       OutlineColor = { 0.2, 0.2, 1.0 },
-      OutlineWeight = 0.1
+      OutlineWidth = 0.1
     },
     -- It might be desired to disable additive blending when using an outline
     UseAdditiveBlending = false

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_scaled.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_scaled.asset
@@ -18,8 +18,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Point Size / Scaling",
-    Path = "/Examples/RenderablePointCloud",
+    Name = "RenderablePointCloud - Point Size / Scaling",
+    Path = "/Examples",
     Description = "Point cloud with configured point size"
   }
 }

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_scaledfromdata.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_scaledfromdata.asset
@@ -26,8 +26,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Size from Data",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Size from Data",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_textured.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_textured.asset
@@ -22,8 +22,8 @@ local Node = {
     UseAdditiveBlending = false
   },
   GUI = {
-    Name = "Textured",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Textured",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_units.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_units.asset
@@ -10,8 +10,8 @@ local Node = {
     Unit = "Km"
   },
   GUI = {
-    Name = "Units",
-    Path = "/Examples/RenderablePointCloud"
+    Name = "RenderablePointCloud - Units",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablepolygoncloud/polygoncloud.asset
+++ b/data/assets/examples/renderable/renderablepolygoncloud/polygoncloud.asset
@@ -15,8 +15,8 @@ local Node = {
     PolygonSides = 6
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/RenderablePolygonCloud"
+    Name = "RenderablePolygonCloud - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablesphereimageonline/simplesphereimageonline.asset
+++ b/data/assets/examples/renderable/renderablesphereimageonline/simplesphereimageonline.asset
@@ -13,8 +13,8 @@ local Node = {
     Segments = 16
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/RenderableSphereImageOnline"
+    Name = "RenderableSphereImageOnline - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderablespherespout/spherespout.asset
+++ b/data/assets/examples/renderable/renderablespherespout/spherespout.asset
@@ -15,8 +15,8 @@ local Node = {
     SpoutName = "WV_SPOUT"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/RenderableSphereSpout"
+    Name = "RenderableSphereSpout - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/renderable/renderabletravelspeed/travelspeed.asset
+++ b/data/assets/examples/renderable/renderabletravelspeed/travelspeed.asset
@@ -14,8 +14,8 @@ local Node = {
     Target = moonAsset.Moon.Identifier
   },
    GUI = {
-     Name = "Light Speed Indicator",
-    Path = "/Examples/RenderableTravelSpeed"
+     Name = "RenderableTravelSpeed - Light Speed Indicator",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/rotation/luarotation/lua.asset
+++ b/data/assets/examples/rotation/luarotation/lua.asset
@@ -20,8 +20,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/LuaRotation"
+    Name = "LuaRotation - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/scale/luascale/lua.asset
+++ b/data/assets/examples/scale/luascale/lua.asset
@@ -20,8 +20,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/LuaScale"
+    Name = "LuaScale - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/scale/nonuniformstaticscale/nonuniformstatic.asset
+++ b/data/assets/examples/scale/nonuniformstaticscale/nonuniformstatic.asset
@@ -18,8 +18,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/NonUniformStaticScale"
+    Name = "NonUniformStaticScale - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/scale/nonuniformstaticscale/nonuniformstatic_ellipsoid.asset
+++ b/data/assets/examples/scale/nonuniformstaticscale/nonuniformstatic_ellipsoid.asset
@@ -15,8 +15,8 @@ local Node = {
     Type = "RenderableSphericalGrid"
   },
   GUI = {
-    Name = "Ellipsoid",
-    Path = "/Examples/NonUniformStaticScale"
+    Name = "NonUniformStaticScale - Ellipsoid",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/scale/staticscale/static.asset
+++ b/data/assets/examples/scale/staticscale/static.asset
@@ -16,8 +16,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/StaticScale"
+    Name = "StaticScale - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/scale/timedependentscale/timedependent.asset
+++ b/data/assets/examples/scale/timedependentscale/timedependent.asset
@@ -16,8 +16,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/TimeDependentScale"
+    Name = "TimeDependentScale - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/scale/timedependentscale/timedependent_speed.asset
+++ b/data/assets/examples/scale/timedependentscale/timedependent_speed.asset
@@ -17,8 +17,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "with Speed",
-    Path = "/Examples/TimeDependentScale"
+    Name = "TimeDependentScale - With Speed",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/tileprovider/tileproviderbyindex/byindex.asset
+++ b/data/assets/examples/tileprovider/tileproviderbyindex/byindex.asset
@@ -45,8 +45,8 @@ local Node = {
     }
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/TileProviderByIndex"
+    Name = "TileProviderByIndex - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/timeframe/union.asset
+++ b/data/assets/examples/timeframe/union.asset
@@ -27,8 +27,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/TimeFrameUnion"
+    Name = "TimeFrameUnion - Basic",
+    Path = "/Examples"
   }
 }
 

--- a/data/assets/examples/translation/luatranslation/lua.asset
+++ b/data/assets/examples/translation/luatranslation/lua.asset
@@ -30,8 +30,8 @@ local Node = {
     Type = "RenderableCartesianAxes"
   },
   GUI = {
-    Name = "Basic",
-    Path = "/Examples/LuaTranslation"
+    Name = "LuaTranslation - Basic",
+    Path = "/Examples"
   }
 }
 


### PR DESCRIPTION
This PR changes the naming of all the "new" examples (that follow the format we decided on for the docs page) to be consistent according to our latest decision. 

In addition it also makes the GUI paths for all the other examples more consistent, so that they will all end up under "Examples" in the Scene menu