### PR TITLE
Add visual test for vertex colors

### DIFF
--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -6,14 +6,14 @@ The files are organized in folders, where the folder name is used as the "group"
 ## Test Structure
 Each test must have a `screenshot` instruction as the **last** entry, which causes an image to be created that is used as the result of the test. Only exactly one `screenshot` instruction per test is currently supported. Each `.ostest` file is a JSON file with two top-level keys: `profile` provides the name of the profile that should be loaded before running these test instructions, and `commands` is a list of instructions that should be executed after the profile is loaded. All instructions must have a `type` and `value` key to determine which type of instruction it is and the parameters for that instruction.
 
-By default, all tests always start paused, MRF caching is enabled, and the user interface and dashboard items are disabled.
+By default on the servers that generate tests for https://regression.openspaceproject.com, all tests always start paused, MRF caching is enabled, and the user interface and dashboard items are disabled.
 
 ### Best practices
   - All tests should start with the instruction to set a specific time to improve reproducibility
   - The fewer instructions there are per test, the better
   - Adding `wait` instructions to ensure OpenSpace has time to load dynamic datasets increases reliability, but too many `wait`s will slow down the overall testing
   - Avoid `recording` and use `navigationstate` and `time` instead
-  - Avoid `script` if possible and use dedicated instructions when they exist. If we see the same `script` instruction used in several tests, they can be upgraded to an instruction at a later stage
+  - Avoid `script` if possible and use dedicated instructions when they exist. If we see the same `script` instruction used in several tests, they can be upgraded to a dedicated instruction at a later stage
 
 ### Instructions
   - `action`: Triggers an action that must already be defined in the profile or previously defined in the test. The provided value must be a string that is the identifier of the action that should be triggered.
@@ -22,9 +22,9 @@ By default, all tests always start paused, MRF caching is enabled, and the user 
 
     Script Equivalent: `openspace.action.triggerAction`
 
-  - `asset`: Loads a given asset file. The provided value must be a string that is the path to the asset file to be loaded.
+  - `asset`: Loads a given asset file. The provided value must be a string that is the path to the asset file to be loaded. This is specified relative to the `data/asset` folder inside OpenSpace.
 
-    Example: `{ "type": "asset", "value": "C:/path/to/file.asset" }`
+    Example: `{ "type": "asset", "value": "path/to/file.asset" }`
 
     Script Equivalent: `openspace.asset.add`
 
@@ -46,7 +46,7 @@ By default, all tests always start paused, MRF caching is enabled, and the user 
 
     Script Equivalent: `openspace.time.setPause`
 
-  - `property`: Instantly sets a specific property or group of properties to the specified value. The provided value must be an object containing a `property` and another `value` key. The `property` key is the identifier or regex for the property or properties that should be set. The (other) `value` key is the new value for the property where the type must match the `property`.
+  - `property`: Instantly sets a specific property or group of properties to the specified value. The provided value must be an object containing another `property` and `value` key. The (other) `property` key is the identifier or regex for the property or properties that should be set. The (other) `value` key is the new value for the property where the type must match the (other) `property`.
 
     Example: `{ "type": "property", "value": { "property": "Scene.Constellations.Renderable.Enabled", "value": true } }`
 

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -22,6 +22,12 @@ By default, all tests always start paused, MRF caching is enabled, and the user 
 
     Script Equivalent: `openspace.action.triggerAction`
 
+  - `asset`: Loads a given asset file. The provided value must be a string that is the path to the asset file to be loaded.
+
+    Example: `{ "type": "asset", "value": "C:/path/to/file.asset" }`
+
+    Script Equivalent: `openspace.asset.add`
+
   - `deltatime`: Instantly changes the delta time in OpenSpace to the provided value. The provided value must be a number that is the delta time in seconds per real-time second that the engine should be set to.
 
     Example: `{ "type": "deltatime", "value": 10 }`

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -1,33 +1,34 @@
 # Visual Test Specification
-All `.ostest` files in this folders specify visual image tests that are automatically run to ensure that changes in OpenSpace do not negatively impact the rendered results. The tested results are available at https://regression.openspaceproject.com.
+All `.ostest` files in these folders specify visual image tests that are automatically run to ensure that changes in OpenSpace do not negatively impact the rendered results. The test results are available at https://regression.openspaceproject.com.
 
