### PR TITLE
Fix, cleanup and simplify RenderableGlobe properties

### DIFF
--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -176,6 +176,13 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
+    constexpr openspace::properties::Property::PropertyInfo AmbientIntensityInfo = {
+        "AmbientIntensity",
+        "Ambient Intensity",
+        "The intensity factor for the ambient light used for light shading.",
+        openspace::properties::Property::Visibility::User
+    };
+
     constexpr openspace::properties::Property::PropertyInfo LightSourceNodeInfo = {
         "LightSourceNode",
         "Light Source",
@@ -253,13 +260,6 @@ namespace {
         openspace::properties::Property::Visibility::Developer
     };
 
-    constexpr openspace::properties::Property::PropertyInfo AmbientIntensityInfo = {
-        "AmbientIntensity",
-        "Ambient Intensity",
-        "The intensity factor for the ambient light used for light shading.",
-        openspace::properties::Property::Visibility::User
-    };
-
     constexpr openspace::properties::Property::PropertyInfo NActiveLayersInfo = {
         "NActiveLayers",
         "Number of active layers",
@@ -276,8 +276,23 @@ namespace {
         // [[codegen::verbatim(PerformShadingInfo.description)]]
         std::optional<bool> performShading;
 
+        // [[codegen::verbatim(AccurateNormalsInfo.description)]]
+        std::optional<bool> useAccurateNormals;
+
+        // [[codegen::verbatim(AmbientIntensityInfo.description)]]
+        std::optional<double> ambientIntensity;
+
+        // [[codegen::verbatim(LightSourceNodeInfo.description)]]
+        std::optional<std::string> lightSourceNode;
+
         // [[codegen::verbatim(RenderAtDistanceInfo.description)]]
         std::optional<bool> renderAtDistance;
+
+        // [[codegen::verbatim(TargetLodScaleFactorInfo.description)]]
+        std::optional<double> targetLodScaleFactor;
+
+        // [[codegen::verbatim(OrenNayarRoughnessInfo.description)]]
+        std::optional<double> orenNayarRoughness;
 
         // A list of layers that should be added to the globe.
         std::optional<std::map<std::string, ghoul::Dictionary>> layers
@@ -314,9 +329,6 @@ namespace {
 
         std::optional<ghoul::Dictionary> shadows
             [[codegen::reference("globebrowsing_shadows_component")]];
-
-        // [[codegen::verbatim(LightSourceNodeInfo.description)]]
-        std::optional<std::string> lightSourceNode;
     };
 #include "renderableglobe_codegen.cpp"
 } // namespace
@@ -640,13 +652,13 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     _performShading = p.performShading.value_or(_performShading);
     addProperty(_performShading);
 
-    // TODO: Missing value from parameters
+    _useAccurateNormals = p.useAccurateNormals.value_or(_useAccurateNormals);
     addProperty(_useAccurateNormals);
 
     _renderAtDistance = p.renderAtDistance.value_or(_renderAtDistance);
     addProperty(_renderAtDistance);
 
-    // TODO: Missing value from parameters
+    _ambientIntensity = p.ambientIntensity.value_or(_ambientIntensity);
     addProperty(_ambientIntensity);
 
     _lightSourceNodeName.onChange([this]() {
@@ -694,7 +706,7 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     });
     addPropertySubOwner(_shadowMappingPropertyOwner);
 
-    // TODO: Missing value from parameters
+    _targetLodScaleFactor = p.targetLodScaleFactor.value_or(_targetLodScaleFactor);
     _targetLodScaleFactor.onChange([this]() {
         const float sf = _targetLodScaleFactor;
         _currentLodScaleFactor = sf;
@@ -703,7 +715,7 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     addProperty(_targetLodScaleFactor);
     addProperty(_currentLodScaleFactor);
 
-    // TODO: Missing value from parameters
+    _orenNayarRoughness = p.orenNayarRoughness.value_or(_orenNayarRoughness);
     addProperty(_orenNayarRoughness);
 
     _nActiveLayers.setReadOnly(true);

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -570,6 +570,11 @@ documentation::Documentation RenderableGlobe::Documentation() {
 
 RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     : Renderable(dictionary)
+    , _debugPropertyOwner({ "Debug" })
+    , _shadowMappingPropertyOwner({ "ShadowMapping", "Shadow Mapping"})
+    , _grid(DefaultSkirtedGridSegments, DefaultSkirtedGridSegments)
+    , _leftRoot(Chunk(LeftHemisphereIndex))
+    , _rightRoot(Chunk(RightHemisphereIndex))
     , _debugProperties({
         BoolProperty(ShowChunkEdgeInfo, false),
         BoolProperty(LevelProjectedAreaInfo, true),
@@ -578,31 +583,26 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
         IntProperty(ModelSpaceRenderingInfo, 14, 1, 22),
         IntProperty(DynamicLodIterationCountInfo, 16, 4, 128)
     })
-    , _generalProperties({
-        BoolProperty(PerformShadingInfo, true),
-        BoolProperty(AccurateNormalsInfo, false),
-        BoolProperty(EclipseInfo, false),
-        BoolProperty(EclipseHardShadowsInfo, false),
+    , _shadowMappingProperties({
         BoolProperty(ShadowMappingInfo, false),
-        BoolProperty(RenderAtDistanceInfo, false),
         FloatProperty(ZFightingPercentageInfo, 0.995f, 0.000001f, 1.f),
-        IntProperty(NumberShadowSamplesInfo, 5, 1, 7),
-        FloatProperty(TargetLodScaleFactorInfo, 15.f, 1.f, 50.f),
-        FloatProperty(CurrentLodScaleFactorInfo, 15.f, 1.f, 50.f),
-        FloatProperty(OrenNayarRoughnessInfo, 0.f, 0.f, 1.f),
-        FloatProperty(AmbientIntensityInfo, 0.05f, 0.f, 1.f),
-        IntProperty(NActiveLayersInfo, 0, 0, OpenGLCap.maxTextureUnits() / 3)
+        IntProperty(NumberShadowSamplesInfo, 5, 1, 7)
     })
-    , _debugPropertyOwner({ "Debug" })
-    , _shadowMappingPropertyOwner({ "ShadowMapping" })
-    , _grid(DefaultSkirtedGridSegments, DefaultSkirtedGridSegments)
-    , _leftRoot(Chunk(LeftHemisphereIndex))
-    , _rightRoot(Chunk(RightHemisphereIndex))
+    , _performShading(PerformShadingInfo, true)
+    , _useAccurateNormals(AccurateNormalsInfo, false)
+    , _ambientIntensity(AmbientIntensityInfo, 0.05f, 0.f, 1.f)
     , _lightSourceNodeName(LightSourceNodeInfo)
+    , _renderAtDistance(RenderAtDistanceInfo, false)
+    , _eclipseShadowsEnabled(EclipseInfo, false)
+    , _eclipseHardShadows(EclipseHardShadowsInfo, false)
+    , _targetLodScaleFactor(TargetLodScaleFactorInfo, 15.f, 1.f, 50.f)
+    , _currentLodScaleFactor(CurrentLodScaleFactorInfo, 15.f, 1.f, 50.f)
+    , _orenNayarRoughness(OrenNayarRoughnessInfo, 0.f, 0.f, 1.f)
+    , _nActiveLayers(NActiveLayersInfo, 0, 0, OpenGLCap.maxTextureUnits() / 3)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
 
-    _generalProperties.currentLodScaleFactor.setReadOnly(true);
+    _currentLodScaleFactor.setReadOnly(true);
 
     // Read the radii in to its own dictionary
     if (p.radii.has_value()) {
@@ -623,11 +623,11 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     // For globes, the interaction sphere is always the same as the bounding sphere
     setInteractionSphere(boundingSphere());
 
-    _generalProperties.performShading =
-        p.performShading.value_or(_generalProperties.performShading);
+    _performShading =
+        p.performShading.value_or(_performShading);
 
-    _generalProperties.renderAtDistance =
-        p.renderAtDistance.value_or(_generalProperties.renderAtDistance);
+    _renderAtDistance =
+        p.renderAtDistance.value_or(_renderAtDistance);
 
     // Init layer manager
     // @TODO (abock, 2021-03-25) The layermanager should be changed to take a
@@ -642,9 +642,10 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     }
 
     addProperty(Fadeable::_opacity);
-    addProperty(_generalProperties.performShading);
-    addProperty(_generalProperties.useAccurateNormals);
-    addProperty(_generalProperties.renderAtDistance);
+    addProperty(_performShading);
+    addProperty(_useAccurateNormals);
+    addProperty(_renderAtDistance);
+    addProperty(_ambientIntensity);
 
     _lightSourceNodeName.onChange([this]() {
         if (_lightSourceNodeName.value().empty()) {
@@ -678,29 +679,28 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
         }
         _ellipsoid.setShadowConfigurationArray(shadowConfArray);
 
-        addProperty(_generalProperties.eclipseShadowsEnabled);
-        addProperty(_generalProperties.eclipseHardShadows);
+        addProperty(_eclipseShadowsEnabled);
+        addProperty(_eclipseHardShadows);
     }
 
-    _shadowMappingPropertyOwner.addProperty(_generalProperties.shadowMapping);
-    _shadowMappingPropertyOwner.addProperty(_generalProperties.zFightingPercentage);
-    _shadowMappingPropertyOwner.addProperty(_generalProperties.nShadowSamples);
-    _generalProperties.nShadowSamples.onChange([this]() {
+    _shadowMappingPropertyOwner.addProperty(_shadowMappingProperties.shadowMapping);
+    _shadowMappingPropertyOwner.addProperty(_shadowMappingProperties.zFightingPercentage);
+    _shadowMappingPropertyOwner.addProperty(_shadowMappingProperties.nShadowSamples);
+    _shadowMappingProperties.nShadowSamples.onChange([this]() {
         _shadersNeedRecompilation = true;
     });
     addPropertySubOwner(_shadowMappingPropertyOwner);
 
-    _generalProperties.targetLodScaleFactor.onChange([this]() {
-        const float sf = _generalProperties.targetLodScaleFactor;
-        _generalProperties.currentLodScaleFactor = sf;
+    _targetLodScaleFactor.onChange([this]() {
+        const float sf = _targetLodScaleFactor;
+        _currentLodScaleFactor = sf;
         _lodScaleFactorDirty = true;
     });
-    addProperty(_generalProperties.targetLodScaleFactor);
-    addProperty(_generalProperties.currentLodScaleFactor);
-    addProperty(_generalProperties.orenNayarRoughness);
-    addProperty(_generalProperties.ambientIntensity);
-    _generalProperties.nActiveLayers.setReadOnly(true);
-    addProperty(_generalProperties.nActiveLayers);
+    addProperty(_targetLodScaleFactor);
+    addProperty(_currentLodScaleFactor);
+    addProperty(_orenNayarRoughness);
+    _nActiveLayers.setReadOnly(true);
+    addProperty(_nActiveLayers);
 
     _debugPropertyOwner.addProperty(_debugProperties.showChunkEdges);
     _debugPropertyOwner.addProperty(_debugProperties.levelByProjectedAreaElseDistance);
@@ -712,10 +712,10 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
     auto notifyShaderRecompilation = [this]() {
         _shadersNeedRecompilation = true;
     };
-    _generalProperties.useAccurateNormals.onChange(notifyShaderRecompilation);
-    _generalProperties.eclipseShadowsEnabled.onChange(notifyShaderRecompilation);
-    _generalProperties.eclipseHardShadows.onChange(notifyShaderRecompilation);
-    _generalProperties.performShading.onChange(notifyShaderRecompilation);
+    _useAccurateNormals.onChange(notifyShaderRecompilation);
+    _eclipseShadowsEnabled.onChange(notifyShaderRecompilation);
+    _eclipseHardShadows.onChange(notifyShaderRecompilation);
+    _performShading.onChange(notifyShaderRecompilation);
     _debugProperties.showChunkEdges.onChange(notifyShaderRecompilation);
 
     _layerManager.onChange([this](Layer* l) {
@@ -750,9 +750,9 @@ RenderableGlobe::RenderableGlobe(const ghoul::Dictionary& dictionary)
         _shadowComponent = std::make_unique<ShadowComponent>(dictionary);
         _shadowComponent->initialize();
         addPropertySubOwner(_shadowComponent.get());
-        _generalProperties.shadowMapping = true;
+        _shadowMappingProperties.shadowMapping = true;
     }
-    _generalProperties.shadowMapping.onChange(notifyShaderRecompilation);
+    _shadowMappingProperties.shadowMapping.onChange(notifyShaderRecompilation);
 
     // Use a secondary renderbin for labels, and other things that we want to be able to
     // render with transparency, on top of the globe, after the atmosphere step
@@ -831,7 +831,7 @@ void RenderableGlobe::render(const RenderData& data, RendererTasks& rendererTask
     constexpr int res = 2880;
     const double distance = res * boundingSphere() / tfov;
 
-    if ((distanceToCamera < distance) || (_generalProperties.renderAtDistance)) {
+    if ((distanceToCamera < distance) || (_renderAtDistance)) {
         try {
             if (_shadowComponent && _shadowComponent->isEnabled()) {
                 // Set matrices and other GL states
@@ -1055,7 +1055,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
     if (_nLayersIsDirty) {
         std::array<LayerGroup*, LayerManager::NumLayerGroups> lgs =
             _layerManager.layerGroups();
-        _generalProperties.nActiveLayers = std::accumulate(
+        _nActiveLayers = std::accumulate(
             lgs.begin(),
             lgs.end(),
             0,
@@ -1076,7 +1076,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
     if (_layerManager.hasAnyBlendingLayersEnabled()) {
         if (_lodScaleFactorDirty) {
             const float dsf = static_cast<float>(
-                _generalProperties.currentLodScaleFactor * _ellipsoid.minimumRadius()
+                _currentLodScaleFactor * _ellipsoid.minimumRadius()
             );
 
             // We are setting the setIgnoreUniformLocationError as it is not super trivial
@@ -1098,12 +1098,12 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
         }
     }
 
-    if (_generalProperties.performShading) {
-        const float onr = _generalProperties.orenNayarRoughness;
+    if (_performShading) {
+        const float onr = _orenNayarRoughness;
         _localRenderer.program->setUniform("orenNayarRoughness", onr);
         _globalRenderer.program->setUniform("orenNayarRoughness", onr);
 
-        const float amb = _generalProperties.ambientIntensity;
+        const float amb = _ambientIntensity;
         _localRenderer.program->setUniform("ambientIntensity", amb);
         _globalRenderer.program->setUniform("ambientIntensity", amb);
     }
@@ -1124,7 +1124,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
         }
 
         const float dsf = static_cast<float>(
-            _generalProperties.currentLodScaleFactor * _ellipsoid.minimumRadius()
+            _currentLodScaleFactor * _ellipsoid.minimumRadius()
         );
         using IgnoreError = ghoul::opengl::ProgramObject::IgnoreError;
         _globalRenderer.program->setIgnoreUniformLocationError(IgnoreError::Yes);
@@ -1146,7 +1146,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
         }
 
         const float dsf = static_cast<float>(
-            _generalProperties.currentLodScaleFactor * _ellipsoid.minimumRadius()
+            _currentLodScaleFactor * _ellipsoid.minimumRadius()
         );
         using IgnoreError = ghoul::opengl::ProgramObject::IgnoreError;
         _localRenderer.program->setIgnoreUniformLocationError(IgnoreError::Yes);
@@ -1200,7 +1200,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
 
     const bool hasHeightLayer =
         !_layerManager.layerGroup(layers::Group::ID::HeightLayers).activeLayers().empty();
-    if (_generalProperties.useAccurateNormals && hasHeightLayer) {
+    if (_useAccurateNormals && hasHeightLayer) {
         // Apply an extra scaling to the height if the object is scaled
         _globalRenderer.program->setUniform(
             "heightScale",
@@ -1216,7 +1216,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
     const bool waterLayersActive =
         !_layerManager.layerGroup(Group::ID::WaterMasks).activeLayers().empty();
 
-    if (nightLayersActive || waterLayersActive || _generalProperties.performShading) {
+    if (nightLayersActive || waterLayersActive || _performShading) {
         const glm::dvec3 directionToSunWorldSpace =
             directionToLightSource(data.modelTransform.translation, _lightSourceNode);
 
@@ -1242,7 +1242,7 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
         data.camera.sgctInternal.projectionMatrix()
     );
 
-    if (nightLayersActive || waterLayersActive || _generalProperties.performShading) {
+    if (nightLayersActive || waterLayersActive || _performShading) {
         const glm::dvec3 directionToSunWorldSpace =
             directionToLightSource(data.modelTransform.translation, _lightSourceNode);
 
@@ -1343,21 +1343,21 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
         const int iterCount = _debugProperties.dynamicLodIterationCount;
         const bool exceededIterations =
             static_cast<int>(_iterationsOfUnavailableData) > iterCount;
-        const float clf = _generalProperties.currentLodScaleFactor;
-        const float clfMin = _generalProperties.currentLodScaleFactor.minValue();
-        const float targetLod = _generalProperties.targetLodScaleFactor;
+        const float clf = _currentLodScaleFactor;
+        const float clfMin = _currentLodScaleFactor.minValue();
+        const float targetLod = _targetLodScaleFactor;
         const bool validLodFactor = clf > clfMin;
         if (exceededIterations && validLodFactor) {
-            _generalProperties.currentLodScaleFactor =
-                _generalProperties.currentLodScaleFactor - 0.1f;
+            _currentLodScaleFactor =
+                _currentLodScaleFactor - 0.1f;
             _iterationsOfUnavailableData = 0;
             _lodScaleFactorDirty = true;
         } // Make 2 times the iterations with available data to move it up again
         else if (static_cast<int>(_iterationsOfAvailableData) >
             (iterCount * 2) && clf < targetLod)
         {
-            _generalProperties.currentLodScaleFactor =
-                _generalProperties.currentLodScaleFactor + 0.1f;
+            _currentLodScaleFactor =
+                _currentLodScaleFactor + 0.1f;
             _iterationsOfAvailableData = 0;
             _lodScaleFactorDirty = true;
         }
@@ -1410,7 +1410,7 @@ void RenderableGlobe::renderChunkGlobally(const Chunk& chunk, const RenderData& 
 
     setCommonUniforms(program, chunk, data);
 
-    if (_generalProperties.eclipseShadowsEnabled &&
+    if (_eclipseShadowsEnabled &&
         !_ellipsoid.shadowConfigurationArray().empty())
     {
         calculateEclipseShadows(program, data, ShadowCompType::GLOBAL_SHADOW);
@@ -1418,7 +1418,7 @@ void RenderableGlobe::renderChunkGlobally(const Chunk& chunk, const RenderData& 
 
     // Shadow Mapping
     ghoul::opengl::TextureUnit shadowMapUnit;
-    if (_generalProperties.shadowMapping && shadowData.shadowDepthTexture != 0) {
+    if (_shadowMappingProperties.shadowMapping && shadowData.shadowDepthTexture != 0) {
         // Adding the model transformation to the final shadow matrix so we have a
         // complete transformation from the model coordinates to the clip space of the
         // light position.
@@ -1431,9 +1431,12 @@ void RenderableGlobe::renderChunkGlobally(const Chunk& chunk, const RenderData& 
         glBindTexture(GL_TEXTURE_2D, shadowData.shadowDepthTexture);
 
         program.setUniform("shadowMapTexture", shadowMapUnit);
-        program.setUniform("zFightingPercentage", _generalProperties.zFightingPercentage);
+        program.setUniform(
+            "zFightingPercentage",
+            _shadowMappingProperties.zFightingPercentage
+        );
     }
-    else if (_generalProperties.shadowMapping) {
+    else if (_shadowMappingProperties.shadowMapping) {
         shadowMapUnit.activate();
         // JCC: Avoiding a to recompiling the shaders or having more than one
         // set of shaders for this step.
@@ -1549,7 +1552,7 @@ void RenderableGlobe::renderChunkLocally(const Chunk& chunk, const RenderData& d
 
     setCommonUniforms(program, chunk, data);
 
-    if (_generalProperties.eclipseShadowsEnabled &&
+    if (_eclipseShadowsEnabled &&
         !_ellipsoid.shadowConfigurationArray().empty())
     {
         calculateEclipseShadows(program, data, ShadowCompType::LOCAL_SHADOW);
@@ -1557,7 +1560,7 @@ void RenderableGlobe::renderChunkLocally(const Chunk& chunk, const RenderData& d
 
     // Shadow Mapping
     ghoul::opengl::TextureUnit shadowMapUnit;
-    if (_generalProperties.shadowMapping && shadowData.shadowDepthTexture != 0) {
+    if (_shadowMappingProperties.shadowMapping && shadowData.shadowDepthTexture != 0) {
         // Adding the model transformation to the final shadow matrix so we have a
         // complete transformation from the model coordinates to the clip space of the
         // light position.
@@ -1570,9 +1573,12 @@ void RenderableGlobe::renderChunkLocally(const Chunk& chunk, const RenderData& d
         glBindTexture(GL_TEXTURE_2D, shadowData.shadowDepthTexture);
 
         program.setUniform("shadowMapTexture", shadowMapUnit);
-        program.setUniform("zFightingPercentage", _generalProperties.zFightingPercentage);
+        program.setUniform(
+            "zFightingPercentage",
+            _shadowMappingProperties.zFightingPercentage
+        );
     }
-    else if (_generalProperties.shadowMapping) {
+    else if (_shadowMappingProperties.shadowMapping) {
         shadowMapUnit.activate();
         // JCC: Avoiding a to recompiling the shaders or having more than one
         // set of shaders for this step.
@@ -1636,7 +1642,7 @@ void RenderableGlobe::setCommonUniforms(ghoul::opengl::ProgramObject& programObj
 
     ZoneScoped;
 
-    if (_generalProperties.useAccurateNormals &&
+    if (_useAccurateNormals &&
         !_layerManager.layerGroup(Group::ID::HeightLayers).activeLayers().empty())
     {
         const glm::dvec3 corner00 = _ellipsoid.cartesianSurfacePosition(
@@ -1738,23 +1744,23 @@ void RenderableGlobe::recompileShaders() {
         !_layerManager.layerGroup(layers::Group::ID::HeightLayers).activeLayers().empty();
 
     pairs.emplace_back("useAccurateNormals",
-        std::to_string(_generalProperties.useAccurateNormals && hasHeightLayer)
+        std::to_string(_useAccurateNormals && hasHeightLayer)
     );
     pairs.emplace_back(
         "performShading",
-        std::to_string(_generalProperties.performShading)
+        std::to_string(_performShading)
     );
     pairs.emplace_back(
         "useEclipseShadows",
-        std::to_string(_generalProperties.eclipseShadowsEnabled)
+        std::to_string(_eclipseShadowsEnabled)
     );
     pairs.emplace_back(
         "useEclipseHardShadows",
-        std::to_string(_generalProperties.eclipseHardShadows)
+        std::to_string(_eclipseHardShadows)
     );
     pairs.emplace_back(
         "enableShadowMapping",
-        std::to_string(_generalProperties.shadowMapping)
+        std::to_string(_shadowMappingProperties.shadowMapping)
     );
     pairs.emplace_back("showChunkEdges", std::to_string(_debugProperties.showChunkEdges));
     pairs.emplace_back("showHeightResolution", "0");
@@ -1850,7 +1856,10 @@ void RenderableGlobe::recompileShaders() {
     }
 
     // Shadow Mapping Samples
-    shaderDictionary.setValue("nShadowSamples", _generalProperties.nShadowSamples - 1);
+    shaderDictionary.setValue(
+        "nShadowSamples",
+        _shadowMappingProperties.nShadowSamples - 1
+    );
 
     // Exclise Shadow Samples
     const int nEclipseShadows = static_cast<int>(
@@ -2274,7 +2283,7 @@ void RenderableGlobe::calculateEclipseShadows(ghoul::opengl::ProgramObject& prog
     // JCC: Removed in favor of: #define USE_ECLIPSE_HARD_SHADOWS #{useEclipseHardShadows}
     /*programObject.setUniform(
         "hardShadows",
-        _generalProperties.eclipseHardShadows
+        _eclipseHardShadows
     );*/
     //programObject.setUniform("calculateEclipseShadows", true);
 }
@@ -2312,7 +2321,7 @@ int RenderableGlobe::desiredLevelByDistance(const Chunk& chunk,
     const double distanceToPatch = glm::length(cameraToChunk);
     const double distance = distanceToPatch;
 
-    const double scaleFactor = _generalProperties.currentLodScaleFactor *
+    const double scaleFactor = _currentLodScaleFactor *
         _ellipsoid.minimumRadius();
     const double projectedScaleFactor = scaleFactor / distance;
     const int desiredLevel = static_cast<int>(ceil(log2(projectedScaleFactor)));
@@ -2399,7 +2408,7 @@ int RenderableGlobe::desiredLevelByProjectedArea(const Chunk& chunk,
     const double areaABC = 0.5 * glm::length(glm::cross(AC, AB));
     const double projectedChunkAreaApprox = 8 * areaABC;
 
-    const double scaledArea = _generalProperties.currentLodScaleFactor *
+    const double scaledArea = _currentLodScaleFactor *
                               projectedChunkAreaApprox;
     return chunk.tileIndex.level + static_cast<int>(round(scaledArea - 1));
 }

--- a/modules/globebrowsing/src/renderableglobe.h
+++ b/modules/globebrowsing/src/renderableglobe.h
@@ -128,38 +128,6 @@ public:
     static documentation::Documentation Documentation();
 
 private:
-    static constexpr int MinSplitDepth = 2;
-    static constexpr int MaxSplitDepth = 22;
-
-    struct {
-        properties::BoolProperty showChunkEdges;
-        properties::BoolProperty levelByProjectedAreaElseDistance;
-        properties::BoolProperty resetTileProviders;
-        properties::BoolProperty performFrustumCulling;
-        properties::IntProperty  modelSpaceRenderingCutoffLevel;
-        properties::IntProperty  dynamicLodIterationCount;
-    } _debugProperties;
-
-    struct {
-        properties::BoolProperty  performShading;
-        properties::BoolProperty  useAccurateNormals;
-        properties::BoolProperty  eclipseShadowsEnabled;
-        properties::BoolProperty  eclipseHardShadows;
-        properties::BoolProperty  shadowMapping;
-        properties::BoolProperty  renderAtDistance;
-        properties::FloatProperty zFightingPercentage;
-        properties::IntProperty   nShadowSamples;
-        properties::FloatProperty targetLodScaleFactor;
-        properties::FloatProperty currentLodScaleFactor;
-        properties::FloatProperty orenNayarRoughness;
-        properties::FloatProperty ambientIntensity;
-        properties::IntProperty   nActiveLayers;
-    } _generalProperties;
-
-    properties::PropertyOwner _debugPropertyOwner;
-
-    properties::PropertyOwner _shadowMappingPropertyOwner;
-
     /**
      * Test if a specific chunk can safely be culled without affecting the rendered image.
      *
@@ -245,15 +213,48 @@ private:
     void setCommonUniforms(ghoul::opengl::ProgramObject& programObject,
         const Chunk& chunk, const RenderData& data);
 
-
     void recompileShaders();
-
 
     void splitChunkNode(Chunk& cn, int depth);
     void mergeChunkNode(Chunk& cn);
     bool updateChunkTree(Chunk& cn, const RenderData& data, const glm::dmat4& mvp);
     void updateChunk(Chunk& chunk, const RenderData& data, const glm::dmat4& mvp) const;
     void freeChunkNode(Chunk* n);
+
+    static constexpr int MinSplitDepth = 2;
+    static constexpr int MaxSplitDepth = 22;
+
+    properties::BoolProperty _performShading;
+    properties::BoolProperty _useAccurateNormals;
+    properties::FloatProperty _ambientIntensity;
+    properties::StringProperty _lightSourceNodeName;
+
+    properties::BoolProperty _renderAtDistance;
+    properties::BoolProperty _eclipseShadowsEnabled;
+    properties::BoolProperty _eclipseHardShadows;
+    properties::FloatProperty _targetLodScaleFactor;
+    properties::FloatProperty _currentLodScaleFactor;
+    properties::FloatProperty _orenNayarRoughness;
+    properties::IntProperty _nActiveLayers;
+
+    struct {
+        properties::BoolProperty showChunkEdges;
+        properties::BoolProperty levelByProjectedAreaElseDistance;
+        properties::BoolProperty resetTileProviders;
+        properties::BoolProperty performFrustumCulling;
+        properties::IntProperty  modelSpaceRenderingCutoffLevel;
+        properties::IntProperty  dynamicLodIterationCount;
+    } _debugProperties;
+
+    properties::PropertyOwner _debugPropertyOwner;
+
+    struct {
+        properties::BoolProperty shadowMapping;
+        properties::FloatProperty zFightingPercentage;
+        properties::IntProperty nShadowSamples;
+    } _shadowMappingProperties;
+
+    properties::PropertyOwner _shadowMappingPropertyOwner;
 
     Ellipsoid _ellipsoid;
     SkirtedGrid _grid;
@@ -269,7 +270,6 @@ private:
     std::vector<const Chunk*> _globalChunkBuffer;
     std::vector<const Chunk*> _localChunkBuffer;
     std::vector<const Chunk*> _traversalMemory;
-
 
     Chunk _leftRoot;  // Covers all negative longitudes
     Chunk _rightRoot; // Covers all positive longitudes
@@ -293,7 +293,6 @@ private:
     } _localRenderer;
 
     SceneGraphNode* _lightSourceNode = nullptr;
-    properties::StringProperty _lightSourceNodeName;
 
     bool _shadersNeedRecompilation = true;
     bool _lodScaleFactorDirty = true;


### PR DESCRIPTION
Some properties could not be set through an asset or script: 
-  useAccurateNormals
-  ambientIntensity
-  targetLodScaleFactor
- orenNayarRoughness

This is now fixed. 
 
 Otherwise, this PR removes the "general properties" struct (which to me was confusing and made the code harder to read) and replaces it with just regular properties and a new group for properties that below to the shadow mapping propertyowner. 