### PR TITLE
Add Esri Wayback layers

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback.asset
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback.asset
@@ -1,0 +1,155 @@
+local globe = asset.require("../../earth")
+
+
+
+local WaybackLayer20140220 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20140220",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20140220.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2014 FEB 20. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20150430 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20150430",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20150430.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2015 APR 30. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20160613 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20160613",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20160613.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2016 JUN 13. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20180108 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20180108",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20180108.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2018 JAN 08. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20180627 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20180627",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20180627.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2018 JUN 27. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20190626 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20190626",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20190626.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2019 JUN 26. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20200610 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20200610",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20200610.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2020 JUN 10. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20210408 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20210408",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20210408.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2021 APR 08. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20211221 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20211221",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20211221.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2021 DEC 21. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20221012 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20221012",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20221012.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2022 OCT 12. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20230613 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20230613",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20230613.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2023 JUN 13. https://livingatlas.arcgis.com/wayback]]
+}
+
+local WaybackLayer20231207 = {
+  Identifier = "ESRI_World_Imagery_Wayback_20231207",
+  ZIndex = 10,
+  FilePath = asset.resource("esri_world_imagery_wayback/20231207.wms"),
+  Description = [[The ESRI World Imagery dataset from the wayback feature showing the
+    Earth how it looked like in 2023 DEC 07. https://livingatlas.arcgis.com/wayback]]
+}
+
+
+
+asset.onInitialize(function()
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20140220)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20150430)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20160613)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20180108)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20180627)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20190626)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20200610)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20210408)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20211221)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20221012)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20230613)
+  openspace.globebrowsing.addLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20231207)
+end)
+
+asset.onDeinitialize(function()
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20231207)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20230613)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20221012)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20211221)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20210408)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20200610)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20190626)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20180627)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20180108)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20160613)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20150430)
+  openspace.globebrowsing.deleteLayer(globe.Earth.Identifier, "ColorLayers", WaybackLayer20140220)
+end)
+
+asset.export("layer20140220", WaybackLayer20140220)
+asset.export("layer20150430", WaybackLayer20150430)
+asset.export("layer20160613", WaybackLayer20160613)
+asset.export("layer20180108", WaybackLayer20180108)
+asset.export("layer20180627", WaybackLayer20180627)
+asset.export("layer20190626", WaybackLayer20190626)
+asset.export("layer20200610", WaybackLayer20200610)
+asset.export("layer20210408", WaybackLayer20210408)
+asset.export("layer20211221", WaybackLayer20211221)
+asset.export("layer20221012", WaybackLayer20221012)
+asset.export("layer20230613", WaybackLayer20230613)
+asset.export("layer20231207", WaybackLayer20231207)
+
+
+
+asset.meta = {
+  Name = "ESRI World Imagery Wayback machine",
+  Description = [[Access to the ESRI World Imagery Wayback machine layers ranging from
+    2014 to 2023]],
+  Author = "ESRI",
+  URL = "https://livingatlas.arcgis.com/wayback",
+  License = "Esri Master License Agreement"
+}

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/10/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback_10/tile/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback_10/tile/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/10/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/10/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20140220.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20150430.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20150430.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/23880/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20150430.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20150430.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/23880/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/23880/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20150430.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20150430.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20160613.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20160613.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/11509/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20160613.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20160613.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/11509/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/11509/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20160613.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20160613.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180108.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180108.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/13161/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180108.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180108.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180108.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180108.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/13161/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/13161/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180627.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180627.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/11334/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180627.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180627.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/11334/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/11334/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180627.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20180627.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20190626.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20190626.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/645/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/645/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20190626.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20190626.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/645/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20190626.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20190626.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20200610.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20200610.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/11135/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20200610.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20200610.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20200610.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20200610.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/11135/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/11135/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20210408.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20210408.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/6863/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/6863/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20210408.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20210408.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/6863/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20210408.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20210408.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20211221.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20211221.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/26120/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/26120/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20211221.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20211221.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/26120/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20211221.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20211221.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20221012.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20221012.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/44988/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/44988/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20221012.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20221012.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/44988/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20221012.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20221012.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20230613.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20230613.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/25982/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/25982/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20230613.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20230613.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20230613.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20230613.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/25982/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20231207.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20231207.wms
@@ -1,6 +1,6 @@
 <GDAL_WMS>
   <Service name="TMS">
-    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/56102/${z}/${y}/${x}</ServerUrl>
+    <ServerUrl>http://liu-se.wms.openspaceproject.com/Earth/Esri_Wayback/tile/56102/${z}/${y}/${x}</ServerUrl>
   </Service>
   <DataWindow>
     <UpperLeftX>-180.0</UpperLeftX>
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:3857</Projection>
+  <Projection>EPSG:4326</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20231207.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20231207.wms
@@ -1,0 +1,21 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/wmts/1.0.0/default028mm/MapServer/tile/56102/${z}/${y}/${x}</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-180.0</UpperLeftX>
+    <UpperLeftY>90</UpperLeftY>
+    <LowerRightX>180</LowerRightX>
+    <LowerRightY>-90</LowerRightY>
+    <TileLevel>19</TileLevel>
+    <TileCountX>2</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:4326</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <MaxConnections>5</MaxConnections>
+  <Timeout>5</Timeout>
+</GDAL_WMS>

--- a/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20231207.wms
+++ b/data/assets/scene/solarsystem/planets/earth/layers/colorlayers/esri_world_imagery_wayback/20231207.wms
@@ -12,7 +12,7 @@
     <TileCountY>1</TileCountY>
     <YOrigin>top</YOrigin>
   </DataWindow>
-  <Projection>EPSG:4326</Projection>
+  <Projection>EPSG:3857</Projection>
   <BlockSizeX>256</BlockSizeX>
   <BlockSizeY>256</BlockSizeY>
   <BandsCount>3</BandsCount>


### PR DESCRIPTION
Add new layers that show the state of the Earth World Imagery at different times (see https://livingatlas.arcgis.com/wayback/ for more information and license information).