-The files are organized by folders, which are used as the "group" name for the test and filename of each test (without `.ostest` extension) is used as the name of the test. In general the first folder should name a profile that is being tested by the files within or a specific use-case, such as testing all renderables. Additional subfolders can be used as required within each top-level folder.
+The files are organized in folders, where the folder name is used as the "group" name for the tests within, and the filename of each test (without the `.ostest` extension) is used as the name of the test. In general, the top-level folder should name a profile or a specific use case that is tested by the files within, such as testing all renderables. Additional subfolders can be used within each top-level folder.
 
 ## Test Structure
-Each test must have a `screenshot` instruction as the last entry, which causes an image to be created that is used as the end result of the test. Only exactly one `screenshot` instruction per test is currently supported. Each `.ostest` file is a JSON file with two top-level keys: `profile` provides the name of the profile that should be loaded before running these test instructions, and `commands` is a list of instructions that should be executed after the profile was loaded. All instructions must have a `type` key to determine which type of instruction it is and most have a `value` key that determines the parameters for that instruction.
+Each test must have a `screenshot` instruction as the **last** entry, which causes an image to be created that is used as the result of the test. Only exactly one `screenshot` instruction per test is currently supported. Each `.ostest` file is a JSON file with two top-level keys: `profile` provides the name of the profile that should be loaded before running these test instructions, and `commands` is a list of instructions that should be executed after the profile is loaded. All instructions must have a `type` and `value` key to determine which type of instruction it is and the parameters for that instruction.
+
+By default, all tests always start paused, MRF caching is enabled, and the user interface and dashboard items are disabled.
 
 ### Best practices
-  - By default, all tests always start paused, MRF caching is enabled, and the user interface and dashboard items are disabled
-  - All test should start with in instruction to set a specific time to improve reproducibility
-  - The few instructions there are per test, the better
-  - Adding `wait` instructions to ensure OpenSpace has time to load dynamic datasets increases reliability, but too many `wait`s will slow-down the over all testing
+  - All tests should start with the instruction to set a specific time to improve reproducibility
+  - The fewer instructions there are per test, the better
+  - Adding `wait` instructions to ensure OpenSpace has time to load dynamic datasets increases reliability, but too many `wait`s will slow down the overall testing
   - Avoid `recording` and use `navigationstate` and `time` instead
-  - Avoid `script` if possible and use dedicated instructions when they exist. If we see the same `script` instruction used in many tests, they can be upgraded to a first-class instruction at later stage
+  - Avoid `script` if possible and use dedicated instructions when they exist. If we see the same `script` instruction used in several tests, they can be upgraded to an instruction at a later stage
 
 ### Instructions
-  - `action`: Triggers an action that must already be defined in the profile or that was defined previously in this test. The provided value must be a string that is the identifier of the action that should be triggered.
+  - `action`: Triggers an action that must already be defined in the profile or previously defined in the test. The provided value must be a string that is the identifier of the action that should be triggered.
 
     Example: `{ "type": "action", "value": "os.FadeDownTrails" }`
 
     Script Equivalent: `openspace.action.triggerAction`
 
-  - `deltatime`: Instantly changes the delta time in OpenSpace to the provided value. The provided value must be a number that is the delta time in seconds per realtime second that the engine should be set to.
+  - `deltatime`: Instantly changes the delta time in OpenSpace to the provided value. The provided value must be a number that is the delta time in seconds per real-time second that the engine should be set to.
 
     Example: `{ "type": "deltatime", "value": 10 }`
 
     Script Equivalent: `openspace.time.setDeltaTime`
 
-  - `navigationstate`: Sets the camera to the provided navigation state. The provided value must be an object that must contain at least a `anchor` and `position` and may optionally contain an `aim`, `referenceFrame`, `up`, `yaw`, `pitch`, and `timestamp`. All these values are then used to instantaneously set the position of the camera.
+  - `navigationstate`: Instantly moves the camera to the provided navigation state. The provided value must be an object that must contain at least an `anchor` and `position` key and may optionally contain the keys `aim`, `referenceFrame`, `up`, `yaw`, `pitch`, and `timestamp`. All these values are then used to instantaneously set the position and rotation of the camera.
 
     Example: `{ "type": "navigationstate", "value": { "anchor": "Juno", "pitch": -0.0165756, "position": [ -22.49081, 1.191533, 26.35740 ], "up": [ 0.0288083, 0.999373, -0.0205962 ], "yaw": 0.152454 } }`
 
@@ -39,7 +40,7 @@ Each test must have a `screenshot` instruction as the last entry, which causes a
 
     Script Equivalent: `openspace.time.setPause`
 
