### PR TITLE
Feature/update gui actions

### DIFF
--- a/include/openspace/engine/globals.h
+++ b/include/openspace/engine/globals.h
@@ -59,7 +59,6 @@ namespace interaction {
     class KeybindingManager;
     class NavigationHandler;
     class SessionRecording;
-    class ShortcutManager;
 } // namespace interaction
 namespace properties { class PropertyOwner; }
 namespace scripting {
@@ -96,7 +95,6 @@ inline interaction::WebsocketInputStates* websocketInputStates;
 inline interaction::KeybindingManager* keybindingManager;
 inline interaction::NavigationHandler* navigationHandler;
 inline interaction::SessionRecording* sessionRecording;
-inline interaction::ShortcutManager* shortcutManager;
 inline properties::PropertyOwner* rootPropertyOwner;
 inline properties::PropertyOwner* screenSpaceRootPropertyOwner;
 inline properties::PropertyOwner* userPropertyOwner;

--- a/include/openspace/events/event.h
+++ b/include/openspace/events/event.h
@@ -73,6 +73,8 @@ struct Event {
         FocusNodeChanged,
         LayerAdded,
         LayerRemoved,
+        ActionAdded,
+        ActionRemoved,
         SessionRecordingPlayback,
         PointSpacecraft,
         RenderableEnabled,
@@ -422,6 +424,42 @@ struct EventLayerRemoved : public Event {
      * \pre uri_ must be a valid uri
      */
     explicit EventLayerRemoved(std::string_view uri_);
+
+    const tstring uri;
+};
+
+/**
+ * This event is created when a layer is added to to a globe.
+ */
+struct EventActionAdded : public Event {
+    static constexpr Type Type = Event::Type::ActionAdded;
+
+    /**
+     * Creates an instance of an EventLayerAdded event.
+     *
+     * \param uri_ A string with the uri of the layer that was added
+     *
+     * \pre uri_ must be a valid uri
+     */
+    explicit EventActionAdded(std::string_view uri_);
+
+    const tstring uri;
+};
+
+/**
+ * This event is created when a layer is removed from a globe.
+ */
+struct EventActionRemoved : public Event {
+    static constexpr Type Type = Event::Type::ActionRemoved;
+
+    /**
+     * Creates an instance of an EventLayerRemoved event.
+     *
+     * \param uri_ The uri of the layer that was removed
+     *
+     * \pre uri_ must be a valid uri
+     */
+    explicit EventActionRemoved(std::string_view uri_);
 
     const tstring uri;
 };

--- a/include/openspace/events/event.h
+++ b/include/openspace/events/event.h
@@ -429,15 +429,15 @@ struct EventLayerRemoved : public Event {
 };
 
 /**
- * This event is created when a layer is added to to a globe.
+ * This event is created when an action is added.
  */
 struct EventActionAdded : public Event {
     static constexpr Type Type = Event::Type::ActionAdded;
 
     /**
-     * Creates an instance of an EventLayerAdded event.
+     * Creates an instance of an EventActionAdded event.
      *
-     * \param uri_ A string with the uri of the layer that was added
+     * \param uri_ A string with the uri of the action that was added
      *
      * \pre uri_ must be a valid uri
      */
@@ -447,15 +447,15 @@ struct EventActionAdded : public Event {
 };
 
 /**
- * This event is created when a layer is removed from a globe.
+ * This event is created when an action is removed.
  */
 struct EventActionRemoved : public Event {
     static constexpr Type Type = Event::Type::ActionRemoved;
 
     /**
-     * Creates an instance of an EventLayerRemoved event.
+     * Creates an instance of an EventActionRemoved event.
      *
-     * \param uri_ The uri of the layer that was removed
+     * \param uri_ The uri of the action that was removed
      *
      * \pre uri_ must be a valid uri
      */

--- a/modules/server/include/topics/shortcuttopic.h
+++ b/modules/server/include/topics/shortcuttopic.h
@@ -37,8 +37,10 @@ public:
     bool isDone() const override;
 
 private:
-    void sendData() const;
+    void sendData(nlohmann::json data) const;
     std::vector<nlohmann::json> shortcutsJson() const;
+    nlohmann::json shortcutJson(const std::string& identifier) const;
+    bool _isDone = true;
 };
 
 } // namespace openspace

--- a/modules/server/include/topics/shortcuttopic.h
+++ b/modules/server/include/topics/shortcuttopic.h
@@ -40,7 +40,6 @@ private:
     void sendData(nlohmann::json data) const;
     std::vector<nlohmann::json> shortcutsJson() const;
     nlohmann::json shortcutJson(const std::string& identifier) const;
-    bool _isDone = true;
 };
 
 } // namespace openspace

