### PR TITLE
Add possiblity to sort SGNs in GUI based on numerical value

### DIFF
--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -271,7 +271,7 @@ local Plane1lh = {
   GUI = {
     Name = "1lh Grid",
     Path = "/Other/Grids",
-    OrderNumber = LightHour
+    OrderingNumber = LightHour
   }
 }
 
@@ -303,7 +303,7 @@ local Plane1ld = {
   GUI = {
     Name = "1ld Grid",
     Path = "/Other/Grids",
-    OrderNumber = LightDay
+    OrderingNumber = LightDay
   }
 }
 
@@ -335,7 +335,7 @@ local Plane1lm = {
   GUI = {
     Name = "1lm Grid",
     Path = "/Other/Grids",
-    OrderNumber = LightMonth
+    OrderingNumber = LightMonth
   }
 }
 
@@ -367,7 +367,7 @@ local Plane1ly = {
   GUI = {
     Name = "1ly Grid",
     Path = "/Other/Grids",
-    OrderNumber = LightYear
+    OrderingNumber = LightYear
   }
 }
 
@@ -399,7 +399,7 @@ local Plane10ly = {
   GUI = {
     Name = "10ly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 10 * LightYear
+    OrderingNumber = 10 * LightYear
   }
 }
 
@@ -431,7 +431,7 @@ local Plane100ly = {
   GUI = {
     Name = "100ly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 100 * LightYear
+    OrderingNumber = 100 * LightYear
   }
 }
 
@@ -463,7 +463,7 @@ local Plane1kly = {
   GUI = {
     Name = "1kly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 1000 * LightYear
+    OrderingNumber = 1000 * LightYear
   }
 }
 
@@ -495,7 +495,7 @@ local Plane10kly = {
   GUI = {
     Name = "10kly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 10000 * LightYear
+    OrderingNumber = 10000 * LightYear
   }
 }
 
@@ -522,7 +522,7 @@ local Plane100kly = {
   GUI = {
     Name = "100kly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 100000 * LightYear
+    OrderingNumber = 100000 * LightYear
   }
 }
 
@@ -549,7 +549,7 @@ local Plane1Mly = {
   GUI = {
     Name = "1Mly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 1E6 * LightYear
+    OrderingNumber = 1E6 * LightYear
   }
 }
 
@@ -576,7 +576,7 @@ local Plane10Mly = {
   GUI = {
     Name = "10Mly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 10E6 * LightYear
+    OrderingNumber = 10E6 * LightYear
   }
 }
 
@@ -603,7 +603,7 @@ local Plane100Mly = {
   GUI = {
     Name = "100Mly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 100E6 * LightYear
+    OrderingNumber = 100E6 * LightYear
   }
 }
 
@@ -630,7 +630,7 @@ local Plane20Gly = {
   GUI = {
     Name = "20Gly Grid",
     Path = "/Other/Grids",
-    OrderNumber = 20E9 * LightYear
+    OrderingNumber = 20E9 * LightYear
   }
 }
 

--- a/data/assets/scene/digitaluniverse/grids.asset
+++ b/data/assets/scene/digitaluniverse/grids.asset
@@ -270,7 +270,8 @@ local Plane1lh = {
   },
   GUI = {
     Name = "1lh Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = LightHour
   }
 }
 
@@ -301,7 +302,8 @@ local Plane1ld = {
   },
   GUI = {
     Name = "1ld Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = LightDay
   }
 }
 
@@ -332,7 +334,8 @@ local Plane1lm = {
   },
   GUI = {
     Name = "1lm Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = LightMonth
   }
 }
 
@@ -363,7 +366,8 @@ local Plane1ly = {
   },
   GUI = {
     Name = "1ly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = LightYear
   }
 }
 
@@ -394,7 +398,8 @@ local Plane10ly = {
   },
   GUI = {
     Name = "10ly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 10 * LightYear
   }
 }
 
@@ -425,7 +430,8 @@ local Plane100ly = {
   },
   GUI = {
     Name = "100ly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 100 * LightYear
   }
 }
 
@@ -456,7 +462,8 @@ local Plane1kly = {
   },
   GUI = {
     Name = "1kly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 1000 * LightYear
   }
 }
 
@@ -487,7 +494,8 @@ local Plane10kly = {
   },
   GUI = {
     Name = "10kly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 10000 * LightYear
   }
 }
 
