### PR TITLE
Fix renderable sphere example and add one for using local image

### DIFF
--- a/data/assets/examples/renderable/renderablesphereimagelocal/sphereimagelocal.asset
+++ b/data/assets/examples/renderable/renderablesphereimagelocal/sphereimagelocal.asset
@@ -1,5 +1,5 @@
 -- Basic
--- This example will show a sphere that is covered with an image which is retrieved from
+-- This example shows a sphere that is covered with an image which is retrieved from
 -- a local file path. The image will be stretched over the entire sphere as an
 -- equirectangular projection.
 

--- a/data/assets/examples/renderable/renderablesphereimagelocal/sphereimagelocal.asset
+++ b/data/assets/examples/renderable/renderablesphereimagelocal/sphereimagelocal.asset
@@ -1,0 +1,24 @@
+-- Basic
+-- This example will show a sphere that is covered with an image which is retrieved from
+-- a local file path. The image will be stretched over the entire sphere as an
+-- equirectangular projection.
+
+local Node = {
+  Identifier = "RenderableSphereImageLocal_Example",
+  Renderable = {
+    Type = "RenderableSphereImageLocal",
+    Texture = openspace.absPath("${DATA}/test2.jpg")
+  },
+  GUI = {
+    Name = "RenderableSphereImageLocal - Basic",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/data/assets/examples/renderable/renderablesphereimageonline/sphereimageonline.asset
+++ b/data/assets/examples/renderable/renderablesphereimageonline/sphereimageonline.asset
@@ -1,16 +1,13 @@
 -- Basic
 -- This example will show a sphere that is covered with an image which is retrieved from
 -- an online URL. The image will be stretched over the entire sphere as an equirectangular
--- projection
+-- projection.
 
 local Node = {
   Identifier = "RenderableSphereImageOnline_Example",
   Renderable = {
     Type = "RenderableSphereImageOnline",
-    URL = "http://data.openspaceproject.com/examples/renderableplaneimageonline.jpg",
-
-    -- Parameters from the parent class `RenderableSphere`
-    Segments = 16
+    URL = "http://data.openspaceproject.com/examples/renderableplaneimageonline.jpg"
   },
   GUI = {
     Name = "Basic",

--- a/data/assets/examples/renderable/renderablesphereimageonline/sphereimageonline.asset
+++ b/data/assets/examples/renderable/renderablesphereimageonline/sphereimageonline.asset
@@ -1,5 +1,5 @@
 -- Basic
--- This example will show a sphere that is covered with an image which is retrieved from
+-- This example shows a sphere that is covered with an image which is retrieved from
 -- an online URL. The image will be stretched over the entire sphere as an equirectangular
 -- projection.
 

--- a/modules/base/rendering/renderablesphere.cpp
+++ b/modules/base/rendering/renderablesphere.cpp
@@ -102,10 +102,10 @@ namespace {
 
     struct [[codegen::Dictionary(RenderableSphere)]] Parameters {
         // [[codegen::verbatim(SizeInfo.description)]]
-        float size;
+        std::optional<float> size [[codegen::greater(0.f)]];
 
         // [[codegen::verbatim(SegmentsInfo.description)]]
-        int segments;
+        std::optional<int> segments [[codegen::greaterequal(4)]];
 
         enum class [[codegen::map(Orientation)]] Orientation {
             Outside,
@@ -140,7 +140,7 @@ documentation::Documentation RenderableSphere::Documentation() {
 RenderableSphere::RenderableSphere(const ghoul::Dictionary& dictionary)
     : Renderable(dictionary)
     , _size(SizeInfo, 1.f, 0.f, 1e25f)
-    , _segments(SegmentsInfo, 8, 4, 1000)
+    , _segments(SegmentsInfo, 16, 4, 1000)
     , _orientation(OrientationInfo, properties::OptionProperty::DisplayType::Dropdown)
     , _mirrorTexture(MirrorTextureInfo, false)
     , _disableFadeInDistance(DisableFadeInOutInfo, false)
@@ -151,7 +151,7 @@ RenderableSphere::RenderableSphere(const ghoul::Dictionary& dictionary)
 
     addProperty(Fadeable::_opacity);
 
-    _size = p.size;
+    _size = p.size.value_or(_size);
     _size.setExponent(15.f);
     _size.onChange([this]() {
         setBoundingSphere(_size);
@@ -159,7 +159,7 @@ RenderableSphere::RenderableSphere(const ghoul::Dictionary& dictionary)
     });
     addProperty(_size);
 
-    _segments = p.segments;
+    _segments = p.segments.value_or(_segments);
     _segments.onChange([this]() {
         _sphereIsDirty = true;
     });


### PR DESCRIPTION
The example `RenderableSphereImageOnline` was broken due to missing the previously non-optional `Size` parameter. 

Both `Size` and `Segments` have been marked as an advanced user property and should not be mandatory in the asset component specification, so I changed that and added verifiers. 

 The example also had a comment about properties from `RenderableSphere`, that the user should ont have to know about. removed this. I also changed the default value to the one we wanted to use for this example, to be a bit smoother per default.
 
 Finally, added a similar example for `RenderableSphereImageLocal`. 