### PR TITLE
"Fix" warning from hdf.asset

### DIFF
--- a/data/assets/scene/digitaluniverse/hdf.asset
+++ b/data/assets/scene/digitaluniverse/hdf.asset
@@ -32,11 +32,7 @@ local Object = {
     },
     Coloring = {
       ColorMapping = {
-        File = ColorMap .. "hudf.cmap",
-        ParameterOptions = {
-          { Key = "proximity", Range = { 1.0, 25.0 } },
-          { Key = "redshift", Range = { 0.0, 0.075 } }
-        }
+        File = ColorMap .. "hudf.cmap"
       }
     },
     Unit = "Mpc",


### PR DESCRIPTION
The "proximity" parameter does not exist in the dataset. Just add all the parameters to be available for color mapping, but not providing a list at all. Default will be `redshift`, which was in the previous list

I wanted this to go through a PR in case anyone has opinions about removing these preset parameters. The color mapping will likely be slightly different, due the previous custom ranges being slightly different than the automatic one (min and max value of the dataset). 

But this asset is not included in any asset per default and the points are hard to see without changing their scale, so personally I don't think it matters. 