@@ -513,7 +521,8 @@ local Plane100kly = {
   },
   GUI = {
     Name = "100kly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 100000 * LightYear
   }
 }
 
@@ -539,7 +548,8 @@ local Plane1Mly = {
   },
   GUI = {
     Name = "1Mly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 1E6 * LightYear
   }
 }
 
@@ -565,7 +575,8 @@ local Plane10Mly = {
   },
   GUI = {
     Name = "10Mly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 10E6 * LightYear
   }
 }
 
@@ -591,7 +602,8 @@ local Plane100Mly = {
   },
   GUI = {
     Name = "100Mly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 100E6 * LightYear
   }
 }
 
@@ -617,7 +629,8 @@ local Plane20Gly = {
   },
   GUI = {
     Name = "20Gly Grid",
-    Path = "/Other/Grids"
+    Path = "/Other/Grids",
+    OrderNumber = 20E9 * LightYear
   }
 }
 

--- a/data/assets/util/webgui.asset
+++ b/data/assets/util/webgui.asset
@@ -4,7 +4,7 @@ local guiCustomization = asset.require("customization/gui")
 
 
 -- Select which commit hashes to use for the frontend and backend
-local frontendHash = "67262b3edb3c33580d73e0bb5a61a0321a0b218e"
+local frontendHash = "654c79e7f30e61249b93be509758ac675022e5f3"
 
 local frontend = asset.resource({
   Identifier = "WebGuiFrontend",

--- a/include/openspace/scene/scenegraphnode.h
+++ b/include/openspace/scene/scenegraphnode.h
@@ -146,6 +146,8 @@ public:
     Renderable* renderable();
 
     std::string guiPath() const;
+    float guiOrderNumber() const;
+    bool useGuiOrder() const;
     bool hasGuiHintHidden() const;
     void setGuiHintHidden(bool value);
 
@@ -170,15 +172,17 @@ private:
     std::vector<std::string> _onRecedeAction;
     std::vector<std::string> _onExitAction;
 
+    ghoul::mm_unique_ptr<Renderable> _renderable;
+
     // If this value is 'true' GUIs are asked to hide this node from collections, as it
     // might be a node that is not very interesting (for example barycenters)
     properties::BoolProperty _guiHidden;
 
-    ghoul::mm_unique_ptr<Renderable> _renderable;
-
     properties::StringProperty _guiPath;
     properties::StringProperty _guiDisplayName;
     properties::StringProperty _guiDescription;
+    properties::FloatProperty _guiOrderNumber;
+    properties::BoolProperty _useGuiOrder;
 
     // Transformation defined by translation, rotation and scale
     struct {

--- a/include/openspace/scene/scenegraphnode.h
+++ b/include/openspace/scene/scenegraphnode.h
@@ -146,8 +146,6 @@ public:
     Renderable* renderable();
 
     std::string guiPath() const;
-    float guiOrderNumber() const;
-    bool useGuiOrder() const;
     bool hasGuiHintHidden() const;
     void setGuiHintHidden(bool value);
 
@@ -181,8 +179,8 @@ private:
     properties::StringProperty _guiPath;
     properties::StringProperty _guiDisplayName;
     properties::StringProperty _guiDescription;
-    properties::FloatProperty _guiOrderNumber;
-    properties::BoolProperty _useGuiOrder;
+    properties::FloatProperty _guiOrderingNumber;
+    properties::BoolProperty _useGuiOrdering;
 
     // Transformation defined by translation, rotation and scale
     struct {

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -175,6 +175,23 @@ namespace {
         openspace::properties::Property::Visibility::Hidden
     };
 
+    constexpr openspace::properties::Property::PropertyInfo GuiOrderInfo = {
+        "GuiOrderNumber",
+        "Gui Order Number",
+        "This is an optional numerical value that will affect the sorting of this scene "
+        "graph node in relation ot its neighbors in the user interface. Nodes with the "
+        "same value will be sorted alphabetically.",
+        openspace::properties::Property::Visibility::Hidden
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo UseGuiOrderInfo = {
+        "UseGuiOrder",
+        "UseGuiOrder",
+        "If true, use the 'GuiOrderNumber' to place this scene graph nodes in a sorted "
+        "way in relation to its neighbors in the GUI",
+        openspace::properties::Property::Visibility::Hidden
+    };
+
     constexpr openspace::properties::Property::PropertyInfo ShowDebugSphereInfo = {
         "ShowDebugSphere",
         "Show Debug Sphere",
@@ -309,6 +326,15 @@ namespace {
             // scene graph node. This is most useful to trim collective lists of nodes and
             // not display, for example, barycenters
             std::optional<bool> hidden;
+
+            // If this value is specified, the scene graph node will be ordered in
+            // relation to its neighbors in the GUI based on this value, so that nodes
+            // with a higher value appear later in the list. Scene graph noeds with the
+            // same value will be sorted alphabetically.
+            //
+            // The nodes without a given value will be placed at the top at the list and
+            // sorted alphabetically.
+            std::optional<double> orderNumber;
         };
         // Additional information that is passed to GUI applications. These are all hints
         // and do not have any impact on the actual function of the scene graph node
@@ -361,6 +387,11 @@ ghoul::mm_unique_ptr<SceneGraphNode> SceneGraphNode::createFromDictionary(
                 throw ghoul::RuntimeError("GuiPath must start with /");
             }
             result->_guiPath = *p.gui->path;
+        }
+
+        result->_useGuiOrder = p.gui->orderNumber.has_value();
+        if (p.gui->orderNumber.has_value()) {
+            result->_guiOrderNumber = *p.gui->orderNumber;
         }
     }
 
@@ -512,6 +543,8 @@ SceneGraphNode::SceneGraphNode()
     , _guiPath(GuiPathInfo, "/")
     , _guiDisplayName(GuiNameInfo)
     , _guiDescription(GuiDescriptionInfo)
+    , _guiOrderNumber(GuiOrderInfo, 0.f)
+    , _useGuiOrder(UseGuiOrderInfo, false)
     , _transform {
         ghoul::mm_unique_ptr<Translation>(
             global::memoryManager->PersistentMemory.alloc<StaticTranslation>()
@@ -593,6 +626,8 @@ SceneGraphNode::SceneGraphNode()
     addProperty(_guiDescription);
     addProperty(_guiHidden);
     addProperty(_guiPath);
+    addProperty(_guiOrderNumber);
+    addProperty(_useGuiOrder);
 }
 
 SceneGraphNode::~SceneGraphNode() {}
@@ -1114,6 +1149,14 @@ glm::dvec3 SceneGraphNode::worldScale() const {
 
 std::string SceneGraphNode::guiPath() const {
     return _guiPath;
+}
+
+float SceneGraphNode::guiOrderNumber() const {
+    return _guiOrderNumber;
+}
+
+bool SceneGraphNode::useGuiOrder() const {
+    return _useGuiOrder;
 }
 
 bool SceneGraphNode::hasGuiHintHidden() const {

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -176,19 +176,19 @@ namespace {
     };
 
     constexpr openspace::properties::Property::PropertyInfo GuiOrderInfo = {
-        "GuiOrderNumber",
-        "Gui Order Number",
+        "GuiOrderingNumber",
+        "Gui Ordering Number",
         "This is an optional numerical value that will affect the sorting of this scene "
-        "graph node in relation to its neighbors in the GUI. Nodes with the "
-        "same value will be sorted alphabetically.",
+        "graph node in relation to its neighbors in the GUI. Nodes with the same value "
+        "will be sorted alphabetically.",
         openspace::properties::Property::Visibility::Hidden
     };
 
     constexpr openspace::properties::Property::PropertyInfo UseGuiOrderInfo = {
-        "UseGuiOrder",
-        "Use Gui Order",
-        "If true, use the 'GuiOrderNumber' to place this scene graph nodes in a sorted "
-        "way in relation to its neighbors in the GUI",
+        "UseGuiOrdering",
+        "Use Gui Ordering",
+        "If true, use the 'GuiOrderingNumber' to place this scene graph node in a "
+        "sorted way in relation to its neighbors in the GUI",
         openspace::properties::Property::Visibility::Hidden
     };
 
@@ -334,7 +334,7 @@ namespace {
             //
             // The nodes without a given value will be placed at the bottom of the list
             // and sorted alphabetically.
-            std::optional<double> orderNumber;
+            std::optional<double> orderingNumber;
         };
         // Additional information that is passed to GUI applications. These are all hints
         // and do not have any impact on the actual function of the scene graph node
@@ -389,9 +389,9 @@ ghoul::mm_unique_ptr<SceneGraphNode> SceneGraphNode::createFromDictionary(
             result->_guiPath = *p.gui->path;
         }
 
-        result->_useGuiOrder = p.gui->orderNumber.has_value();
-        if (p.gui->orderNumber.has_value()) {
-            result->_guiOrderNumber = *p.gui->orderNumber;
+        result->_useGuiOrdering = p.gui->orderingNumber.has_value();
+        if (p.gui->orderingNumber.has_value()) {
+            result->_guiOrderingNumber = *p.gui->orderingNumber;
         }
     }
 
@@ -543,8 +543,8 @@ SceneGraphNode::SceneGraphNode()
     , _guiPath(GuiPathInfo, "/")
     , _guiDisplayName(GuiNameInfo)
     , _guiDescription(GuiDescriptionInfo)
-    , _guiOrderNumber(GuiOrderInfo, 0.f)
-    , _useGuiOrder(UseGuiOrderInfo, false)
+    , _guiOrderingNumber(GuiOrderInfo, 0.f)
+    , _useGuiOrdering(UseGuiOrderInfo, false)
     , _transform {
         ghoul::mm_unique_ptr<Translation>(
             global::memoryManager->PersistentMemory.alloc<StaticTranslation>()
@@ -626,8 +626,8 @@ SceneGraphNode::SceneGraphNode()
     addProperty(_guiDescription);
     addProperty(_guiHidden);
     addProperty(_guiPath);
-    addProperty(_guiOrderNumber);
-    addProperty(_useGuiOrder);
+    addProperty(_guiOrderingNumber);
+    addProperty(_useGuiOrdering);
 }
 
 SceneGraphNode::~SceneGraphNode() {}
@@ -1149,14 +1149,6 @@ glm::dvec3 SceneGraphNode::worldScale() const {
 
 std::string SceneGraphNode::guiPath() const {
     return _guiPath;
-}
-
-float SceneGraphNode::guiOrderNumber() const {
-    return _guiOrderNumber;
-}
-
-bool SceneGraphNode::useGuiOrder() const {
-    return _useGuiOrder;
 }
 
 bool SceneGraphNode::hasGuiHintHidden() const {

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -332,8 +332,8 @@ namespace {
             // with a higher value appear later in the list. Scene graph noeds with the
             // same value will be sorted alphabetically.
             //
-            // The nodes without a given value will be placed at the top at the list and
-            // sorted alphabetically.
+            // The nodes without a given value will be placed at the bottom of the list
+            // and sorted alphabetically.
             std::optional<double> orderNumber;
         };
         // Additional information that is passed to GUI applications. These are all hints

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -179,14 +179,14 @@ namespace {
         "GuiOrderNumber",
         "Gui Order Number",
         "This is an optional numerical value that will affect the sorting of this scene "
-        "graph node in relation ot its neighbors in the user interface. Nodes with the "
+        "graph node in relation to its neighbors in the GUI. Nodes with the "
         "same value will be sorted alphabetically.",
         openspace::properties::Property::Visibility::Hidden
     };
 
     constexpr openspace::properties::Property::PropertyInfo UseGuiOrderInfo = {
         "UseGuiOrder",
-        "UseGuiOrder",
+        "Use Gui Order",
         "If true, use the 'GuiOrderNumber' to place this scene graph nodes in a sorted "
         "way in relation to its neighbors in the GUI",
         openspace::properties::Property::Visibility::Hidden
@@ -329,7 +329,7 @@ namespace {
 
             // If this value is specified, the scene graph node will be ordered in
             // relation to its neighbors in the GUI based on this value, so that nodes
-            // with a higher value appear later in the list. Scene graph noeds with the
+            // with a higher value appear later in the list. Scene graph nodes with the
             // same value will be sorted alphabetically.
             //
             // The nodes without a given value will be placed at the bottom of the list


### PR DESCRIPTION
Adds property the scene graph nodes for sorting the item in the GUI based on a number instead of alphabetically, with respect to its neighboring scene graph nodes in the menu. 

Let me know what you think of the property name `OrderNumber`. Didn't come up with anything better...

This PR should be combined with the following PR in the WebGUI repo: https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/192

Also applies the new sorting to the grids, to sort them based on their size instead of alphabetically:

![image](https://github.com/OpenSpace/OpenSpace/assets/8808894/b8f8a9c1-7d1c-4125-a5af-2a03da2db666)

Note that: 
- Another PR is coming for also controlling the order of the _Groups_ in the UI.
- We do not care about using this ordering in the ImGui UI. Hence why it is not applied there