### PR TITLE
Add new TileProvider to select tile providers based on the date and apply to VIIRS Joint Polar Satellite System

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/definitions/noaa20.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/definitions/noaa20.asset
@@ -1,0 +1,33 @@
+local Layer = {
+  Identifier = "Temporal_NOAA20_VIIRS",
+  Name = "Temporal NOAA20 VIIRS",
+  Type = "TemporalTileProvider",
+  Mode = "Prototyped",
+  Prototyped = {
+    Time = {
+      Start = "2018-01-05",
+      End = "Today"
+    },
+    TemporalResolution = "1d",
+    TimeFormat = "YYYY-MM-DD",
+    Prototype = openspace.globebrowsing.createTemporalGibsGdalXml(
+      "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
+      "250m",
+      "jpg"
+    )
+  },
+  PadTiles = false
+}
+
+
+asset.export("Layer", Layer)
+
+
+
+asset.meta = {
+  Name = "NOAA 20",
+  Description = [[A layer that sources its images from the NOAA-20 satellite that is part of the Joint Polar Satellite System.]],
+  Author = "OpenSpace Team",
+  URL = "http://www.openspaceproject.com",
+  License = "MIT License"
+}

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/definitions/noaa21.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/definitions/noaa21.asset
@@ -1,0 +1,33 @@
+local Layer = {
+  Identifier = "Temporal_NOAA21_VIIRS",
+  Name = "Temporal NOAA21 VIIRS",
+  Type = "TemporalTileProvider",
+  Mode = "Prototyped",
+  Prototyped = {
+    Time = {
+      Start = "2024-04-19",
+      End = "Today"
+    },
+    TemporalResolution = "1d",
+    TimeFormat = "YYYY-MM-DD",
+    Prototype = openspace.globebrowsing.createTemporalGibsGdalXml(
+      "VIIRS_NOAA21_CorrectedReflectance_TrueColor",
+      "250m",
+      "jpg"
+    )
+  },
+  PadTiles = false
+}
+
+
+asset.export("Layer", Layer)
+
+
+
+asset.meta = {
+  Name = "NOAA 20",
+  Description = [[A layer that sources its images from the NOAA-21 satellite that is part of the Joint Polar Satellite System.]],
+  Author = "OpenSpace Team",
+  URL = "http://www.openspaceproject.com",
+  License = "MIT License"
+}

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/definitions/snpp.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/definitions/snpp.asset
@@ -1,0 +1,33 @@
+local Layer = {
+  Identifier = "Temporal_SNPP_VIIRS",
+  Name = "Temporal SNPP VIIRS",
+  Type = "TemporalTileProvider",
+  Mode = "Prototyped",
+  Prototyped = {
+    Time = {
+      Start = "2015-11-24",
+      End = "Today"
+    },
+    TemporalResolution = "1d",
+    TimeFormat = "YYYY-MM-DD",
+    Prototype = openspace.globebrowsing.createTemporalGibsGdalXml(
+      "VIIRS_SNPP_CorrectedReflectance_TrueColor",
+      "250m",
+      "jpg"
+    )
+  },
+  PadTiles = false
+}
+
+
+asset.export("Layer", Layer)
+
+
+
+asset.meta = {
+  Name = "NOAA 20",
+  Description = [[A layer that sources its images from the Suomi NPP satellite that is part of the Joint Polar Satellite System.]],
+  Author = "OpenSpace Team",
+  URL = "http://www.openspaceproject.com",
+  License = "MIT License"
+}

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_noaa20_combo.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_noaa20_combo.asset
@@ -1,4 +1,5 @@
 local globe = asset.require("../../earth")
+local noaa20 = asset.require("./definitions/noaa20")
 
 
 
