### PR TITLE
UI updates

### DIFF
--- a/data/assets/util/webgui.asset
+++ b/data/assets/util/webgui.asset
@@ -4,7 +4,7 @@ local guiCustomization = asset.require("customization/gui")
 
 
 -- Select which commit hashes to use for the frontend and backend
-local frontendHash = "95ed7fb5853d27d2b879f6f409f3101a018e03ce"
+local frontendHash = "c607523e86ab29c573b157c956dcf0b0e4492395"
 
 local frontend = asset.resource({
   Identifier = "WebGuiFrontend",

--- a/include/openspace/events/event.h
+++ b/include/openspace/events/event.h
@@ -58,13 +58,9 @@ struct Event {
     //     if they are triggered by events
     //  6. Add the new enum entry into the `toString` and `fromString` methods
     enum class Type : uint8_t {
-        SceneGraphNodeAdded,
-        SceneGraphNodeRemoved,
         ParallelConnection,
         ProfileLoadingFinished,
         ApplicationShutdown,
-        ScreenSpaceRenderableAdded,
-        ScreenSpaceRenderableRemoved,
         CameraFocusTransition,
         TimeOfInterestReached,
         MissionEventReached,
@@ -113,43 +109,6 @@ void logAllEvents(const Event* e);
 //
 //  Events
 //
-
-/**
- * This event is created whenever a new scene graph node is added to the system. By the
- * time this event is signalled, the scene graph node has already been created and added
- * to the scene.
- */
-struct EventSceneGraphNodeAdded : public Event {
-    static constexpr Type Type = Event::Type::SceneGraphNodeAdded;
-
-    /**
-     * Creates an instance of an EventSceneGraphNodeAdded event.
-     *
-     * \param node_ A pointer to the node that was added
-     *
-     * \pre node_ must not be nullptr
-     */
-    explicit EventSceneGraphNodeAdded(const SceneGraphNode* node_);
-    const tstring uri;
-};
-
-/**
- * This event is created whenever a scene graph node was removed. By the time this event
- * is signalled, the scene graph node has already been removed.
- */
-struct EventSceneGraphNodeRemoved : public Event {
-    static constexpr Type Type = Event::Type::SceneGraphNodeRemoved;
-
-    /**
-     * Creates an instance of an EventSceneGraphNodeRemoved event.
-     *
-     * \param node_ A pointer to the node that was removed
-     *
-     * \pre node_ must not be nullptr
-     */
-    explicit EventSceneGraphNodeRemoved(const SceneGraphNode* node_);
-    const tstring uri;
-};
 
 /**
  * This event is created whenever something in the parallel connection subsystem changes.
@@ -210,43 +169,6 @@ struct EventApplicationShutdown : public Event {
      */
     explicit EventApplicationShutdown(State state_);
     const State state;
-};
-
-/**
- * This event is created when a new screenspace renderable has been created.  By the time
- * this event is created, the screenspace renderable is already registered and available.
- */
-struct EventScreenSpaceRenderableAdded : public Event {
-    static constexpr Type Type = Event::Type::ScreenSpaceRenderableAdded;
-
-    /**
-     * Creates an instance of an EventScreenSpaceRenderableAdded event.
-     *
-     * \param renderable_ The the new screenspace renderable that was added to the system
-     *
-     * \pre renderable_ must not be nullptr
-     */
-    explicit EventScreenSpaceRenderableAdded(const ScreenSpaceRenderable* renderable_);
-    const tstring uri;
-};
-
-/**
- * This event is created when a screenspace renderable has been removed from the system.
- * When this event is created, the screenspace renderable has already been removed and is
- * no longer available.
- */
-struct EventScreenSpaceRenderableRemoved : public Event {
-    static constexpr Type Type = Event::Type::ScreenSpaceRenderableRemoved;
-
-    /**
-     * Creates an instance of an EventScreenSpaceRenderableRemoved event.
-     *
-     * \param renderable_ The the new screenspace renderable that was removed
-     *
-     * \pre renderable_ must not be nullptr
-     */
-    explicit EventScreenSpaceRenderableRemoved(const ScreenSpaceRenderable* renderable_);
-    const tstring uri;
 };
 
 /**

--- a/include/openspace/events/event.h
+++ b/include/openspace/events/event.h
@@ -67,8 +67,8 @@ struct Event {
         PlanetEclipsed,
         InterpolationFinished,
         FocusNodeChanged,
-        LayerAdded,
-        LayerRemoved,
+        PropertyTreeUpdated,
+        PropertyTreePruned,
         ActionAdded,
         ActionRemoved,
         SessionRecordingPlayback,
@@ -315,37 +315,38 @@ struct EventFocusNodeChanged : public Event {
 };
 
 /**
- * This event is created when a layer is added to to a globe.
+ * This event is created a property owner or property has been added or has changed.
  */
-struct EventLayerAdded : public Event {
-    static constexpr Type Type = Event::Type::LayerAdded;
+struct EventPropertyTreeUpdated : public Event {
+    static constexpr Type Type = Event::Type::PropertyTreeUpdated;
 
     /**
-     * Creates an instance of an EventLayerAdded event.
+     * Creates an instance of an EventPropertyTreeUpdated event.
      *
-     * \param uri_ A string with the uri of the layer that was added
+     * \param uri_ A string with the uri of the property or property owner that was added
      *
      * \pre uri_ must be a valid uri
      */
-    explicit EventLayerAdded(std::string_view uri_);
+    explicit EventPropertyTreeUpdated(std::string_view uri_);
 
     const tstring uri;
 };
 
 /**
- * This event is created when a layer is removed from a globe.
+ * This event is created when a property owner or property is removed from a the property
+ * tree.
  */
-struct EventLayerRemoved : public Event {
-    static constexpr Type Type = Event::Type::LayerRemoved;
+struct EventPropertyTreePruned : public Event {
+    static constexpr Type Type = Event::Type::PropertyTreePruned;
 
     /**
-     * Creates an instance of an EventLayerRemoved event.
+     * Creates an instance of an EventPropertyTreePruned event.
      *
-     * \param uri_ The uri of the layer that was removed
+     * \param uri_ The uri of the property or property owner that was removed
      *
      * \pre uri_ must be a valid uri
      */
-    explicit EventLayerRemoved(std::string_view uri_);
+    explicit EventPropertyTreePruned(std::string_view uri_);
 
     const tstring uri;
 };

--- a/include/openspace/properties/numericalproperty.inl
+++ b/include/openspace/properties/numericalproperty.inl
@@ -113,7 +113,7 @@ void NumericalProperty<T>::setExponent(float exponent) {
                 std::format(
                     "Setting exponent for properties with negative values in "
                     "[min, max] range is not yet supported. Property: {}",
-                    this->fullyQualifiedIdentifier()
+                    this->uri()
                 )
             );
             _exponent = 1.f;

--- a/include/openspace/properties/property.h
+++ b/include/openspace/properties/property.h
@@ -294,13 +294,15 @@ public:
     const std::string& identifier() const;
 
     /**
-     * Returns the fully qualified name for this Property that uniquely identifies this
-     * Property within OpenSpace. It consists of the identifier preceded by all levels of
-     * PropertyOwner%s separated with `.`; for example: `owner1.owner2.identifier`.
+     * Returns the URI for this Property that uniquely identifies this Property within
+     * OpenSpace. It consists of the identifier preceded by all levels of PropertyOwner%s
+     * separated with `.`; for example: `owner1.owner2.identifier`. If the URI is invalid
+     * (the Property hasn't been added to the property tree yet), it returns an empty
+     * string.
      *
      * \return The fully qualified identifier for this Property
      */
-    std::string fullyQualifiedIdentifier() const;
+    std::string uri() const;
 
     /**
      * Returns the PropertyOwner of this Property or `nullptr`, if it does not have an

--- a/modules/base/rendering/pointcloud/renderableinterpolatedpoints.cpp
+++ b/modules/base/rendering/pointcloud/renderableinterpolatedpoints.cpp
@@ -198,7 +198,7 @@ RenderableInterpolatedPoints::Interpolation::Interpolation()
         float remaining = value.maxValue() - value;
         float duration = remaining / speed;
         triggerInterpolation(
-            value.fullyQualifiedIdentifier(),
+            value.uri(),
             value.maxValue(),
             duration
         );
@@ -206,21 +206,21 @@ RenderableInterpolatedPoints::Interpolation::Interpolation()
 
     interpolateToStart.onChange([triggerInterpolation, this]() {
         float duration = value / speed;
-        triggerInterpolation(value.fullyQualifiedIdentifier(), 0.f, duration);
+        triggerInterpolation(value.uri(), 0.f, duration);
     });
 
     interpolateToNextStep.onChange([triggerInterpolation, this]() {
         float prevValue = glm::floor(value);
         float newValue = glm::min(prevValue + 1.f, value.maxValue());
         float duration = 1.f / speed;
-        triggerInterpolation(value.fullyQualifiedIdentifier(), newValue, duration);
+        triggerInterpolation(value.uri(), newValue, duration);
     });
 
     interpolateToPrevStep.onChange([triggerInterpolation, this]() {
         float prevValue = glm::ceil(value);
         float newValue = glm::max(prevValue - 1.f, value.minValue());
         float duration = 1.f / speed;
-        triggerInterpolation(value.fullyQualifiedIdentifier(), newValue, duration);
+        triggerInterpolation(value.uri(), newValue, duration);
     });
 
     addProperty(interpolateToEnd);

--- a/modules/globebrowsing/src/layergroup.cpp
+++ b/modules/globebrowsing/src/layergroup.cpp
@@ -163,19 +163,6 @@ Layer* LayerGroup::addLayer(const ghoul::Dictionary& layerDict) {
     properties::PropertyOwner* layerGroup = ptr->owner();
     properties::PropertyOwner* layerManager = layerGroup->owner();
 
-    // @TODO (emmbr, 2021-11-03) If the layer is added as part of the globe's
-    // dictionary during construction this function is called in the LayerManager's
-    // initialize function. This means that the layerManager does not exists yet, and
-    // we cannot find which SGN it belongs to... Want to avoid doing this check, so
-    // this should be fixed (probably as part of a cleanup/rewite of the LayerManager)
-    if (layerManager) {
-        properties::PropertyOwner* globe = layerManager->owner();
-        properties::PropertyOwner* sceneGraphNode = globe->owner();
-        global::eventEngine->publishEvent<events::EventLayerAdded>(
-            ptr->uri()
-        );
-    }
-
     return ptr;
 }
 
@@ -193,9 +180,7 @@ void LayerGroup::deleteLayer(const std::string& layerName) {
             properties::PropertyOwner* layerManager = layerGroup->owner();
             properties::PropertyOwner* globe = layerManager->owner();
             properties::PropertyOwner* sceneGraphNode = globe->owner();
-            global::eventEngine->publishEvent<events::EventLayerRemoved>(
-                it->get()->uri()
-            );
+
             // We need to keep the name of the layer since we only get it as a reference
             // and the name needs to survive the deletion
             const std::string lName = layerName;
@@ -292,6 +277,9 @@ void LayerGroup::moveLayer(int oldPosition, int newPosition) {
     RenderableGlobe* renderable = dynamic_cast<RenderableGlobe*>(manager->owner());
     ghoul_assert(manager, "Hierarchy error: LayerManager. Owner is not RenderableGlobe");
     renderable->invalidateShader();
+
+    // Notify that the layers are in a different order
+    global::eventEngine->publishEvent<events::EventPropertyTreeUpdated>(uri());
 }
 
 std::vector<Layer*> LayerGroup::layers() const {

--- a/modules/imgui/src/renderproperties.cpp
+++ b/modules/imgui/src/renderproperties.cpp
@@ -65,7 +65,7 @@ void renderTooltip(Property* prop, double delay) {
         }
         ImGui::Text(
             "%s",
-            (std::string("Identifier: ") + prop->fullyQualifiedIdentifier()).c_str()
+            (std::string("Identifier: ") + prop->uri()).c_str()
         );
         ImGui::EndTooltip();
     }
@@ -95,7 +95,7 @@ void renderBoolProperty(Property* prop, const std::string& ownerName,
     }
 
     if (value != p->value()) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), value ? "true" : "false");
+        executeSetPropertyScript(p->uri(), value ? "true" : "false");
     }
     ImGui::PopID();
 }
@@ -158,7 +158,7 @@ void renderOptionProperty(Property* prop, const std::string& ownerName,
         }
     }
     if (value != p->value() && !isReadOnly) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), std::to_string(value));
+        executeSetPropertyScript(p->uri(), std::to_string(value));
     }
     ImGui::PopID();
 }
@@ -200,7 +200,7 @@ void renderSelectionProperty(Property* prop, const std::string& ownerName,
                 parameters.pop_back();
             }
             parameters += "}";
-            executeSetPropertyScript(p->fullyQualifiedIdentifier(), parameters);
+            executeSetPropertyScript(p->uri(), parameters);
         }
         ImGui::TreePop();
     }
@@ -231,7 +231,7 @@ void renderStringProperty(Property* prop, const std::string& ownerName,
 
     if (hasNewValue) {
         executeSetPropertyScript(
-            p->fullyQualifiedIdentifier(),
+            p->uri(),
             "[[" + std::string(buffer.data()) + "]]"
         );
     }
@@ -283,7 +283,7 @@ void renderDoubleListProperty(Property* prop, const std::string& ownerName,
     ImGui::PushID((ownerName + '.' + name).c_str());
 
     const std::string value = p->stringValue();
-    renderListProperty(name, p->fullyQualifiedIdentifier(), value);
+    renderListProperty(name, p->uri(), value);
 
     if (showTooltip) {
         renderTooltip(prop, tooltipDelay);
@@ -301,7 +301,7 @@ void renderIntListProperty(Property* prop, const std::string& ownerName,
     ImGui::PushID((ownerName + '.' + name).c_str());
 
     const std::string value = p->stringValue();
-    renderListProperty(name, p->fullyQualifiedIdentifier(), value);
+    renderListProperty(name, p->uri(), value);
 
     if (showTooltip) {
         renderTooltip(prop, tooltipDelay);
@@ -319,7 +319,7 @@ void renderStringListProperty(Property* prop, const std::string& ownerName,
     ImGui::PushID((ownerName + '.' + name).c_str());
 
     const std::string value = p->stringValue();
-    renderListProperty(name, p->fullyQualifiedIdentifier(), value);
+    renderListProperty(name, p->uri(), value);
 
     if (showTooltip) {
         renderTooltip(prop, tooltipDelay);
@@ -358,7 +358,7 @@ void renderDoubleProperty(properties::Property* prop, const std::string& ownerNa
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), std::to_string(value));
+        executeSetPropertyScript(p->uri(), std::to_string(value));
     }
 
     ImGui::PopID();
@@ -382,7 +382,7 @@ void renderIntProperty(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), std::to_string(value));
+        executeSetPropertyScript(p->uri(), std::to_string(value));
     }
 
     ImGui::PopID();
@@ -405,7 +405,7 @@ void renderIVec2Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -428,7 +428,7 @@ void renderIVec3Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
     ImGui::PopID();
 }
@@ -450,7 +450,7 @@ void renderIVec4Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
     ImGui::PopID();
 }
@@ -479,7 +479,7 @@ void renderFloatProperty(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), std::to_string(value));
+        executeSetPropertyScript(p->uri(), std::to_string(value));
     }
 
     ImGui::PopID();
@@ -509,7 +509,7 @@ void renderVec2Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -545,7 +545,7 @@ void renderVec3Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -581,7 +581,7 @@ void renderVec4Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -611,7 +611,7 @@ void renderDVec2Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -641,7 +641,7 @@ void renderDVec3Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -671,7 +671,7 @@ void renderDVec4Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -723,7 +723,7 @@ void renderDMat2Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -785,7 +785,7 @@ void renderDMat3Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -857,7 +857,7 @@ void renderDMat4Property(Property* prop, const std::string& ownerName,
     }
 
     if (changed) {
-        executeSetPropertyScript(p->fullyQualifiedIdentifier(), ghoul::to_string(value));
+        executeSetPropertyScript(p->uri(), ghoul::to_string(value));
     }
 
     ImGui::PopID();
@@ -872,7 +872,7 @@ void renderTriggerProperty(Property* prop, const std::string& ownerName,
 
     const bool pressed = ImGui::Button(name.c_str());
     if (pressed) {
-        executeSetPropertyScript(prop->fullyQualifiedIdentifier(), "nil");
+        executeSetPropertyScript(prop->uri(), "nil");
     }
     if (showTooltip) {
         renderTooltip(prop, tooltipDelay);

--- a/src/documentation/documentationengine.cpp
+++ b/src/documentation/documentationengine.cpp
@@ -206,7 +206,7 @@ namespace {
             std::string name = !p->guiName().empty() ? p->guiName() : p->identifier();
             propertyJson[NameKey] = name;
             propertyJson[TypeKey] = p->className();
-            propertyJson[UriKey] = p->fullyQualifiedIdentifier();
+            propertyJson[UriKey] = p->uri();
             propertyJson[IdentifierKey] = p->identifier();
             propertyJson[DescriptionKey] = p->description();
 

--- a/src/events/event.cpp
+++ b/src/events/event.cpp
@@ -609,7 +609,7 @@ EventPlanetEclipsed::EventPlanetEclipsed(const SceneGraphNode* eclipsee_,
 EventInterpolationFinished::EventInterpolationFinished(
                                                     const properties::Property* property_)
     : Event(Type)
-    , property(temporaryString(property_->fullyQualifiedIdentifier()))
+    , property(temporaryString(property_->uri()))
 {}
 
 EventFocusNodeChanged::EventFocusNodeChanged(const SceneGraphNode* oldNode_,

--- a/src/events/event.cpp
+++ b/src/events/event.cpp
@@ -126,14 +126,14 @@ void log(int i, const EventFocusNodeChanged& e) {
     LINFO(std::format("[{}] FocusNodeChanged: {} -> {}", i, e.oldNode, e.newNode));
 }
 
-void log(int i, const EventLayerAdded& e) {
-    ghoul_assert(e.type == EventLayerAdded::Type, "Wrong type");
-    LINFO(std::format("[{}] LayerAdded: {}", i, e.uri));
+void log(int i, const EventPropertyTreeUpdated& e) {
+    ghoul_assert(e.type == EventPropertyTreeUpdated::Type, "Wrong type");
+    LINFO(std::format("[{}] PropertyTreeUpdated: {}", i, e.uri));
 }
 
-void log(int i, const EventLayerRemoved& e) {
-    ghoul_assert(e.type == EventLayerRemoved::Type, "Wrong type");
-    LINFO(std::format("[{}] LayerRemoved: {}", i, e.uri));
+void log(int i, const EventPropertyTreePruned& e) {
+    ghoul_assert(e.type == EventPropertyTreePruned::Type, "Wrong type");
+    LINFO(std::format("[{}] PropertyTreePruned: {}", i, e.uri));
 }
 
 void log(int i, const EventActionAdded& e) {
@@ -222,8 +222,8 @@ std::string_view toString(Event::Type type) {
         case Event::Type::PlanetEclipsed: return "PlanetEclipsed";
         case Event::Type::InterpolationFinished: return "InterpolationFinished";
         case Event::Type::FocusNodeChanged: return "FocusNodeChanged";
-        case Event::Type::LayerAdded: return "LayerAdded";
-        case Event::Type::LayerRemoved: return "LayerRemoved";
+        case Event::Type::PropertyTreeUpdated: return "PropertyTreeUpdated";
+        case Event::Type::PropertyTreePruned: return "PropertyTreePruned";
         case Event::Type::ActionAdded: return "ActionAdded";
         case Event::Type::ActionRemoved: return "ActionRemoved";
         case Event::Type::SessionRecordingPlayback: return "SessionRecordingPlayback";
@@ -268,11 +268,11 @@ Event::Type fromString(std::string_view str) {
     else if (str == "FocusNodeChanged") {
         return Event::Type::FocusNodeChanged;
     }
-    else if (str == "LayerAdded") {
-        return Event::Type::LayerAdded;
+    else if (str == "PropertyTreeUpdated") {
+        return Event::Type::PropertyTreeUpdated;
     }
-    else if (str == "LayerRemoved") {
-        return Event::Type::LayerRemoved;
+    else if (str == "PropertyTreePruned") {
+        return Event::Type::PropertyTreePruned;
     }
     else if (str == "ActionAdded") {
         return Event::Type::ActionAdded;
@@ -389,16 +389,16 @@ ghoul::Dictionary toParameter(const Event& e) {
                 std::string(static_cast<const EventFocusNodeChanged&>(e).newNode)
             );
             break;
-        case Event::Type::LayerAdded:
+        case Event::Type::PropertyTreeUpdated:
             d.setValue(
                 "Uri",
-                std::string(static_cast<const EventLayerAdded&>(e).uri)
+                std::string(static_cast<const EventPropertyTreeUpdated&>(e).uri)
             );
             break;
-        case Event::Type::LayerRemoved:
+        case Event::Type::PropertyTreePruned:
             d.setValue(
                 "Uri",
-                std::string(static_cast<const EventLayerRemoved&>(e).uri)
+                std::string(static_cast<const EventPropertyTreePruned&>(e).uri)
             );
             break;
         case Event::Type::ActionAdded:
@@ -517,11 +517,11 @@ void logAllEvents(const Event* e) {
             case Event::Type::FocusNodeChanged:
                 log(i, *static_cast<const EventFocusNodeChanged*>(e));
                 break;
-            case Event::Type::LayerAdded:
-                log(i, *static_cast<const EventLayerAdded*>(e));
+            case Event::Type::PropertyTreeUpdated:
+                log(i, *static_cast<const EventPropertyTreeUpdated*>(e));
                 break;
-            case Event::Type::LayerRemoved:
-                log(i, *static_cast<const EventLayerRemoved*>(e));
+            case Event::Type::PropertyTreePruned:
+                log(i, *static_cast<const EventPropertyTreePruned*>(e));
                 break;
             case Event::Type::ActionAdded:
                 log(i, *static_cast<const EventActionAdded*>(e));
@@ -621,12 +621,12 @@ EventFocusNodeChanged::EventFocusNodeChanged(const SceneGraphNode* oldNode_,
     ghoul_assert(newNode_, "There must be a new node");
 }
 
-EventLayerAdded::EventLayerAdded(std::string_view uri_)
+EventPropertyTreeUpdated::EventPropertyTreeUpdated(std::string_view uri_)
     : Event(Type)
     , uri(temporaryString(uri_))
 {}
 
-EventLayerRemoved::EventLayerRemoved(std::string_view uri_)
+EventPropertyTreePruned::EventPropertyTreePruned(std::string_view uri_)
     : Event(Type)
     , uri(temporaryString(uri_))
 {}

--- a/src/events/event.cpp
+++ b/src/events/event.cpp
@@ -43,16 +43,6 @@ using namespace std::string_literals;
 
 namespace openspace::events {
 
-void log(int i, const EventSceneGraphNodeAdded& e) {
-    ghoul_assert(e.type == EventSceneGraphNodeAdded::Type, "Wrong type");
-    LINFO(std::format("[{}] SceneGraphNodeAdded: {}", i, e.uri));
-}
-
-void log(int i, const EventSceneGraphNodeRemoved& e) {
-    ghoul_assert(e.type == EventSceneGraphNodeRemoved::Type, "Wrong type");
-    LINFO(std::format("[{}] SceneGraphNodeRemoved: {}", i, e.uri));
-}
-
 void log(int i, const EventParallelConnection& e) {
     ghoul_assert(e.type == EventParallelConnection::Type, "Wrong type");
     std::string_view state = [](EventParallelConnection::State s) {
@@ -83,16 +73,6 @@ void log(int i, const EventApplicationShutdown& e) {
         }
     }(e.state);
     LINFO(std::format("[{}] ApplicationShutdown", i));
-}
-
-void log(int i, const EventScreenSpaceRenderableAdded& e) {
-    ghoul_assert(e.type == EventScreenSpaceRenderableAdded::Type, "Wrong type");
-    LINFO(std::format("[{}] ScreenSpaceRenderableAdded: {}", i, e.uri));
-}
-
-void log(int i, const EventScreenSpaceRenderableRemoved& e) {
-    ghoul_assert(e.type == EventScreenSpaceRenderableRemoved::Type, "Wrong type");
-    LINFO(std::format("[{}] ScreenSpaceRenderableRemoved: {}", i, e.uri));
 }
 
 void log(int i, const EventCameraFocusTransition& e) {
@@ -233,14 +213,9 @@ void log(int i, const CustomEvent& e) {
 
 std::string_view toString(Event::Type type) {
     switch (type) {
-        case Event::Type::SceneGraphNodeAdded: return "SceneGraphNodeAdded";
-        case Event::Type::SceneGraphNodeRemoved: return "SceneGraphNodeRemoved";
         case Event::Type::ParallelConnection: return "ParallelConnection";
         case Event::Type::ProfileLoadingFinished: return "ProfileLoadingFinished";
         case Event::Type::ApplicationShutdown: return "ApplicationShutdown";
-        case Event::Type::ScreenSpaceRenderableAdded: return "ScreenSpaceRenderableAdded";
-        case Event::Type::ScreenSpaceRenderableRemoved:
-            return "ScreenSpaceRenderableRemoved";
         case Event::Type::CameraFocusTransition: return "CameraFocusTransition";
         case Event::Type::TimeOfInterestReached: return "TimeOfInterestReached";
         case Event::Type::MissionEventReached: return "MissionEventReached";
@@ -266,13 +241,7 @@ std::string_view toString(Event::Type type) {
 }
 
 Event::Type fromString(std::string_view str) {
-    if (str == "SceneGraphNodeAdded") {
-        return Event::Type::SceneGraphNodeAdded;
-    }
-    else if (str == "SceneGraphNodeRemoved") {
-        return Event::Type::SceneGraphNodeRemoved;
-    }
-    else if (str == "ParallelConnection") {
+    if (str == "ParallelConnection") {
         return Event::Type::ParallelConnection;
     }
     else if (str == "ProfileLoadingFinished") {
@@ -280,12 +249,6 @@ Event::Type fromString(std::string_view str) {
     }
     else if (str == "ApplicationShutdown") {
         return Event::Type::ApplicationShutdown;
-    }
-    else if (str == "ScreenSpaceRenderableAdded") {
-        return Event::Type::ScreenSpaceRenderableAdded;
-    }
-    else if (str == "ScreenSpaceRenderableRemoved") {
-        return Event::Type::ScreenSpaceRenderableRemoved;
     }
     else if (str == "CameraFocusTransition") {
         return Event::Type::CameraFocusTransition;
@@ -351,18 +314,6 @@ Event::Type fromString(std::string_view str) {
 ghoul::Dictionary toParameter(const Event& e) {
     ghoul::Dictionary d;
     switch (e.type) {
-        case Event::Type::SceneGraphNodeAdded:
-            d.setValue(
-                "Uri",
-                std::string(static_cast<const EventSceneGraphNodeAdded&>(e).uri)
-            );
-            break;
-        case Event::Type::SceneGraphNodeRemoved:
-            d.setValue(
-                "Uri",
-                std::string(static_cast<const EventSceneGraphNodeRemoved&>(e).uri)
-            );
-            break;
         case Event::Type::ParallelConnection:
             switch (static_cast<const EventParallelConnection&>(e).state) {
                 case EventParallelConnection::State::Established:
@@ -391,22 +342,6 @@ ghoul::Dictionary toParameter(const Event& e) {
                     d.setValue("State", "Finished"s);
                     break;
             }
-            break;
-        case Event::Type::ScreenSpaceRenderableAdded:
-            d.setValue(
-                "Uri",
-                std::string(
-                    static_cast<const EventScreenSpaceRenderableAdded&>(e).uri
-                )
-            );
-            break;
-        case Event::Type::ScreenSpaceRenderableRemoved:
-            d.setValue(
-                "Uri",
-                std::string(
-                    static_cast<const EventScreenSpaceRenderableRemoved&>(e).uri
-                )
-            );
             break;
         case Event::Type::CameraFocusTransition:
             d.setValue(
@@ -555,12 +490,6 @@ void logAllEvents(const Event* e) {
     int i = 0;
     while (e) {
         switch (e->type) {
-            case Event::Type::SceneGraphNodeAdded:
-                log(i, *static_cast<const EventSceneGraphNodeAdded*>(e));
-                break;
-            case Event::Type::SceneGraphNodeRemoved:
-                log(i, *static_cast<const EventSceneGraphNodeRemoved*>(e));
-                break;
             case Event::Type::ParallelConnection:
                 log(i, *static_cast<const EventParallelConnection*>(e));
                 break;
@@ -569,12 +498,6 @@ void logAllEvents(const Event* e) {
                 break;
             case Event::Type::ApplicationShutdown:
                 log(i, *static_cast<const EventApplicationShutdown*>(e));
-                break;
-            case Event::Type::ScreenSpaceRenderableAdded:
-                log(i, *static_cast<const EventScreenSpaceRenderableAdded*>(e));
-                break;
-            case Event::Type::ScreenSpaceRenderableRemoved:
-                log(i, *static_cast<const EventScreenSpaceRenderableRemoved*>(e));
                 break;
             case Event::Type::CameraFocusTransition:
                 log(i, *static_cast<const EventCameraFocusTransition*>(e));
@@ -642,16 +565,6 @@ void logAllEvents(const Event* e) {
     }
 }
 
-EventSceneGraphNodeAdded::EventSceneGraphNodeAdded(const SceneGraphNode* node_)
-    : Event(Type)
-    , uri(temporaryString(node_->uri()))
-{}
-
-EventSceneGraphNodeRemoved::EventSceneGraphNodeRemoved(const SceneGraphNode* node_)
-    : Event(Type)
-    , uri(temporaryString(node_->uri()))
-{}
-
 EventParallelConnection::EventParallelConnection(State state_)
     : Event(Type)
     , state(state_)
@@ -664,18 +577,6 @@ EventProfileLoadingFinished::EventProfileLoadingFinished()
 EventApplicationShutdown::EventApplicationShutdown(State state_)
     : Event(Type)
     , state(state_)
-{}
-
-EventScreenSpaceRenderableAdded::EventScreenSpaceRenderableAdded(
-                                                 const ScreenSpaceRenderable* renderable_)
-    : Event(Type)
-    , uri(temporaryString(renderable_->uri()))
-{}
-
-EventScreenSpaceRenderableRemoved::EventScreenSpaceRenderableRemoved(
-                                                 const ScreenSpaceRenderable* renderable_)
-    : Event(Type)
-    , uri(temporaryString(renderable_->uri()))
 {}
 
 EventCameraFocusTransition::EventCameraFocusTransition(const Camera* camera_,

--- a/src/interaction/sessionrecording.cpp
+++ b/src/interaction/sessionrecording.cpp
@@ -976,7 +976,7 @@ void SessionRecording::saveScriptKeyframeAscii(Timestamps& times,
 }
 
 void SessionRecording::savePropertyBaseline(properties::Property& prop) {
-    const std::string propIdentifier = prop.fullyQualifiedIdentifier();
+    const std::string propIdentifier = prop.uri();
     if (isPropertyAllowedForBaseline(propIdentifier)) {
         const bool isPropAlreadySaved = (
             std::find(

--- a/src/properties/property.cpp
+++ b/src/properties/property.cpp
@@ -76,7 +76,7 @@ const std::string& Property::identifier() const {
     return _identifier;
 }
 
-std::string Property::fullyQualifiedIdentifier() const {
+std::string Property::uri() const {
     std::string identifier = "";
     const std::string& ownerUri = owner()->uri();
     if (!ownerUri.empty()) {
@@ -264,7 +264,7 @@ void Property::resetToUnchanged() {
 
 std::string Property::generateJsonDescription() const {
     const std::string cName = escapedJson(std::string(className()));
-    const std::string identifier = fullyQualifiedIdentifier();
+    const std::string identifier = uri();
     const std::string identifierSan = escapedJson(identifier);
     const std::string gName = guiName();
     const std::string gNameSan = escapedJson(gName);

--- a/src/properties/property.cpp
+++ b/src/properties/property.cpp
@@ -77,10 +77,10 @@ const std::string& Property::identifier() const {
 }
 
 std::string Property::fullyQualifiedIdentifier() const {
-    std::string identifier = _identifier;
+    std::string identifier = "";
     const std::string& ownerUri = owner()->uri();
     if (!ownerUri.empty()) {
-        identifier = std::format("{}.{}", ownerUri, identifier);
+        identifier = std::format("{}.{}", ownerUri, _identifier);
     }
     return identifier;
 }

--- a/src/properties/propertyowner.cpp
+++ b/src/properties/propertyowner.cpp
@@ -242,9 +242,9 @@ void PropertyOwner::addProperty(Property* prop) {
             prop->setPropertyOwner(this);
 
             // Validate the uri
-            std::string uriParent = uri();
-            if (!uriParent.empty()) {
-                std::string id = std::format("{}.{}", uriParent, prop->identifier());
+            std::string parentUri = uri();
+            if (!parentUri .empty()) {
+                std::string id = std::format("{}.{}", parentUri , prop->identifier());
                 global::eventEngine->publishEvent<events::EventPropertyTreeUpdated>(id);
             }
         }

--- a/src/properties/propertyowner.cpp
+++ b/src/properties/propertyowner.cpp
@@ -261,7 +261,7 @@ void PropertyOwner::addProperty(Property* prop) {
             prop->setPropertyOwner(this);
 
             // Notify change so we can update the UI
-            publishPropertyTreeUpdatedEvent(prop->fullyQualifiedIdentifier());
+            publishPropertyTreeUpdatedEvent(prop->uri());
         }
     }
 }
@@ -333,7 +333,7 @@ void PropertyOwner::removeProperty(Property* prop) {
     // If we found the property identifier, we can delete it
     if (it != _properties.end() && (*it)->identifier() == prop->identifier()) {
         // Notify change so we can update the UI
-        publishPropertyTreePrunedEvent(prop->fullyQualifiedIdentifier());
+        publishPropertyTreePrunedEvent(prop->uri());
 
         (*it)->setPropertyOwner(nullptr);
         _properties.erase(it);

--- a/src/properties/propertyowner.cpp
+++ b/src/properties/propertyowner.cpp
@@ -242,8 +242,9 @@ void PropertyOwner::addProperty(Property* prop) {
             prop->setPropertyOwner(this);
 
             // Validate the uri
-            if (!uri().empty()) {
-                std::string id = std::format("{}.{}", uri(), prop->identifier());
+            std::string uriParent = uri();
+            if (!uriParent.empty()) {
+                std::string id = std::format("{}.{}", uriParent, prop->identifier());
                 global::eventEngine->publishEvent<events::EventPropertyTreeUpdated>(id);
             }
         }
@@ -323,8 +324,9 @@ void PropertyOwner::removeProperty(Property* prop) {
     if (it != _properties.end() && (*it)->identifier() == prop->identifier()) {
         // Validate the URI. Due to removal timings it is possible the parents are already
         // removed from the property tree
-        if (!uri().empty()) {
-            std::string id = std::format("{}.{}", uri(), prop->identifier());
+        std::string uriParent = uri();
+        if (!uriParent.empty()) {
+            std::string id = std::format("{}.{}", uriParent, prop->identifier());
             global::eventEngine->publishEvent<events::EventPropertyTreePruned>(id);
         }
         (*it)->setPropertyOwner(nullptr);

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -1069,8 +1069,6 @@ void RenderEngine::addScreenSpaceRenderable(std::unique_ptr<ScreenSpaceRenderabl
     ScreenSpaceRenderable* ssr = s.get();
     global::screenSpaceRootPropertyOwner->addPropertySubOwner(ssr);
     global::screenSpaceRenderables->push_back(std::move(s));
-
-    global::eventEngine->publishEvent<events::EventScreenSpaceRenderableAdded>(ssr);
 }
 
 void RenderEngine::removeScreenSpaceRenderable(ScreenSpaceRenderable* s) {
@@ -1081,7 +1079,6 @@ void RenderEngine::removeScreenSpaceRenderable(ScreenSpaceRenderable* s) {
     );
 
     if (it != global::screenSpaceRenderables->end()) {
-        global::eventEngine->publishEvent<events::EventScreenSpaceRenderableRemoved>(s);
         s->deinitializeGL();
         s->deinitialize();
         global::screenSpaceRootPropertyOwner->removePropertySubOwner(s);

--- a/src/scene/profile.cpp
+++ b/src/scene/profile.cpp
@@ -640,7 +640,7 @@ void Profile::saveCurrentSettingsToProfile(const properties::PropertyOwner& root
     for (properties::Property* prop : ps) {
         Property p;
         p.setType = Property::SetType::SetPropertyValueSingle;
-        p.name = prop->fullyQualifiedIdentifier();
+        p.name = prop->uri();
         p.value = prop->stringValue();
         properties.push_back(std::move(p));
     }

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -166,7 +166,6 @@ void Scene::registerNode(SceneGraphNode* node) {
     _nodesByIdentifier[node->identifier()] = node;
     addPropertySubOwner(node);
     _dirtyNodeRegistry = true;
-    global::eventEngine->publishEvent<events::EventSceneGraphNodeAdded>(node);
 }
 
 void Scene::unregisterNode(SceneGraphNode* node) {
@@ -186,7 +185,6 @@ void Scene::unregisterNode(SceneGraphNode* node) {
     }
     removePropertySubOwner(node);
     _dirtyNodeRegistry = true;
-    global::eventEngine->publishEvent<events::EventSceneGraphNodeRemoved>(node);
 }
 
 void Scene::markNodeRegistryDirty() {

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -141,7 +141,7 @@ std::vector<openspace::properties::Property*> findMatchesInAllProperties(
     // of the loop, the property name regex was probably misspelled.
     for (properties::Property* prop : properties) {
         // Check the regular expression for all properties
-        const std::string id = prop->fullyQualifiedIdentifier();
+        const std::string id = prop->uri();
 
         if (isLiteral && id != propertyName) {
             continue;
@@ -227,7 +227,7 @@ void applyRegularExpression(lua_State* L, const std::string& regex,
                 std::format(
                     "{}: Property '{}' does not accept input of type '{}'. Requested "
                     "type: {}",
-                    errorLocation(L), prop->fullyQualifiedIdentifier(),
+                    errorLocation(L), prop->uri(),
                     luaTypeToString(type), luaTypeToString(prop->typeLua())
                 )
             );
@@ -544,7 +544,7 @@ namespace {
     std::vector<std::string> res;
     for (properties::Property* prop : props) {
         // Check the regular expression for all properties
-        const std::string& id = prop->fullyQualifiedIdentifier();
+        const std::string& id = prop->uri();
 
         if (isLiteral && id != propertyName) {
             continue;


### PR DESCRIPTION
To be used with this PR: https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/194

This PR will mirror (hopefully) all updates to the property tree in the UI, including:
* All property owner removals and additions during runtime
* All property removals and additions during runtime
* Globebrowsing layer reorderings

Changes made:
* Removed all events for removing and adding SceneGraphNodes, ScreenSpaceRenderables and Layers
* Instead created two new events: PropertyTreeUpdated and PropertyTreePruned
* These events are published in the PropertyOwner functions addProperty, addPropertySubowner, removeProperty, and removePropertySubowner, to ensure that all changes in the property tree are reflected in the UI
* The URI of the Property or PropertyOwner is validated before the event is published
* Necessary adjustments to the UI code

Testing is encouraged:) For example doing this during runtime:
* Adding and removing assets
* Removing and adding properties with scripting 
* Reorder, add, and remove layers
* Modify properties such as OptionProperty
* etc

Notes:
* There is a bug in the removal of layers from the UI that are not related to the changes made in this PR
* I removed some code in the UI in the DragDropLayerList. I watched the tutorial linked and in that he didn't use the refs that we had. The motivation seemed to be to prevent unnecessary re-renders but that does not seem to be a problem. The refs did however make it difficult to sync with Redux

Closes #3339, closes #3331, closes #3263, closes #1929