--- a/modules/server/src/topics/shortcuttopic.cpp
+++ b/modules/server/src/topics/shortcuttopic.cpp
@@ -110,7 +110,8 @@ nlohmann::json ShortcutTopic::shortcutJson(const std::string& identifier) const 
         actions.end(),
         [&identifier](const interaction::Action& action) {
             return action.identifier == identifier;
-    });
+        }
+    );
 
     if (found == actions.end()) {
         return json;

--- a/modules/server/src/topics/shortcuttopic.cpp
+++ b/modules/server/src/topics/shortcuttopic.cpp
@@ -129,7 +129,7 @@ nlohmann::json ShortcutTopic::shortcutJson(const std::string& identifier) const 
 }
 
 void ShortcutTopic::sendData(nlohmann::json data) const {
-    _connection->sendJson(wrappedPayload({ { "actions", data } }));
+    _connection->sendJson(wrappedPayload({ { "shortcuts", data } }));
 }
 
 void ShortcutTopic::handleJson(const nlohmann::json& input) {

--- a/modules/server/src/topics/shortcuttopic.cpp
+++ b/modules/server/src/topics/shortcuttopic.cpp
@@ -35,7 +35,7 @@ using nlohmann::json;
 namespace openspace {
 
 bool ShortcutTopic::isDone() const {
-    return _isDone;
+    return true;
 }
 
 std::vector<nlohmann::json> ShortcutTopic::shortcutsJson() const {
@@ -134,17 +134,10 @@ void ShortcutTopic::sendData(nlohmann::json data) const {
 
 void ShortcutTopic::handleJson(const nlohmann::json& input) {
     const std::string& event = input.at("event").get<std::string>();
-    if (event == "start_subscription") {
-        // TODO: Subscribe to shortcuts and keybindings
+    if (event == "get_all_shortcuts") {
         sendData(shortcutsJson());
-        _isDone = false;
     }
-    else if (event == "stop_subscription") {
-        // TODO: Unsubscribe to shortcuts and keybindings
-        _isDone = true;
-        return;
-    }
-    else if (event == "get_action") {
+    else if (event == "get_shortcut") {
         const std::string& identifier = input.at("identifier").get<std::string>();
         sendData(shortcutJson(identifier));
     }

--- a/modules/server/src/topics/shortcuttopic.cpp
+++ b/modules/server/src/topics/shortcuttopic.cpp
@@ -114,7 +114,7 @@ nlohmann::json ShortcutTopic::shortcutJson(const std::string& identifier) const 
     );
 
     if (found == actions.end()) {
-        return json;
+        return {};
     }
     interaction::Action action = *found;
 

--- a/src/events/event.cpp
+++ b/src/events/event.cpp
@@ -156,6 +156,16 @@ void log(int i, const EventLayerRemoved& e) {
     LINFO(std::format("[{}] LayerRemoved: {}", i, e.uri));
 }
 
+void log(int i, const EventActionAdded& e) {
+    ghoul_assert(e.type == EventActionAdded::Type, "Wrong type");
+    LINFO(std::format("[{}] ActionAdded: {}", i, e.uri));
+}
+
+void log(int i, const EventActionRemoved& e) {
+    ghoul_assert(e.type == EventActionRemoved::Type, "Wrong type");
+    LINFO(std::format("[{}] ActionRemoved: {}", i, e.uri));
+}
+
 void log(int i, const EventSessionRecordingPlayback& e) {
     ghoul_assert(e.type == EventSessionRecordingPlayback::Type, "Wrong type");
 
@@ -239,6 +249,8 @@ std::string_view toString(Event::Type type) {
         case Event::Type::FocusNodeChanged: return "FocusNodeChanged";
         case Event::Type::LayerAdded: return "LayerAdded";
         case Event::Type::LayerRemoved: return "LayerRemoved";
+        case Event::Type::ActionAdded: return "ActionAdded";
+        case Event::Type::ActionRemoved: return "ActionRemoved";
         case Event::Type::SessionRecordingPlayback: return "SessionRecordingPlayback";
         case Event::Type::PointSpacecraft: return "PointSpacecraft";
         case Event::Type::RenderableEnabled: return "RenderableEnabled";
@@ -298,6 +310,12 @@ Event::Type fromString(std::string_view str) {
     }
     else if (str == "LayerRemoved") {
         return Event::Type::LayerRemoved;
+    }
+    else if (str == "ActionAdded") {
+        return Event::Type::ActionAdded;
+    }
+    else if (str == "ActionRemoved") {
+        return Event::Type::ActionRemoved;
     }
     else if (str == "SessionRecordingPlayback") {
         return Event::Type::SessionRecordingPlayback;
@@ -448,6 +466,18 @@ ghoul::Dictionary toParameter(const Event& e) {
                 std::string(static_cast<const EventLayerRemoved&>(e).uri)
             );
             break;
+        case Event::Type::ActionAdded:
+            d.setValue(
+                "Uri",
+                std::string(static_cast<const EventActionAdded&>(e).uri)
+            );
+            break;
+        case Event::Type::ActionRemoved:
+            d.setValue(
+                "Uri",
+                std::string(static_cast<const EventActionRemoved&>(e).uri)
+            );
+            break;
         case Event::Type::SessionRecordingPlayback:
             switch (static_cast<const EventSessionRecordingPlayback&>(e).state) {
                 case EventSessionRecordingPlayback::State::Started:
@@ -570,6 +600,12 @@ void logAllEvents(const Event* e) {
             case Event::Type::LayerRemoved:
                 log(i, *static_cast<const EventLayerRemoved*>(e));
                 break;
+            case Event::Type::ActionAdded:
+                log(i, *static_cast<const EventActionAdded*>(e));
+                break;
+            case Event::Type::ActionRemoved:
+                log(i, *static_cast<const EventActionRemoved*>(e));
+                break;
             case Event::Type::SessionRecordingPlayback:
                 log(i, *static_cast<const EventSessionRecordingPlayback*>(e));
                 break;
@@ -690,6 +726,16 @@ EventLayerAdded::EventLayerAdded(std::string_view uri_)
 {}
 
 EventLayerRemoved::EventLayerRemoved(std::string_view uri_)
+    : Event(Type)
+    , uri(temporaryString(uri_))
+{}
+
+EventActionAdded::EventActionAdded(std::string_view uri_)
+    : Event(Type)
+    , uri(temporaryString(uri_))
+{}
+
+EventActionRemoved::EventActionRemoved(std::string_view uri_)
     : Event(Type)
     , uri(temporaryString(uri_))
 {}

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -63,6 +63,9 @@ void ActionManager::removeAction(const std::string& identifier) {
 
     const unsigned int hash = ghoul::hashCRC32(identifier);
     const auto it = _actions.find(hash);
+    global::eventEngine->publishEvent<events::EventActionRemoved>(
+        identifier
+    );
     _actions.erase(it);
 }
 

--- a/src/interaction/actionmanager.cpp
+++ b/src/interaction/actionmanager.cpp
@@ -24,6 +24,8 @@
 
 #include <openspace/interaction/actionmanager.h>
 
+#include <openspace/events/event.h>
+#include <openspace/events/eventengine.h>
 #include <openspace/engine/globals.h>
 #include <openspace/scripting/lualibrary.h>
 #include <openspace/scripting/scriptengine.h>
@@ -49,6 +51,9 @@ void ActionManager::registerAction(Action action) {
     ghoul_assert(!hasAction(action.identifier), "Identifier already existed");
 
     const unsigned int hash = ghoul::hashCRC32(action.identifier);
+    global::eventEngine->publishEvent<events::EventActionAdded>(
+        action.identifier
+    );
     _actions[hash] = std::move(action);
 }
 


### PR DESCRIPTION
Updates the GUI when an action is added or removed. To be used with this PR:

I removed the subscriptions as they are not really needed for actions - not that many actions are added or removed during a regular session. Instead a new topic is created when needed. The UI listens to the event topic which now notifies when an action has been added or removed.

There are some naming conventions we might want to look over for consistency, such as "action" vs "shortcut" and "uri" vs "identifier".
