### PR TITLE
Fix url sync 

### DIFF
--- a/modules/sync/syncs/urlsynchronization.cpp
+++ b/modules/sync/syncs/urlsynchronization.cpp
@@ -225,7 +225,7 @@ bool UrlSynchronization::isEachFileValid() {
 
     if (ossyncVersion == "1.0") {
         // We need to mutex-protect the access to the time conversion for now
-        std::lock_guard guard(UrlSynchronization::_mutex);
+        std::lock_guard guard(_mutex);
 
         ghoul::getline(file >> std::ws, line);
         const std::string& fileIsValidToDate = line;

--- a/modules/sync/syncs/urlsynchronization.cpp
+++ b/modules/sync/syncs/urlsynchronization.cpp
@@ -265,7 +265,7 @@ bool UrlSynchronization::isEachFileValid() {
 
 void UrlSynchronization::createSyncFile(bool) const {
     // We need to mutex-protect the access to the time conversion for now
-    std::lock_guard guard(UrlSynchronization::_mutex);
+    std::lock_guard guard(_mutex);
 
     std::filesystem::path dir = directory();
     std::filesystem::create_directories(dir);

--- a/modules/sync/syncs/urlsynchronization.cpp
+++ b/modules/sync/syncs/urlsynchronization.cpp
@@ -225,7 +225,7 @@ bool UrlSynchronization::isEachFileValid() {
 
     if (ossyncVersion == "1.0") {
         // We need to mutex-protect the access to the time conversion for now
-        std::lock_guard guard(_mutex);
+        std::lock_guard guard(UrlSynchronization::_mutex);
 
         ghoul::getline(file >> std::ws, line);
         const std::string& fileIsValidToDate = line;
@@ -265,7 +265,7 @@ bool UrlSynchronization::isEachFileValid() {
 
 void UrlSynchronization::createSyncFile(bool) const {
     // We need to mutex-protect the access to the time conversion for now
-    std::lock_guard guard(_mutex);
+    std::lock_guard guard(UrlSynchronization::_mutex);
 
     std::filesystem::path dir = directory();
     std::filesystem::create_directories(dir);

--- a/modules/sync/syncs/urlsynchronization.h
+++ b/modules/sync/syncs/urlsynchronization.h
@@ -123,7 +123,7 @@ private:
     /// Determines how long the file is valid before it should be downloaded again
     double _secondsUntilResync = MaxDateAsJ2000;
 
-    mutable std::mutex _mutex;
+    inline static std::mutex _mutex;
 };
 
 } // namespace openspace


### PR DESCRIPTION
There was an issue with the URL sync when several instances asked Spice for time information at the same time. Since Spice is not multithreaded it could not handle more than 1 request at a time and an exception was thrown occasionally during loading. This did not happen often but can be tested by removing all previous satellite URL sync data from the sync folder and then loading a profile with all satellites. Then all satellites will sync with the URL sync and this crash will most likely happen. This PR fixes this by making the mutex static so all URL sync instances wait their turn before asking Spice for time information. 

I am not sure what we lose by not having the `mutable` keyword for the mutex anymore but from some fast searching, I couldn't find a good way to combine the two keywords. 