### PR TITLE
Lua Sandboxing

### DIFF
--- a/data/assets/global/localbookmarks.asset
+++ b/data/assets/global/localbookmarks.asset
@@ -13,15 +13,11 @@ end
 
 -- Create bookmarks file if it does not exist
 if not openspace.fileExists(localBookmarks) then
-  local file = io.open(localBookmarks, "w")
-  file:write(
-    "Group (optional),Name (required),Globe (optional),Lat (required if globe)," ..
-    "Lon (required if globe),Altitude (optional if globe),x (required if not globe)," ..
-    "y (required if not globe),z (required if not globe),Scale (optional)," ..
-    "LineWidth (optional)\n" ..
-    "NASA,Kennedy Space Center,Earth,28.6658276,-80.70282839,,,,,,\n"
+  openspace.downloadFile(
+    "http://liu-se.cdn.openspaceproject.com/files/misc/localbookmarks.csv",
+    openspace.absPath("${USER}/bookmarks/localbookmarks.csv"),
+    true
   )
-  file:close()
 end
 
 local nodes = bookmarkHelper.loadBookmarks(

--- a/data/assets/scene/milkyway/constellations/constellation_art.asset
+++ b/data/assets/scene/milkyway/constellations/constellation_art.asset
@@ -22,8 +22,6 @@ local data = asset.resource({
 --function that reads the file
 local function createConstellations(baseIdentifier, guiPath, constellationfile)
   local genConstellations = {}
-  --skip the first line
-  local notFirstLine = false
   -- define parsec to meters
   local PARSEC_CONSTANT = 3.0856776E16
   -- how many parsecs away do you want the images to be?
@@ -31,68 +29,74 @@ local function createConstellations(baseIdentifier, guiPath, constellationfile)
   -- but they can really be anywhere since the billboard size will scale with distance.
   local distanceMultiplier = 3.2
   local baseScale = 1e17
-  for line in io.lines(openspace.absPath(constellationfile)) do
-    if (notFirstLine) then
-      -- describes the data
-      local matchstring = "(.-),(.-),(.-),(.-),(.-),(.-),(.-),(.-),(.-),(.-),(.-),(.-)$"
-      local group, abbreviation, name, x, y, z, scale, imageName, rotX, rotY, rotZ, centerStar = line:match(matchstring)
-      local magVec = math.sqrt(x*x + y*y + z*z)
-      local normx = x / magVec
-      local normy = y / magVec
-      local normz = z / magVec
+  local lines = openspace.readCSVFile(openspace.absPath(constellationfile))
+  for _, line in ipairs(lines) do
+    -- describes the data
+    local group = line[1]
+    local abbreviation = line[2]
+    local name = line[3]
+    local x = tonumber(line[4])
+    local y = tonumber(line[5])
+    local z = tonumber(line[6])
+    local scale = tonumber(line[7])
+    local imageName = line[8]
+    local rotX = tonumber(line[9])
+    local rotY = tonumber(line[10])
+    local rotZ = tonumber(line[11])
+    local centerStar = line[12]
+    local magVec = math.sqrt(x*x + y*y + z*z)
+    local normx = x / magVec
+    local normy = y / magVec
+    local normz = z / magVec
 
-      -- Use the full name in the data constellations.dat if possible
-      -- Otherwise, use the given name in the constellation_data.csv file
-      local foundName = constellations_helper.findFullName(abbreviation)
-      if foundName ~= nil then
-        name = foundName
-      end
+    -- Use the full name in the data constellations.dat if possible
+    -- Otherwise, use the given name in the constellation_data.csv file
+    local foundName = constellations_helper.findFullName(abbreviation)
+    if foundName ~= nil then
+      name = foundName
+    end
 
-      group = (group == "" and globe or group)
+    group = (group == "" and globe or group)
 
-      local aconstellation = {
-        -- Identifier = guiPath .. "-" .. name,
-        Identifier = baseIdentifier .. "-" .. abbreviation,
-        Parent = transforms.SolarSystemBarycenter.Identifier,
-        Transform = {
-          Translation = {
-            Type = "StaticTranslation",
-            -- position is in parsecs from the SolarSystemBarycenter, so convert to meters
-            Position = {
-              normx * PARSEC_CONSTANT * distanceMultiplier,
-              normy * PARSEC_CONSTANT * distanceMultiplier,
-              normz * PARSEC_CONSTANT * distanceMultiplier
-            }
-          },
-          Rotation = {
-            Type = "StaticRotation",
-            Rotation = { tonumber(rotX), tonumber(rotY), tonumber(rotZ) }
+    local aconstellation = {
+      -- Identifier = guiPath .. "-" .. name,
+      Identifier = baseIdentifier .. "-" .. abbreviation,
+      Parent = transforms.SolarSystemBarycenter.Identifier,
+      Transform = {
+        Translation = {
+          Type = "StaticTranslation",
+          -- position is in parsecs from the SolarSystemBarycenter, so convert to meters
+          Position = {
+            normx * PARSEC_CONSTANT * distanceMultiplier,
+            normy * PARSEC_CONSTANT * distanceMultiplier,
+            normz * PARSEC_CONSTANT * distanceMultiplier
           }
         },
-        Renderable = {
-          Type = "RenderablePlaneImageLocal",
-          Enabled = false,
-          Size = tonumber(baseScale * scale * distanceMultiplier / 10),
-          Origin = "Center",
-          Billboard = false,
-          LazyLoading = true,
-          Texture = images .. imageName,
-          BlendMode = "Additive",
-          Opacity = 0.1,
-          DimInAtmosphere = true
-        },
-        Tag = { "ImageConstellation", group, "daytime_hidden" },
-        GUI = {
-          Name = name .. " Image",
-          Path = "/Milky Way/Constellations/" .. guiPath,
-          Description = name .. " Image"
+        Rotation = {
+          Type = "StaticRotation",
+          Rotation = { tonumber(rotX), tonumber(rotY), tonumber(rotZ) }
         }
+      },
+      Renderable = {
+        Type = "RenderablePlaneImageLocal",
+        Enabled = false,
+        Size = tonumber(baseScale * scale * distanceMultiplier / 10),
+        Origin = "Center",
+        Billboard = false,
+        LazyLoading = true,
+        Texture = images .. imageName,
+        BlendMode = "Additive",
+        Opacity = 0.1,
+        DimInAtmosphere = true
+      },
+      Tag = { "ImageConstellation", group, "daytime_hidden" },
+      GUI = {
+        Name = name .. " Image",
+        Path = "/Milky Way/Constellations/" .. guiPath,
+        Description = name .. " Image"
       }
-      table.insert(genConstellations, aconstellation)
-
-    else
-      notFirstLine = true
-    end
+    }
+    table.insert(genConstellations, aconstellation)
   end
   return genConstellations
 end

--- a/data/assets/util/constellations_helper.asset
+++ b/data/assets/util/constellations_helper.asset
@@ -11,14 +11,10 @@ local data = asset.resource({
 -- If the file does not exist or if a match could not be found, it returns nil
 local function findFullName(abbreviation)
   local namesFile = data .. "constellations.dat"
-  local file = io.open(namesFile, "r")
   local fullName = ""
 
-  if file == nil then
-    return nil
-  end
-
-  for line in io.lines(namesFile) do
+  local lines = openspace.readFileLines(namesFile)
+  for _, line in ipairs(lines) do
     -- Try and find the identifier in the file
     local index, length = line:find(abbreviation)
     if index ~= nil and index < 4 then
@@ -37,7 +33,6 @@ local function findFullName(abbreviation)
     end
   end
 
-  file:close()
   if fullName == "" then
     openspace.printError(
       "Error when calling function 'findFullName' in file 'util/constellations_helper': " ..

--- a/include/openspace/engine/configuration.h
+++ b/include/openspace/engine/configuration.h
@@ -105,6 +105,8 @@ struct Configuration {
 
     bool shouldUseScreenshotDate = false;
 
+    bool sandboxedLua = true;
+
     std::string onScreenTextScaling = "window";
     bool usePerProfileCache = false;
 

--- a/include/openspace/scripting/scriptengine.h
+++ b/include/openspace/scripting/scriptengine.h
@@ -62,7 +62,7 @@ public:
 
     static constexpr std::string_view OpenSpaceLibraryName = "openspace";
 
-    ScriptEngine();
+    explicit ScriptEngine(bool sandboxedLua = true);
 
     /**
      * Initializes the internal Lua state and registers a common set of library functions.

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -226,6 +226,8 @@ LogEachOpenGLCall = false
 PrintEvents = false
 ConsoleKey = "GRAVEACCENT"
 
+SandboxedLua = true
+
 ShutdownCountdown = 3
 ScreenshotUseDate = true
 BypassLauncher = false

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -394,6 +394,7 @@ void OpenSpaceEngine::initialize() {
         // we have to recreate it here.
         // @TODO (2024-08-07, abock) It's not pretty, but doing it differently would
         // require a bigger rewrite of how we handle the ScriptEngine
+        global::scriptEngine->~ScriptEngine();
         global::scriptEngine = new (global::scriptEngine) scripting::ScriptEngine(
             global::configuration->sandboxedLua
         );

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -389,6 +389,16 @@ void OpenSpaceEngine::initialize() {
     // Register the provided shader directories
     ghoul::opengl::ShaderPreprocessor::addIncludePath(absPath("${SHADERS}"));
 
+    if (!global::configuration->sandboxedLua) {
+        // The Lua state is sandboxed by default, so if the user wants an unsandboxed one,
+        // we have to recreate it here.
+        // @TODO (2024-08-07, abock) It's not pretty, but doing it differently would
+        // require a bigger rewrite of how we handle the ScriptEngine
+        global::scriptEngine = new (global::scriptEngine) scripting::ScriptEngine(
+            global::configuration->sandboxedLua
+        );
+    }
+
     // Register Lua script functions
     LDEBUG("Registering Lua libraries");
     registerCoreClasses(*global::scriptEngine);
@@ -906,7 +916,9 @@ void OpenSpaceEngine::runGlobalCustomizationScripts() {
     ZoneScoped;
 
     LINFO("Running Global initialization scripts");
-    const ghoul::lua::LuaState state;
+    const ghoul::lua::LuaState state = ghoul::lua::LuaState(
+        ghoul::lua::LuaState::Sandboxed::No
+    );
     global::scriptEngine->initializeLuaState(state);
 
     for (const std::string& script : global::configuration->globalCustomizationScripts) {

--- a/src/scripting/scriptengine.cpp
+++ b/src/scripting/scriptengine.cpp
@@ -88,7 +88,9 @@ namespace {
 
 namespace openspace::scripting {
 
-ScriptEngine::ScriptEngine() {}
+ScriptEngine::ScriptEngine(bool sandboxedLua)
+    : _state(ghoul::lua::LuaState::Sandboxed(sandboxedLua))
+{}
 
 void ScriptEngine::initialize() {
     ZoneScoped;

--- a/src/scripting/scriptengine.cpp
+++ b/src/scripting/scriptengine.cpp
@@ -80,9 +80,6 @@ namespace {
 
         return result;
     }
-
-
-
 #include "scriptengine_codegen.cpp"
 } // namespace
 


### PR DESCRIPTION
This change disables the `require` function in Lua and the `io`, `os`, and `package` tables in an effort to better secure our Lua interpreter against potentially malicious code. There is a new `openspace.cfg` setting `SandboxedLua` that toggles that behavior, with it being _enabled_ by default. 

This change required changing the constellation asset files as they previously relied on the `io` functions. This dependency has been replaced with OpenSpace-native functions instead.

To test in here is whether we have any asset files that no longer work as they require the use of any of the now-removed tables.  If that is the case, the assets need to be rewritten to use (potentially new) OpenSpace functions instead.