### PR TITLE
Give exoplanets a color based on their size

### DIFF
--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -335,24 +335,12 @@ void createExoplanetSystem(const std::string& starName,
         "}";
 
         std::string planetLayers = "";
-        if (!planetTexture.empty()) {
-            planetLayers = "{"
-                "Identifier = 'PlanetTexture',"
-                "FilePath = openspace.absPath('" + formatPathToLua(planetTexture) + "'),"
-                "BlendMode = 'Color',"
-                "Enabled = true"
-            "}";
-        }
 
         // Add a color layer with a fixed single color that represent the planet size,
         // that is, approximately what type of planet it is.
-        // @TODO (2024-09-10, emmbr) this should be a color map to use based on radius
-        // that can be set by the user. But, to do that it would be nice to have an
-        // updated transfer function / color map format that suppotrs categorical color
-        // mapping based on thresholds in a better way.
+        // @TODO (2024-09-10, emmbr) Ideally the user should be able to edit this
         if (!std::isnan(planet.r)) {
             float rInMeter = static_cast<float>(planetRadius);
-
             glm::vec3 colorFromSize = glm::vec3(0.f);
 
             // Source for the radius constants:
@@ -375,17 +363,22 @@ void createExoplanetSystem(const std::string& starName,
                 colorFromSize = glm::vec3(0.55f, 0.34f, 0.39f);
             }
 
-            if (!planetLayers.empty()) {
-                planetLayers += ",";
-            }
             planetLayers += "{"
                 "Identifier = 'ColorFromSize',"
                 "Type = 'SolidColor',"
                 "Color = " + ghoul::to_string(colorFromSize) + ","
-                "BlendMode = 'Normal',"
                 "Enabled = true"
             "}";
         }
+
+        if (!planetTexture.empty()) {
+            planetLayers += ",{"
+                "Identifier = 'PlanetTexture',"
+                "FilePath = openspace.absPath('" + formatPathToLua(planetTexture) + "'),"
+                "Enabled = true"
+            "}";
+        }
+
         // @TODO: This needs to be documented somewhere. Layer description?
 
         const std::string planetNode = "{"

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -200,6 +200,25 @@ void createExoplanetSystem(const std::string& starName,
             "}";
     }
 
+    // @TODO (2024-09-16, emmbr) Compose a more extensive summary of the system,
+    // based on more data in the archive (like number of stars) and the plantes.
+    // Also include more data on the star itself (like spectral type)
+    float distanceToOurSystem = glm::length(starPosInParsec) *
+        distanceconstants::Parsec / distanceconstants::LightYear;
+
+    size_t nPlanets = system.planetNames.size();
+    const std::string starDescription = std::format(
+        "The star {} is the host star of an exoplanet system with {} {} that {}  "
+        "enough data to be visualized. It has a size of {:.2f} Solar radii and an "
+        "effective temperature of {:.0f} Kelvin. The system is located at a "
+        "distance of {:.0f} Light years from Earth.",
+        sanitizedStarName, nPlanets,
+        nPlanets > 1 ? "planets" : "planet",
+        nPlanets > 1 ? "have" : "has",
+        radiusInMeter / distanceconstants::SolarRadius,
+        system.starData.teff, distanceToOurSystem
+    );
+
     const std::string starGlobeRenderableString = "Renderable = {"
         "Type = 'RenderableGlobe',"
         "Radii = " + std::to_string(radiusInMeter) + ","
@@ -226,7 +245,8 @@ void createExoplanetSystem(const std::string& starName,
         "Tag = {'exoplanet_system'},"
         "GUI = {"
             "Name = '" + sanitizedStarName + " (Star)',"
-            "Path = '" + guiPath + "'"
+            "Path = '" + guiPath + "',"
+            "Description = \"" +starDescription + "\""
         "}"
     "}";
 
@@ -418,7 +438,7 @@ void createExoplanetSystem(const std::string& starName,
             "}";
         }
 
-        std::string planetDescription = std::format(
+        const std::string planetDescription = std::format(
             "The exoplanet {} falls into the category of {}. Some key facts: "
             "Radius: {:.2f} Earth radii, {:.2f} Jupiter radii. "
             "Orbit Period: {:.1f} (Earth) days. "
@@ -528,7 +548,11 @@ void createExoplanetSystem(const std::string& starName,
                 "Tag = {'exoplanet_uncertainty_disc'},"
                 "GUI = {"
                     "Name = '" + planetName + " Disc',"
-                    "Path = '" + guiPath + "'"
+                    "Path = '" + guiPath + "',"
+                    "Description = \"The width of this disc around the planet's orbit "
+                        "marks the uncertainty of the orbit (based on the uncertainty of "
+                        "the semi-major axis and eccentricity measures). The wider the "
+                        "disc, the more uncertain the orbit is.\""
                 "}"
             "}";
 
@@ -572,7 +596,9 @@ void createExoplanetSystem(const std::string& starName,
         "Tag = {'exoplanet_1au_ring'},"
         "GUI = {"
             "Name = '1 AU Size Comparison Circle',"
-            "Path = '" + guiPath + "'"
+            "Path = '" + guiPath + "',"
+            "Description = \"A circe with a radius of 1 Astronomical Unit. That is, its "
+                "size corresponds to the size of Earth's orbit.\""
         "}"
     "}";
 

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -209,9 +209,9 @@ void createExoplanetSystem(const std::string& starName,
     size_t nPlanets = system.planetNames.size();
     const std::string starDescription = std::format(
         "The star {} is the host star of an exoplanet system with {} {} that {}  "
-        "enough data to be visualized. It has a size of {:.2f} Solar radii and an "
+        "enough data to be visualized. It has a size of {:.2f} solar radii and an "
         "effective temperature of {:.0f} Kelvin. The system is located at a "
-        "distance of {:.0f} Light years from Earth.",
+        "distance of {:.0f} light-years from Earth.",
         sanitizedStarName, nPlanets,
         nPlanets > 1 ? "planets" : "planet",
         nPlanets > 1 ? "have" : "has",
@@ -354,8 +354,8 @@ void createExoplanetSystem(const std::string& starName,
             "Period = " + std::to_string(periodInSeconds) + ""
         "}";
 
-        std::string planetLayers = "";
-        std::string planetTypeDesc = "";
+        std::string planetLayers;
+        std::string planetTypeDesc;
 
         // Constant for different categories of sizes of planets (in Earth radii)
         // Source: https://www.nasa.gov/image-article/sizes-of-known-exoplanets/
@@ -390,28 +390,28 @@ void createExoplanetSystem(const std::string& starName,
             float rInMeter = static_cast<float>(planetRadius);
             glm::vec3 colorFromSize = glm::vec3(0.f);
 
-            // Terrestrial
             if (rInMeter < MaxR_Terrestrial * distanceconstants::EarthRadius) {
+                // Terrestrial
                 colorFromSize = glm::vec3(0.32f, 0.2f, 0.1f); // Brown
                 planetTypeDesc = TerrestrialDesc;
             }
-            // Super-Earths
             else if (rInMeter < MaxR_SuperEarth * distanceconstants::EarthRadius) {
+                // Super-Earths
                 colorFromSize = glm::vec3(1.f, 0.76f, 0.65f); // Beige
                 planetTypeDesc = SuperEarthDesc;
             }
-            // Neptune-like
             else if (rInMeter < MaxR_NeptuneLike * distanceconstants::EarthRadius) {
+                // Neptune-like
                 colorFromSize = glm::vec3(0.22f, 0.49f, 0.50f); // Blue
                 planetTypeDesc = NeptuneLikeDesc;
             }
-            // Gas Giants (Saturn and Jupiter size, and much larger!)
             else {
+                // Gas Giants (Saturn and Jupiter size, and much larger!)
                 colorFromSize = glm::vec3(0.55f, 0.34f, 0.39f); // Wine red
                 planetTypeDesc = GasGiantDesc;
             }
 
-            std::string description = std::format(
+            const std::string description = std::format(
                 "This layer gives a fixed color to the planet surface based on the "
                 "planet radius. The planets are split into four categories based on "
                 "their radius (in Earth radii). 1) {} are Brown, 2) {} are Beige, 3) "
@@ -599,7 +599,7 @@ void createExoplanetSystem(const std::string& starName,
         "GUI = {"
             "Name = '1 AU Size Comparison Circle',"
             "Path = '" + guiPath + "',"
-            "Description = \"A circe with a radius of 1 Astronomical Unit. That is, its "
+            "Description = \"A circle with a radius of 1 Astronomical Unit. That is, its "
                 "size corresponds to the size of Earth's orbit.\""
         "}"
     "}";

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -450,7 +450,9 @@ void createExoplanetSystem(const std::string& starName,
             planet.per, planet.a, planet.ecc
         );
 
-        // TODO: only set ambient intensity if no planetTexture was added
+        // Use a higher ambient intensity when only the color from size is used, so that
+        // the color is more clearly visible from any direction
+        float ambientIntensity = planetTexture.empty() ? 0.5f : 0.15f;
 
         const std::string planetNode = "{"
             "Identifier = '" + planetIdentifier + "',"
@@ -464,7 +466,7 @@ void createExoplanetSystem(const std::string& starName,
                     "ColorLayers = {" + planetLayers + "}"
                 "},"
                 "LightSourceNode = '" + starIdentifier + "',"
-                "AmbientIntensity = 0.2"
+                "AmbientIntensity = " + std::to_string(ambientIntensity) +
             "},"
             "Tag = { 'exoplanet_planet' }, "
             "Transform = { "

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -201,7 +201,7 @@ void createExoplanetSystem(const std::string& starName,
     }
 
     // @TODO (2024-09-16, emmbr) Compose a more extensive summary of the system,
-    // based on more data in the archive (like number of stars) and the plantes.
+    // based on more data in the archive (like number of stars) and the planets.
     // Also include more data on the star itself (like spectral type)
     float distanceToOurSystem = glm::length(starPosInParsec) *
         distanceconstants::Parsec / distanceconstants::LightYear;
@@ -246,7 +246,7 @@ void createExoplanetSystem(const std::string& starName,
         "GUI = {"
             "Name = '" + sanitizedStarName + " (Star)',"
             "Path = '" + guiPath + "',"
-            "Description = \"" +starDescription + "\""
+            "Description = \"" + starDescription + "\""
         "}"
     "}";
 
@@ -359,9 +359,9 @@ void createExoplanetSystem(const std::string& starName,
 
         // Constant for different categories of sizes of planets (in Earth radii)
         // Source: https://www.nasa.gov/image-article/sizes-of-known-exoplanets/
-        constexpr float MaxR_Terrestrial = 1.25f;
-        constexpr float MaxR_SuperEarth = 2.f;
-        constexpr float MaxR_NeptuneLike = 6.f;
+        constexpr float TerrestrialMaxR = 1.25f;
+        constexpr float SuperEarthMaxR = 2.f;
+        constexpr float NeptuneLikeMaxR = 6.f;
 
         const std::string TerrestrialDesc = std::format(
             "Terrestrial planets (R < {} Earth radii)",

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -360,7 +360,7 @@ void createExoplanetSystem(const std::string& starName,
 
             // Terrestrial
             if (rInMeter < 1.25f * distanceconstants::EarthRadius) {
-                colorFromSize = glm::vec3(0.56f, 0.42f, 0.31f);
+                colorFromSize = glm::vec3(0.32f, 0.2f, 0.1f);
             }
             // Super-Earths
             else if (rInMeter < 2.f * distanceconstants::EarthRadius) {

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -344,6 +344,50 @@ void createExoplanetSystem(const std::string& starName,
             "}";
         }
 
+        // Add a color layer with a fixed single color that represent the planet size,
+        // that is, approximately what type of planet it is.
+        // @TODO (2024-09-10, emmbr) this should be a color map to use based on radius
+        // that can be set by the user. But, to do that it would be nice to have an
+        // updated transfer function / color map format that suppotrs categorical color
+        // mapping based on thresholds in a better way.
+        if (!std::isnan(planet.r)) {
+            float rInMeter = static_cast<float>(planetRadius);
+
+            glm::vec3 colorFromSize = glm::vec3(0.f);
+
+            // Source for the radius constants:
+            // https://www.nasa.gov/image-article/sizes-of-known-exoplanets/
+
+            // Terrestrial
+            if (rInMeter < 1.25f * distanceconstants::EarthRadius) {
+                colorFromSize = glm::vec3(0.56f, 0.42f, 0.31f);
+            }
+            // Super-Earths
+            else if (rInMeter < 2.f * distanceconstants::EarthRadius) {
+                colorFromSize = glm::vec3(1.f, 0.76f, 0.65f);
+            }
+            // Neptune-like
+            else if (rInMeter < 6.f * distanceconstants::EarthRadius) {
+                colorFromSize = glm::vec3(0.22f, 0.49f, 0.50f);
+            }
+            // Gas Giants (Saturn and Jupiter size, and much larger!)
+            else {
+                colorFromSize = glm::vec3(0.55f, 0.34f, 0.39f);
+            }
+
+            if (!planetLayers.empty()) {
+                planetLayers += ",";
+            }
+            planetLayers += "{"
+                "Identifier = 'ColorFromSize',"
+                "Type = 'SolidColor',"
+                "Color = " + ghoul::to_string(colorFromSize) + ","
+                "BlendMode = 'Normal',"
+                "Enabled = true"
+            "}";
+        }
+        // @TODO: This needs to be documented somewhere. Layer description?
+
         const std::string planetNode = "{"
             "Identifier = '" + planetIdentifier + "',"
             "Parent = '" + starIdentifier + "',"
@@ -355,7 +399,8 @@ void createExoplanetSystem(const std::string& starName,
                 "Layers = {"
                     "ColorLayers = {" + planetLayers + "}"
                 "},"
-                "LightSourceNode = '" + starIdentifier + "'"
+                "LightSourceNode = '" + starIdentifier + "',"
+                "AmbientIntensity = 0.2"
             "},"
             "Tag = { 'exoplanet_planet' }, "
             "Transform = { "

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -357,6 +357,7 @@ void createExoplanetSystem(const std::string& starName,
                 "},"
                 "LightSourceNode = '" + starIdentifier + "'"
             "},"
+            "Tag = { 'exoplanet_planet' }, "
             "Transform = { "
                 "Translation = " + planetKeplerTranslation + ""
             "},"

--- a/modules/exoplanets/exoplanetsmodule_lua.inl
+++ b/modules/exoplanets/exoplanetsmodule_lua.inl
@@ -365,22 +365,22 @@ void createExoplanetSystem(const std::string& starName,
 
         const std::string TerrestrialDesc = std::format(
             "Terrestrial planets (R < {} Earth radii)",
-            MaxR_Terrestrial
+            TerrestrialMaxR
         );
 
         const std::string SuperEarthDesc = std::format(
             "Super-Earths ({} < R < {} Earth radii)",
-            MaxR_Terrestrial, MaxR_SuperEarth
+            TerrestrialMaxR, SuperEarthMaxR
         );
 
         const std::string NeptuneLikeDesc = std::format(
             "Neptune-like planets ({} < R < {} Earth radii)",
-            MaxR_SuperEarth, MaxR_NeptuneLike
+            SuperEarthMaxR, NeptuneLikeMaxR
         );
 
         const std::string GasGiantDesc = std::format(
             "Gas giants or larger planets (R > {} Earth radii)",
-            MaxR_NeptuneLike
+            NeptuneLikeMaxR
         );
 
         // Add a color layer with a fixed single color that represent the planet size,
@@ -390,17 +390,17 @@ void createExoplanetSystem(const std::string& starName,
             float rInMeter = static_cast<float>(planetRadius);
             glm::vec3 colorFromSize = glm::vec3(0.f);
 
-            if (rInMeter < MaxR_Terrestrial * distanceconstants::EarthRadius) {
+            if (rInMeter < TerrestrialMaxR * distanceconstants::EarthRadius) {
                 // Terrestrial
                 colorFromSize = glm::vec3(0.32f, 0.2f, 0.1f); // Brown
                 planetTypeDesc = TerrestrialDesc;
             }
-            else if (rInMeter < MaxR_SuperEarth * distanceconstants::EarthRadius) {
+            else if (rInMeter < SuperEarthMaxR * distanceconstants::EarthRadius) {
                 // Super-Earths
                 colorFromSize = glm::vec3(1.f, 0.76f, 0.65f); // Beige
                 planetTypeDesc = SuperEarthDesc;
             }
-            else if (rInMeter < MaxR_NeptuneLike * distanceconstants::EarthRadius) {
+            else if (rInMeter < NeptuneLikeMaxR * distanceconstants::EarthRadius) {
                 // Neptune-like
                 colorFromSize = glm::vec3(0.22f, 0.49f, 0.50f); // Blue
                 planetTypeDesc = NeptuneLikeDesc;

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -1202,7 +1202,13 @@ void RenderableGlobe::renderChunks(const RenderData& data, RendererTasks&,
             _cachedInverseModelTransform * glm::dvec4(data.camera.positionVec3(), 1.0)
         );
 
+        using IgnoreError = ghoul::opengl::ProgramObject::IgnoreError;
+        _globalRenderer.program->setIgnoreUniformLocationError(IgnoreError::Yes);
+        // The cameraPosition is not used if a globe only has a solid color, but it would
+        // be costlier to figure that out and will only trigger rarely, so instead we just
+        // ignore the location error
         _globalRenderer.program->setUniform("cameraPosition", glm::vec3(cameraPosition));
+        _globalRenderer.program->setIgnoreUniformLocationError(IgnoreError::No);
     }
 
     const glm::mat4 modelViewTransform = glm::mat4(viewTransform * _cachedModelTransform);


### PR DESCRIPTION
Adds a color to the exoplanets based on their size (Terrestrial, Super-Earth, Neptune-like or Gas giant and larger). 

Other additions include:
- adding a tag `exoplanet_planet` for the exoplanet
- adding descriptions to some of the scene graph nodes that ar eadded as part of the system (partly addresses issue #2864, but not fully)

The colors are inspired by the following graphic from NASA, with constants taken from this source: 
https://www.nasa.gov/image-article/sizes-of-known-exoplanets/
![image](https://github.com/user-attachments/assets/8782fc31-7449-4503-9b5a-b9bace76cc0e)


Here's an example for the KOI-351 system, which has planets of all 4 types
![image](https://github.com/user-attachments/assets/88f5cf06-7f46-4ec5-95c6-67f91ff416d8)