-  - `property`: Sets a specific property or group of properties to the specified value. This change is instantaneous. The provided value must contain a `property` key that is the identifier or regex for the property that should be set and a `value` key that is the new value for the property. The type of the `value` must be correct for the matched `property`.
+  - `property`: Instantly sets a specific property or group of properties to the specified value. The provided value must be an object containing a `property` and another `value` key. The `property` key is the identifier or regex for the property or properties that should be set. The (other) `value` key is the new value for the property where the type must match the `property`.
 
     Example: `{ "type": "property", "value": { "property": "Scene.Constellations.Renderable.Enabled", "value": true } }`
 
@@ -51,19 +52,19 @@ Each test must have a `screenshot` instruction as the last entry, which causes a
 
     Script Equivalent: `openspace.sessionRecording.startPlayback`
 
-  - `screenshot`: Takes a screenshot of the application. At the moment, there can be only exactly one instruction of this type and it should be the last instruction in the test. This instruction also does not take any parameters
+  - `screenshot`: Takes a screenshot of the application. At the moment, there can be only exactly one instruction of this type and it must be the last instruction in the test. This instruction is the only one to not use the `value` key.
 
     Example: `{ "type": "screenshot" }`
 
     Script Equivalent: `openspace.takeScreenshot`
 
-  - `script`: Executes the script that is passed in as a value. That value must be a string that is the Lua script that is executed directly.
+  - `script`: Instantly executes the script that is passed in as a value. That value must be a string that is the Lua script to execute.
 
-    Example: `{ "type": "script", "value": "openspace.printError("Hello world") }`
+    Example: `{ "type": "script", "value": "openspace.printError('Hello world')" }`
 
     Script Equivalent: `value`
 
-  - `time`: Sets the in-game time to the provided value. The value can be either a string, in which case it needs to be a valid date-time string, or a number, in which case it represents the number of seconds past the J2000 epoch.
+  - `time`: Sets the in-game time to the provided value. The value can be either a string, which needs to be a valid date-time string, or a number, which represents the number of seconds past the J2000 epoch.
 
     Example: `{ "type": "time", "value": "2016-07-01T00:00:01.00" }`
 

--- a/tests/visual/renderable/model_vertex_colors.ostest
+++ b/tests/visual/renderable/model_vertex_colors.ostest
@@ -1,0 +1,25 @@
+{
+  "profile": "empty",
+  "commands": [
+    { "type": "time", "value": "2024-07-11T12:00:00.00" },
+    {
+      "type": "property",
+      "value": { "property": "NavigationHandler.OrbitalNavigator.LimitZoom.EnabledMinimumAllowedDistance", "value": false }
+    },
+    {
+      "type": "asset",
+      "value": "examples/renderable/renderablemodel/model.asset"
+    },
+    { "type": "wait", "value": 5 },
+    {
+      "type": "navigationstate",
+      "value": {
+        "anchor": "RenderableModel_Example",
+        "up": [ -0.008132849760983194, 0.9986021710677091, 0.0522260537818345 ],
+        "position": [0.10334103813188818, -0.20823861895763798, 3.9977746547860167 ]
+      }
+    },
+    { "type": "wait", "value": 2 },
+    { "type": "screenshot" }
+  ]
+}

--- a/tests/visual/renderable/model_vertex_colors.ostest
+++ b/tests/visual/renderable/model_vertex_colors.ostest
@@ -8,13 +8,13 @@
     },
     {
       "type": "asset",
-      "value": "examples/renderable/renderablemodel/model.asset"
+      "value": "examples/renderable/renderablemodel/model_vertex_colors.asset"
     },
     { "type": "wait", "value": 5 },
     {
       "type": "navigationstate",
       "value": {
-        "anchor": "RenderableModel_Example",
+        "anchor": "RenderableModel_Example_Vertex_Colors",
         "up": [ -0.008132849760983194, 0.9986021710677091, 0.0522260537818345 ],
         "position": [0.10334103813188818, -0.20823861895763798, 3.9977746547860167 ]
       }


### PR DESCRIPTION
Note that this PR merges into the branch _feature/model-vertex-colors_, not the _master_ branch. 

Add a new visual test for the RenderableModel with vertex colors. The chosen model is handy as a test since it will show in an obvious way if the vertex colors are not loaded and applied correctly.

Also, I updated the readme file for the visual tests to be easier to read and added the new asset instruction from the PR in the tests repo https://github.com/OpenSpace/OpenSpaceVisualTesting/pull/5. 

