### PR TITLE
Add ability for SPICE translation and rotation to account for light travel time

### DIFF
--- a/include/openspace/util/spicemanager.h
+++ b/include/openspace/util/spicemanager.h
@@ -994,6 +994,55 @@ public:
         int numberOfTerminatorPoints);
 
     /**
+     * The structure retuned by the #lightTime method.
+     */
+    struct LightTimeResult {
+        /// Epoch of the signal at the target.
+        /// This is the time at which the signal would arrive at the target.
+        double epochAtTarget = 0.0;
+
+        /// Time between transmit and receipt of the signal.
+        /// This is the light travel time.
+        double elapsed = 0.0;
+    };
+
+    /**
+     * This method returns time of a signal recieved at a target from an \observer
+     * corrected for light travel time.
+     *
+     * \param observedTime Time at which the signal was received
+     * \param target The target who emited the signal
+     * \param observer The observer who received the signal
+     * \param direction The direction of travel ("->" or "<-")
+     *
+     * \return The LightTimeResult structure that contains information about the time
+     *
+     * \throw SpiceException If \p instrument does not name a valid NAIF object
+     * \post The returned structure has all its values initialized
+     *
+     * \see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/ltime_c.html
+     */
+    LightTimeResult lightTravelTime(double observedTime, int target, int observer, const std::string& direction) const;
+
+    /**
+    * This method returns time of a signal recieved at a target from an \observer
+    * corrected for light travel time.
+    *
+    * \param observedTime Time at which the signal was received
+    * \param target The target who emited the signal
+    * \param observer The observer who received the signal
+    * \param direction The direction of travel ("->" or "<-")
+    *
+    * \return The LightTimeResult structure that contains information about the time
+    *
+    * \throw SpiceException If \p instrument does not name a valid NAIF object
+    * \post The returned structure has all its values initialized
+    *
+    * \see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/ltime_c.html
+    */
+    LightTimeResult lightTravelTime(double observedTime, const std::string& target, const std::string& observer, const std::string& direction) const;
+
+    /**
      * Sets the SpiceManager's exception handling. If UseException::No is passed to this
      * function, all subsequent calls will not throw an error, but fail silently instead.
      * If set to UseException::Yes, a SpiceException is thrown whenever an error occurs.

--- a/modules/space/rotation/spicerotation.h
+++ b/modules/space/rotation/spicerotation.h
@@ -48,6 +48,9 @@ private:
     properties::StringProperty _sourceFrame;
     properties::StringProperty _destinationFrame;
     properties::StringProperty _fixedDate;
+    properties::BoolProperty _useLightTravelTime;
+    properties::StringProperty _lightTravelTimeObserver;
+    properties::StringProperty _lightTravelTimeTarget;
 
     ghoul::mm_unique_ptr<TimeFrame> _timeFrame;
     std::optional<double> _fixedEphemerisTime;

--- a/modules/space/translation/spicetranslation.h
+++ b/modules/space/translation/spicetranslation.h
@@ -45,6 +45,7 @@ private:
     properties::StringProperty _observer;
     properties::StringProperty _frame;
     properties::StringProperty _fixedDate;
+    properties::BoolProperty _useLightTravelTime;
 
     // We are accessing these values every frame and when retrieving a string from the
     // StringProperty, it allocates some new memory, which we want to prevent. Until the

--- a/src/util/spicemanager.cpp
+++ b/src/util/spicemanager.cpp
@@ -1387,6 +1387,17 @@ glm::dmat3 SpiceManager::getEstimatedTransformMatrix(const std::string& fromFram
     return result;
 }
 
+SpiceManager::LightTimeResult SpiceManager::lightTravelTime(double observedTime, const std::string& target, const std::string& observer, const std::string& direction) const {
+    return lightTravelTime(observedTime, naifId(observer), naifId(target), direction);
+}
+
+SpiceManager::LightTimeResult SpiceManager::lightTravelTime(double observedTime, int target, int observer, const std::string& direction) const {
+
+    LightTimeResult res;
+    ltime_c(observedTime, observer, direction.c_str(), target, &res.epochAtTarget, &res.elapsed);
+    return res;
+}
+
 void SpiceManager::loadLeapSecondsSpiceKernel() {
     constexpr std::string_view Naif00012tlsSource = R"(
 KPL/LSK


### PR DESCRIPTION
The use case here was that we wanted to show and asteroid casting a shadow on earth. However, by the time the shadow reaches earth, it will have moved and rotated. So without this change the shadow will land on the wrong part of earth. 

Using this change the body will be moved back in it's orbit by the amount of light travel time.

Following the same thought thru to rotation, the body will be rotated back in time to the rotation that would be observed. Right now if you were to anchor and aim at Jupiter, and change the fov so that you could see it, you would see the rotation of Jupiter _at the current time_, not the rotation at Jupiter _as it would be observed from earth at the current time_  (since you would really be seeing Jupiter 4 minutes ago)

(note when using light travel time for rotation, you must also provide the target/observer body IDs since they are not know based on the rotation frame)

First and second screenshots show Jupiter with its regular rotation, and then with light travel time to the sun accounted for.
Third screenshot shows Neptune (barycenter) moved back by the light travel time to the sun.

(also this PR adds a lightTravelTime function to the spicemanager that is used by the rotation, but could be used in the future by other new functions) 


![OpenSpace_000003](https://github.com/OpenSpace/OpenSpace/assets/708535/895057b0-74f6-40d8-b40d-857c3d022b26)
![OpenSpace_000004](https://github.com/OpenSpace/OpenSpace/assets/708535/b13e41fc-7ede-402e-b1ca-5d1fce53dbf5)
![OpenSpace_000005](https://github.com/OpenSpace/OpenSpace/assets/708535/839fe43e-40bf-471b-9bf2-d6bd240608c1)