@@ -11,26 +12,7 @@ local Layer = {
   LevelTileProviders = {
     {
       MaxLevel = 4,
-      TileProvider = {
-        Identifier = "Temporal_VIIRS_NOAA20",
-        Name = "Temporal VIIRS NOAA20",
-        Type = "TemporalTileProvider",
-        Mode = "Prototyped",
-        Prototyped = {
-          Time = {
-            Start = "2020-04-25",
-            End = "Today"
-          },
-          TemporalResolution = "1d",
-          TimeFormat = "YYYY-MM-DD",
-          Prototype = openspace.globebrowsing.createTemporalGibsGdalXml(
-            "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
-            "250m",
-            "jpg"
-          )
-        },
-        PadTiles = false
-      }
+      TileProvider = noaa20.Layer
     },
     {
       MaxLevel = 22,

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_snpp_combo.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_snpp_combo.asset
@@ -1,18 +1,18 @@
 local globe = asset.require("../../earth")
-local noaa21 = asset.require("./definitions/noaa21")
+local snpp = asset.require("./definitions/snpp")
 
 
 
 local Layer = {
-  Identifier = "ESRI_NOAA21_Combo",
-  Name = "ESRI NOAA21 Combo",
+  Identifier = "ESRI_VIIRS_Combo",
+  Name = "ESRI VIIRS Combo",
   Enabled = asset.enabled,
-  ZIndex = 30,
+  ZIndex = 20,
   Type = "TileProviderByLevel",
   LevelTileProviders = {
     {
       MaxLevel = 4,
-      TileProvider = noaa21.Layer
+      TileProvider = snpp.Layer
     },
     {
       MaxLevel = 22,
@@ -25,8 +25,8 @@ local Layer = {
     }
   },
   PadTiles = false,
-  Description = [[Level based layer combining "NOAA20 SNPP (Temporal)" and ESRI World
-    Imagery. "NOAA20 SNPP (Temporal)" is faded out at tile level 4]]
+  Description = [[Level based layer combining "VIIRS SNPP (Temporal)" and ESRI World
+    Imagery. "VIIRS SNPP (Temporal)" is faded out at tile level 4]]
 }
 
 
@@ -43,9 +43,9 @@ asset.export("layer", Layer)
 
 
 asset.meta = {
-  Name = "ESRI NOAA20 VIIRS Combo",
-  Description = [[Level based layer combining "NOAA20 SNPP (Temporal)" and ESRI World
-  Imagery. "NOAA20 SNPP (Temporal)" is faded out at tile level 4]],
+  Name = "ESRI VIIRS Combo",
+  Description = [[Level based layer combining "VIIRS SNPP (Temporal)" and ESRI World
+  Imagery. "VIIRS SNPP (Temporal)" is faded out at tile level 4]],
   Author = "OpenSpace Tem",
   URL = "http://www.openspaceproject.com",
   License = "MIT License"

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_viirs_combo.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_viirs_combo.asset
@@ -1,4 +1,7 @@
 local globe = asset.require("../../earth")
+local snpp = asset.require("./definitions/snpp")
+local noaa20 = asset.require("./definitions/noaa20")
+local noaa21 = asset.require("./definitions/noaa21")
 
 
 
@@ -12,24 +15,14 @@ local Layer = {
     {
       MaxLevel = 4,
       TileProvider = {
-        Identifier = "Temporal_VIIRS_SNPP",
-        Name = "Temporal VIIRS SNPP",
-        Type = "TemporalTileProvider",
-        Mode = "Prototyped",
-        Prototyped = {
-          Time = {
-            Start = "2015-11-24",
-            End = "2024-05-27"
-          },
-          TemporalResolution = "1d",
-          TimeFormat = "YYYY-MM-DD",
-          Prototype = openspace.globebrowsing.createTemporalGibsGdalXml(
-            "VIIRS_SNPP_CorrectedReflectance_TrueColor",
-            "250m",
-            "jpg"
-          )
-        },
-        PadTiles = false
+        Identifier = "VIIRS_Joint_Layer",
+        Name = "VIIRS Joint Layer",
+        Type = "TileProviderByDate",
+        Providers = {
+          ["2015-11-24"] = snpp.Layer,
+          ["2018-01-05"] = noaa20.Layer,
+          ["2024-04-19"] = noaa21.Layer
+        }
       }
     },
     {
@@ -43,8 +36,8 @@ local Layer = {
     }
   },
   PadTiles = false,
-  Description = [[Level based layer combining "VIIRS SNPP (Temporal)" and ESRI World
-    Imagery. "VIIRS SNPP (Temporal)" is faded out at tile level 4]]
+  Description = [[Level based layer combining different VIIRS layers and ESRI World
+    Imagery. VIIRS is faded out at tile level 4]]
 }
 
 

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/viirs_noaa21_temporal.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/viirs_noaa21_temporal.asset
@@ -1,20 +1,20 @@
 local globe = asset.require("../../earth")
-local noaa20 = asset.require("./definitions/noaa20")
+local noaa21 = asset.require("./definitions/noaa21")
 
 
 
 asset.onInitialize(function()
-  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", noaa20.Layer)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", noaa21.Layer)
 end)
 
 asset.onDeinitialize(function()
-  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", noaa20.Layer)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", noaa21.Layer)
 end)
 
 
 
 asset.meta = {
-  Name = "VIIRS NOAA20 (Temporal)",
+  Name = "VIIRS NOAA21 (Temporal)",
   Description = "This layer has the best daily Earth Image",
   Author = "NASA EOSDIS Global Imagery Browse Services",
   URL =

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/viirs_snpp_temporal.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/viirs_snpp_temporal.asset
@@ -1,41 +1,15 @@
 local globe = asset.require("../../earth")
+local snpp = asset.require("./definitions/snpp")
 
-
-
-local Layer = {
-  Identifier = "VIIRS_SNPP_Temporal",
-  Name = "VIIRS SNPP (Temporal)",
-  Enabled = asset.enabled,
-  ZIndex = 30,
-  Type = "TemporalTileProvider",
-  Mode = "Prototyped",
-  Prototyped = {
-    Time = {
-      Start = "2015-11-24",
-      End = "Today"
-    },
-    TemporalResolution = "1d",
-    TimeFormat = "YYYY-MM-DD",
-    Prototype = openspace.globebrowsing.createTemporalGibsGdalXml(
-      "VIIRS_SNPP_CorrectedReflectance_TrueColor",
-      "250m",
-      "jpg"
-    )
-  },
-  Description = [[Temporal coverage: 11 November 2015 - Present. The imagery resolution
-    is 0.25 km, and the temporal resolution is daily]]
-}
 
 
 asset.onInitialize(function()
-  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", Layer)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", snpp.Layer)
 end)
 
 asset.onDeinitialize(function()
-  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", Layer)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", snpp.Layer)
 end)
-
-asset.export("layer", Layer)
 
 
 

--- a/modules/base/rendering/screenspacedashboard.cpp
+++ b/modules/base/rendering/screenspacedashboard.cpp
@@ -92,10 +92,6 @@ ScreenSpaceDashboard::ScreenSpaceDashboard(const ghoul::Dictionary& dictionary)
         throw ghoul::RuntimeError("Cannot specify items when using the main dashboard");
     }
 
-    if (!_useMainDashboard) {
-        addPropertySubOwner(_dashboard);
-    }
-
     if (p.items.has_value()) {
         ghoul_assert(_useMainDashboard, "Cannot add items to the main dashboard");
         for (const ghoul::Dictionary& item : *p.items) {

--- a/modules/base/rendering/screenspacedashboard.cpp
+++ b/modules/base/rendering/screenspacedashboard.cpp
@@ -92,6 +92,10 @@ ScreenSpaceDashboard::ScreenSpaceDashboard(const ghoul::Dictionary& dictionary)
         throw ghoul::RuntimeError("Cannot specify items when using the main dashboard");
     }
 
+    if (!_useMainDashboard) {
+        addPropertySubOwner(_dashboard);
+    }
+
     if (p.items.has_value()) {
         ghoul_assert(_useMainDashboard, "Cannot add items to the main dashboard");
         for (const ghoul::Dictionary& item : *p.items) {

--- a/modules/globebrowsing/CMakeLists.txt
+++ b/modules/globebrowsing/CMakeLists.txt
@@ -74,6 +74,7 @@ set(HEADER_FILES
   src/tileprovider/texttileprovider.h
   src/tileprovider/tileindextileprovider.h
   src/tileprovider/tileprovider.h
+  src/tileprovider/tileproviderbydate.h
   src/tileprovider/tileproviderbyindex.h
   src/tileprovider/tileproviderbylevel.h
 )
@@ -120,6 +121,7 @@ set(SOURCE_FILES
   src/tileprovider/texttileprovider.cpp
   src/tileprovider/tileindextileprovider.cpp
   src/tileprovider/tileprovider.cpp
+  src/tileprovider/tileproviderbydate.cpp
   src/tileprovider/tileproviderbyindex.cpp
   src/tileprovider/tileproviderbylevel.cpp
 )

--- a/modules/globebrowsing/globebrowsingmodule.cpp
+++ b/modules/globebrowsing/globebrowsingmodule.cpp
@@ -48,6 +48,7 @@
 #include <modules/globebrowsing/src/tileprovider/temporaltileprovider.h>
 #include <modules/globebrowsing/src/tileprovider/tileindextileprovider.h>
 #include <modules/globebrowsing/src/tileprovider/tileprovider.h>
+#include <modules/globebrowsing/src/tileprovider/tileproviderbydate.h>
 #include <modules/globebrowsing/src/tileprovider/tileproviderbyindex.h>
 #include <modules/globebrowsing/src/tileprovider/tileproviderbylevel.h>
 #include <openspace/camera/camera.h>
@@ -310,6 +311,7 @@ void GlobeBrowsingModule::internalInitialize(const ghoul::Dictionary& dict) {
     fTileProvider->registerClass<TemporalTileProvider>("TemporalTileProvider");
     fTileProvider->registerClass<TileIndexTileProvider>("TileIndexTileProvider");
     fTileProvider->registerClass<SizeReferenceTileProvider>("SizeReferenceTileProvider");
+    fTileProvider->registerClass<TileProviderByDate>("TileProviderByDate");
     fTileProvider->registerClass<TileProviderByLevel>("TileProviderByLevel");
     fTileProvider->registerClass<TileProviderByIndex>("TileProviderByIndex");
 
@@ -338,6 +340,7 @@ std::vector<documentation::Documentation> GlobeBrowsingModule::documentations() 
         globebrowsing::SizeReferenceTileProvider::Documentation(),
         globebrowsing::TemporalTileProvider::Documentation(),
         globebrowsing::TileIndexTileProvider::Documentation(),
+        globebrowsing::TileProviderByDate::Documentation(),
         globebrowsing::TileProviderByIndex::Documentation(),
         globebrowsing::TileProviderByLevel::Documentation(),
         globebrowsing::GeoJsonManager::Documentation(),

--- a/modules/globebrowsing/shaders/texturetilemapping.glsl
+++ b/modules/globebrowsing/shaders/texturetilemapping.glsl
@@ -151,15 +151,17 @@ vec4 getSample#{layerGroup}#{i}(vec2 uv, vec3 levelWeights,
   c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
 #elif (#{#{layerGroup}#{i}LayerType} == 5) // TileIndexTileProvider
   c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
-#elif (#{#{layerGroup}#{i}LayerType} == 6) // TileProviderByIndex
+#elif (#{#{layerGroup}#{i}LayerType} == 6) // TileProviderByDate
   c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
-#elif (#{#{layerGroup}#{i}LayerType} == 7) // TileProviderByLevel
+#elif (#{#{layerGroup}#{i}LayerType} == 7) // TileProviderByIndex
   c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
-#elif (#{#{layerGroup}#{i}LayerType} == 8) // SolidColor
+#elif (#{#{layerGroup}#{i}LayerType} == 8) // TileProviderByLevel
+  c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
+#elif (#{#{layerGroup}#{i}LayerType} == 9) // SolidColor
   c.rgb = #{layerGroup}[#{i}].color;
-#elif (#{#{layerGroup}#{i}LayerType} == 9) // SpoutImageProvider
+#elif (#{#{layerGroup}#{i}LayerType} == 10) // SpoutImageProvider
   c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
-#elif (#{#{layerGroup}#{i}LayerType} == 10) // VideoTileProvider
+#elif (#{#{layerGroup}#{i}LayerType} == 11) // VideoTileProvider
   c = getTexVal(#{layerGroup}[#{i}].pile, levelWeights, uv);
 #endif
 

--- a/modules/globebrowsing/src/gpulayergroup.cpp
+++ b/modules/globebrowsing/src/gpulayergroup.cpp
@@ -74,6 +74,7 @@ void GPULayerGroup::setValue(ghoul::opengl::ProgramObject& program,
             case layers::Layer::ID::SizeReferenceTileProvider:
             case layers::Layer::ID::TemporalTileProvider:
             case layers::Layer::ID::TileIndexTileProvider:
+            case layers::Layer::ID::TileProviderByDate:
             case layers::Layer::ID::TileProviderByIndex:
             case layers::Layer::ID::TileProviderByLevel: {
                 const ChunkTilePile& ctp = al.chunkTilePile(
@@ -146,6 +147,7 @@ void GPULayerGroup::bind(ghoul::opengl::ProgramObject& p, const LayerGroup& laye
             case layers::Layer::ID::SizeReferenceTileProvider:
             case layers::Layer::ID::TemporalTileProvider:
             case layers::Layer::ID::TileIndexTileProvider:
+            case layers::Layer::ID::TileProviderByDate:
             case layers::Layer::ID::TileProviderByIndex:
             case layers::Layer::ID::TileProviderByLevel: {
                 gal.gpuChunkTiles.resize(pileSize);

--- a/modules/globebrowsing/src/layer.cpp
+++ b/modules/globebrowsing/src/layer.cpp
@@ -130,8 +130,8 @@ namespace {
         std::optional<std::string> type [[codegen::inlist("DefaultTileProvider",
             "SingleImageProvider", "ImageSequenceTileProvider",
             "SizeReferenceTileProvider", "TemporalTileProvider", "TileIndexTileProvider",
-            "TileProviderByIndex", "TileProviderByLevel", "SolidColor",
-            "SpoutImageProvider", "VideoTileProvider")]];
+            "TileProviderByDate", "TileProviderByIndex", "TileProviderByLevel",
+            "SolidColor", "SpoutImageProvider", "VideoTileProvider")]];
 
         // Determine whether the layer is enabled or not. If this value is not specified,
         // the layer is disabled
@@ -342,6 +342,7 @@ Layer::Layer(layers::Group::ID id, const ghoul::Dictionary& layerDict, LayerGrou
             case layers::Layer::ID::SizeReferenceTileProvider:
             case layers::Layer::ID::TemporalTileProvider:
             case layers::Layer::ID::TileIndexTileProvider:
+            case layers::Layer::ID::TileProviderByDate:
             case layers::Layer::ID::TileProviderByIndex:
             case layers::Layer::ID::TileProviderByLevel:
             case layers::Layer::ID::VideoTileProvider:
@@ -513,6 +514,7 @@ void Layer::initializeBasedOnType(layers::Layer::ID id, ghoul::Dictionary initDi
         case layers::Layer::ID::SizeReferenceTileProvider:
         case layers::Layer::ID::TemporalTileProvider:
         case layers::Layer::ID::TileIndexTileProvider:
+        case layers::Layer::ID::TileProviderByDate:
         case layers::Layer::ID::TileProviderByIndex:
         case layers::Layer::ID::TileProviderByLevel:
         case layers::Layer::ID::VideoTileProvider:
@@ -546,6 +548,7 @@ void Layer::addVisibleProperties() {
         case layers::Layer::ID::SizeReferenceTileProvider:
         case layers::Layer::ID::TemporalTileProvider:
         case layers::Layer::ID::TileIndexTileProvider:
+        case layers::Layer::ID::TileProviderByDate:
         case layers::Layer::ID::TileProviderByIndex:
         case layers::Layer::ID::TileProviderByLevel:
         case layers::Layer::ID::VideoTileProvider:

--- a/modules/globebrowsing/src/layergroupid.h
+++ b/modules/globebrowsing/src/layergroupid.h
@@ -84,6 +84,7 @@ struct Layer {
         SizeReferenceTileProvider,
         TemporalTileProvider,
         TileIndexTileProvider,
+        TileProviderByDate,
         TileProviderByIndex,
         TileProviderByLevel,
         SolidColor,
@@ -95,7 +96,7 @@ struct Layer {
     std::string_view identifier;
 };
 
-constexpr std::array<Layer, 11> Layers = {
+constexpr std::array<Layer, 12> Layers = {
     Layer {
         .id = Layer::ID::DefaultTileProvider,
         .identifier = "DefaultTileProvider"
@@ -119,6 +120,10 @@ constexpr std::array<Layer, 11> Layers = {
     Layer {
         .id = Layer::ID::TileIndexTileProvider,
         .identifier = "TileIndexTileProvider"
+    },
+    Layer {
+        .id = Layer::ID::TileProviderByDate,
+        .identifier = "TileProviderByDate"
     },
     Layer {
         .id = Layer::ID::TileProviderByIndex,

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1006,7 +1006,7 @@ void RenderableGlobe::update(const UpdateData& data) {
 }
 
 bool RenderableGlobe::renderedWithDesiredData() const {
-    return _allChunksAvailable;
+    return true;
 }
 
 const LayerManager& RenderableGlobe::layerManager() const {

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1006,7 +1006,7 @@ void RenderableGlobe::update(const UpdateData& data) {
 }
 
 bool RenderableGlobe::renderedWithDesiredData() const {
-    return true;
+    return _allChunksAvailable;
 }
 
 const LayerManager& RenderableGlobe::layerManager() const {

--- a/modules/globebrowsing/src/tileprovider/tileproviderbydate.cpp
+++ b/modules/globebrowsing/src/tileprovider/tileproviderbydate.cpp
@@ -144,6 +144,19 @@ void TileProviderByDate::update() {
     // Then check update our current tile provider pointer
     const double time = global::timeManager->time().j2000Seconds();
     ghoul_assert(!_tileProviders.empty(), "There should be tile providers at this point");
+
+    // We use the first tileprovider for all times before the beginning start
+    if (time < _tileProviders.begin()->startTime) {
+        _currentTileProvider = _tileProviders.begin()->tileProvider.get();
+        return;
+    }
+
+    // And the last tileprovider for all times after the end
+    if (time > _tileProviders.back().startTime) {
+        _currentTileProvider = _tileProviders.back().tileProvider.get();
+        return;
+    }
+
     _currentTileProvider = _tileProviders.begin()->tileProvider.get();
     for (const Provider& p : _tileProviders) {
         if (p.startTime > time) {

--- a/modules/globebrowsing/src/tileprovider/tileproviderbydate.cpp
+++ b/modules/globebrowsing/src/tileprovider/tileproviderbydate.cpp
@@ -1,0 +1,177 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2024                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <modules/globebrowsing/src/tileprovider/tileproviderbydate.h>
+
+#include <openspace/documentation/documentation.h>
+#include <openspace/engine/globals.h>
+#include <openspace/util/spicemanager.h>
+#include <openspace/util/timemanager.h>
+#include <functional>
+
+namespace {
+    struct [[codegen::Dictionary(TileProviderByDate)]] Parameters {
+        // Specifies the list of tile providers and for which times they are used for. The
+        // tile provider with the earliest time will be used for all dates prior to that
+        // date and the provider with the latest time will be used for all dates
+        // afterwards. In between, a provider is used from the specified time until the
+        // time of the next provider
+        std::map<std::string, ghoul::Dictionary> providers;
+    };
+#include "tileproviderbydate_codegen.cpp"
+} // namespace
+
+namespace openspace::globebrowsing {
+
+documentation::Documentation TileProviderByDate::Documentation() {
+    return codegen::doc<Parameters>("globebrowsing_tileproviderbydate");
+}
+
+TileProviderByDate::TileProviderByDate(const ghoul::Dictionary& dictionary) {
+    ZoneScoped;
+
+    Parameters p = codegen::bake<Parameters>(dictionary);
+
+    // For now we need to inject the LayerGroupID this way. We don't want it to be part of
+    // the parameters struct as that would mean it would be visible to the end user, which
+    // we don't want since this value just comes from whoever creates it, not the user
+    ghoul_assert(dictionary.hasValue<int>("LayerGroupID"), "No Layer Group ID provided");
+    const layers::Group::ID group = static_cast<layers::Group::ID>(
+        dictionary.value<int>("LayerGroupID")
+    );
+
+    for (std::pair<const std::string, ghoul::Dictionary>& prov : p.providers) {
+        prov.second.setValue("LayerGroupID", static_cast<int>(group));
+
+        // Pass down the caching information from the enclosing dictionary
+        if (dictionary.hasValue<std::string>("GlobeName")) {
+            prov.second.setValue("GlobeName", dictionary.value<std::string>("GlobeName"));
+        }
+        layers::Layer::ID typeID = layers::Layer::ID::DefaultTileProvider;
+
+        if (prov.second.hasValue<std::string>("Type")) {
+            const std::string type = prov.second.value<std::string>("Type");
+            typeID = ghoul::from_string<layers::Layer::ID>(type);
+        }
+
+        std::unique_ptr<TileProvider> tp = createFromDictionary(typeID, prov.second);
+        const std::string provId = prov.second.value<std::string>("Identifier");
+        tp->setIdentifier(provId);
+        const std::string providerName = prov.second.value<std::string>("Name");
+        tp->setGuiName(providerName);
+        addPropertySubOwner(tp.get());
+
+        const double time = SpiceManager::ref().ephemerisTimeFromDate(prov.first);
+        _tileProviders.emplace_back(time, std::move(tp));
+    }
+
+    // After we added all tile providers, we need to sort them as they might have been
+    // given in an arbitrary order
+    std::sort(
+        _tileProviders.begin(),
+        _tileProviders.end(),
+        [](const Provider& lhs, const Provider& rhs) {
+            return lhs.startTime < rhs.startTime;
+        }
+    );
+}
+
+void TileProviderByDate::internalInitialize() {
+    for (const Provider& p : _tileProviders) {
+        p.tileProvider->initialize();
+    }
+}
+
+void TileProviderByDate::internalDeinitialize() {
+    for (const Provider& p : _tileProviders) {
+        p.tileProvider->deinitialize();
+    }
+}
+
+Tile TileProviderByDate::tile(const TileIndex& tileIndex) {
+    ZoneScoped;
+
+    return _currentTileProvider ? _currentTileProvider->tile(tileIndex) : Tile();
+}
+
+Tile::Status TileProviderByDate::tileStatus(const TileIndex& index) {
+    return
+        _currentTileProvider ?
+        _currentTileProvider->tileStatus(index) :
+        Tile::Status::Unavailable;
+}
+
+
+TileDepthTransform TileProviderByDate::depthTransform() {
+    return _currentTileProvider ?
+        _currentTileProvider->depthTransform() :
+        TileDepthTransform(0.f, 1.f);
+}
+
+void TileProviderByDate::update() {
+    if (_tileProviders.empty()) {
+        // If there are no tile providers, then there is no work to be done
+        _currentTileProvider = nullptr;
+        return;
+    }
+
+    // First update all tile providers
+    for (const Provider& p : _tileProviders) {
+        p.tileProvider->update();
+    }
+
+    // Then check update our current tile provider pointer
+    const double time = global::timeManager->time().j2000Seconds();
+    ghoul_assert(!_tileProviders.empty(), "There should be tile providers at this point");
+    _currentTileProvider = _tileProviders.begin()->tileProvider.get();
+    for (const Provider& p : _tileProviders) {
+        if (p.startTime > time) {
+            // We have found the first entry that is larger than the current time, which
+            // means that we are done
+            return;
+        }
+
+        _currentTileProvider = p.tileProvider.get();
+    }
+}
+
+void TileProviderByDate::reset() {
+    for (const Provider& p : _tileProviders) {
+        p.tileProvider->reset();
+    }
+}
+
+int TileProviderByDate::minLevel() {
+    return _currentTileProvider ? _currentTileProvider->minLevel() : 1;
+}
+
+int TileProviderByDate::maxLevel() {
+    return _currentTileProvider ? _currentTileProvider->maxLevel() : 1;
+}
+
+float TileProviderByDate::noDataValueAsFloat() {
+    return _currentTileProvider ? _currentTileProvider->noDataValueAsFloat() : 1;
+}
+
+} // namespace openspace::globebrowsing

--- a/modules/globebrowsing/src/tileprovider/tileproviderbydate.h
+++ b/modules/globebrowsing/src/tileprovider/tileproviderbydate.h
@@ -1,0 +1,65 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2024                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_MODULE_GLOBEBROWSING___TILEPROVIDER__TILEPROVIDERBYDATE___H__
+#define __OPENSPACE_MODULE_GLOBEBROWSING___TILEPROVIDER__TILEPROVIDERBYDATE___H__
+
+#include <modules/globebrowsing/src/tileprovider/tileprovider.h>
+
+#include <vector>
+
+namespace openspace::globebrowsing {
+
+class TileProviderByDate : public TileProvider {
+public:
+    TileProviderByDate(const ghoul::Dictionary& dictionary);
+
+    Tile tile(const TileIndex& tileIndex) override final;
+    Tile::Status tileStatus(const TileIndex& index) override final;
+    TileDepthTransform depthTransform() override final;
+    void update() override final;
+    void reset() override final;
+    int minLevel() override final;
+    int maxLevel() override final;
+    float noDataValueAsFloat() override final;
+
+    static documentation::Documentation Documentation();
+
+private:
+    struct Provider {
+        // The time at which this provider becomes valid
+        double startTime = 0.0;
+        std::unique_ptr<TileProvider> tileProvider;
+    };
+
+    std::vector<Provider> _tileProviders;
+    TileProvider* _currentTileProvider = nullptr;
+
+    void internalInitialize() override final;
+    void internalDeinitialize() override final;
+};
+
+} // namespace openspace::globebrowsing
+
+#endif // __OPENSPACE_MODULE_GLOBEBROWSING___TILEPROVIDER__TILEPROVIDERBYDATE___H__


### PR DESCRIPTION
Adds a new TileProvider (TileProviderByDate) that has a map from date -> TileProvider.  This new tile provider is applied to the VIIIRS instruments on the JPSS satellites (Suomi NPP, NOAA-20, and NOAA-21) to create one asset file that users can use that will automaticalyl select the newest available satellite for the in-game time.  This is a better approach to deal with the multiple layers and effectively closes #3303 as that method would have required an additional internet access where as this will handled locally and will handle the caching transparently as well.

As part of this change the copy-and-pasting of the SNPP, NOAA20, and NOAA21 layer descriptions became pretty high, so this PR also rearranges those layer specifications by creating "definition" files that only _define_ a layer but not _add_ the layer. This way the definitions can be reused without dragging in the individual layers automatically.


1. If someone has a better folder name than "definitions", I'd be happy.
2. Writing an example for the new layer provider is out of scope for this PR (for now;  maybe if there is time, but I don't want to wait for me to do it) as I want to get it into 0.20.1 as 0.20.0 has some issue with the default layer not updating due to time-mismatches and it's more important to get this in
