### PR TITLE
update background and foreground colors in launcher

### DIFF
--- a/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
+++ b/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
@@ -36,10 +36,9 @@ LauncherWindow  QLabel#version-info {
 }
 
 LauncherWindow  QComboBox#config {
-  background: rgb(96, 96, 96);
-  border: 1px solid rgb(128, 128, 128);
-  border-radius: 3px;
-  border-color: rgb(225, 225, 225);
+  background: rgb(86, 86, 86);
+  border: 1px solid rgb(225, 225, 225);
+  border-radius: 2px;
   padding: 1px 18px 1px 3px;
   min-width: 14em;
   font-size: 10pt;
@@ -49,7 +48,7 @@ LauncherWindow  QComboBox#config {
 }
 
 LauncherWindow  QComboBox#config:hover {
-  background: rgb(120, 120, 120);
+  background: rgb(110, 110, 110);
 }
 
 LauncherWindow  QComboBox#config:disabled {
@@ -58,25 +57,23 @@ LauncherWindow  QComboBox#config:disabled {
 }
 
 LauncherWindow  QPushButton#large {
-  background: rgb(128, 128, 128);
+  background: rgb(96, 96, 96);
+  border: 2px solid rgb(225, 225, 225);
   border-radius: 2px;
   border-style: outset;
-  border-width: 2px;
-  border-color: rgb(225, 225, 225);
   font-size: 16pt;
   font-weight: bold;
-  color: rgb(239, 239, 239);
+  color: rgb(255, 255, 255);
 }
 LauncherWindow  QPushButton#large:hover {
-  background: rgb(150, 150, 150);
+  background: rgb(120, 120, 120);
 }
 
 LauncherWindow  QPushButton#small {
-  background: rgb(96, 96, 96);
+  background: rgb(86, 86, 86);
+  border: 1px solid rgb(225, 225, 225);
   border-radius: 2px;
   border-style: outset;
-  border-width: 1px;
-  border-color: rgb(225, 225, 225);
   min-height: 1em;
   font-size: 10pt;
   font-weight: bold;
@@ -84,12 +81,12 @@ LauncherWindow  QPushButton#small {
 }
 
 LauncherWindow  QPushButton#small:hover {
-  background: rgb(120, 120, 120);
+  background: rgb(110, 110, 110);
 }
 
 LauncherWindow  QPushButton#small:disabled {
-  color: rgb(180, 180, 180);
-  background: rgb(160, 160, 160);
+  background: rgb(204, 204, 204);
+  color: rgb(86, 86, 86);
 }
 
 LauncherWindow  QPushButton#settings {


### PR DESCRIPTION
Updated the font and background colors in the launcher so the contrasts are ok in terms of accessibility, fixes #3093 
Not too sure about the disabled edit button under the config we could go 

https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=&foreground-colors=%23FFFFFF%2C%20White%0D%0A%23F2F2F2%2C%20242%0D%0A%23DDDDDD%2C%20221%0D%0A%23CCCCCC%2C%20204%0D%0A%23A0A0A0%2C%20160%0D%0A%23888888%2C%20136%0D%0A%23808080%2C%20128%0D%0A%23787878%2C%20120%0D%0A%236E6E6E%2C%20110%0D%0A%236C6C6C%2C%20108%0D%0A%23606060%2C%2096%0D%0A%23565656%2C%2086%0D%0A%23404040%2C%20Charcoal%2C%2064%0D%0A%23000000%2C%20Black%0D%0A%232F78C5%2C%20Effective%20on%20Extremes%0D%0A%230F60B6%2C%20Effective%20on%20Lights%0D%0A%23398EEA%2C%20Ineffective%0D%0A&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18
New: ![newUI_launcher](https://github.com/user-attachments/assets/b620de3c-52ee-490e-9200-4f6203bcba78)

Prev: ![oldUI_launcher](https://github.com/user-attachments/assets/7fd31071-9a25-4279-89b0-f6b76461bec1)
