### PR TITLE
Add the ability to query RAM and VRAM usage

### DIFF
--- a/include/openspace/engine/openspaceengine.h
+++ b/include/openspace/engine/openspaceengine.h
@@ -134,6 +134,9 @@ public:
 
     void createUserDirectoriesIfNecessary();
 
+    uint64_t ramInUse() const;
+    uint64_t vramInUse() const;
+
     /**
      * Returns the Lua library that contains all Lua functions available to affect the
      * application.

--- a/modules/imgui/src/guimemorycomponent.cpp
+++ b/modules/imgui/src/guimemorycomponent.cpp
@@ -67,9 +67,9 @@ void GuiMemoryComponent::render() {
     _isCollapsed = ImGui::IsWindowCollapsed();
 
     uint64_t ram = global::openSpaceEngine->ramInUse();
-    ImGui::Text("RAM: %u (%.2f MiB)", ram, ram / (1024.f * 1024.f));
+    ImGui::Text("RAM: %u (%f MiB)", ram, ram / (1024.f * 1024.f));
     uint64_t vram = global::openSpaceEngine->vramInUse();
-    ImGui::Text("VRAM: %u (%.2f MiB)", vram, vram / (1024.f * 1024.f));
+    ImGui::Text("VRAM: %u (%f MiB)", vram, vram / (1024.f * 1024.f));
 
     ImGui::Spacing();
 

--- a/modules/imgui/src/guimemorycomponent.cpp
+++ b/modules/imgui/src/guimemorycomponent.cpp
@@ -26,6 +26,7 @@
 
 #include <modules/imgui/include/imgui_include.h>
 #include <openspace/engine/globals.h>
+#include <openspace/engine/openspaceengine.h>
 #include <openspace/util/memorymanager.h>
 
 namespace {
@@ -65,11 +66,16 @@ void GuiMemoryComponent::render() {
     _isEnabled = v;
     _isCollapsed = ImGui::IsWindowCollapsed();
 
+    uint64_t ram = global::openSpaceEngine->ramInUse();
+    ImGui::Text("RAM: %u (%.2f MiB)", ram, ram / (1024.f * 1024.f));
+    uint64_t vram = global::openSpaceEngine->vramInUse();
+    ImGui::Text("VRAM: %u (%.2f MiB)", vram, vram / (1024.f * 1024.f));
+
+    ImGui::Spacing();
+
     ImGui::Text("%s", "Persistent Memory Pool");
     renderMemoryPoolInformation(global::memoryManager->PersistentMemory);
 
-    //ImGui::Text("%s", "Temporary Memory Pool");
-    //renderMemoryPoolInformation(global::memoryManager.TemporaryMemory);
     ImGui::End();
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -503,6 +503,9 @@ configure_file(
 if (APPLE)
   target_link_libraries(openspace-core INTERFACE external-system-apple)
 endif ()
+if (WIN32)
+  target_link_libraries(openspace-core PUBLIC "pdh")
+endif ()
 
 set_openspace_compile_settings(openspace-core)
 target_link_libraries(openspace-core PUBLIC Ghoul spice external-curl)

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1045,6 +1045,10 @@ void OpenSpaceEngine::loadFonts() {
 void OpenSpaceEngine::preSynchronization() {
     ZoneScoped;
     TracyGpuZone("preSynchronization");
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
     LTRACE("OpenSpaceEngine::preSynchronization(begin)");
 
@@ -1111,6 +1115,10 @@ void OpenSpaceEngine::preSynchronization() {
 
     for (const std::function<void()>& func : *global::callback::preSync) {
         ZoneScopedN("[Module] preSync");
+#ifdef TRACY_ENABLE
+        TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+        TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
         func();
     }
@@ -1137,6 +1145,10 @@ void OpenSpaceEngine::postSynchronizationPreDraw() {
     ZoneScoped;
     TracyGpuZone("postSynchronizationPreDraw");
     LTRACE("OpenSpaceEngine::postSynchronizationPreDraw(begin)");
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
     const bool master = global::windowDelegate->isMaster();
     global::syncEngine->postSynchronization(SyncEngine::IsMaster(master));
@@ -1166,6 +1178,10 @@ void OpenSpaceEngine::postSynchronizationPreDraw() {
 
     for (const std::function<void()>& func : *global::callback::postSyncPreDraw) {
         ZoneScopedN("[Module] postSyncPreDraw");
+#ifdef TRACY_ENABLE
+        TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+        TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
         func();
     }
@@ -1210,6 +1226,10 @@ void OpenSpaceEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& view
 
     for (const std::function<void()>& func : *global::callback::render) {
         ZoneScopedN("[Module] render");
+#ifdef TRACY_ENABLE
+        TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+        TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
         func();
     }
@@ -1221,6 +1241,10 @@ void OpenSpaceEngine::drawOverlays() {
     ZoneScoped;
     TracyGpuZone("Draw2D");
     LTRACE("OpenSpaceEngine::drawOverlays(begin)");
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
     viewportChanged();
 
@@ -1237,6 +1261,11 @@ void OpenSpaceEngine::drawOverlays() {
 
     for (const std::function<void()>& func : *global::callback::draw2D) {
         ZoneScopedN("[Module] draw2D");
+#ifdef TRACY_ENABLE
+        TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+        TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
+
         func();
     }
 
@@ -1246,12 +1275,20 @@ void OpenSpaceEngine::drawOverlays() {
 void OpenSpaceEngine::postDraw() {
     ZoneScoped;
     TracyGpuZone("postDraw");
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
     LTRACE("OpenSpaceEngine::postDraw(begin)");
 
     global::renderEngine->postDraw();
 
     for (const std::function<void()>& func : *global::callback::postDraw) {
         ZoneScopedN("[Module] postDraw");
+#ifdef TRACY_ENABLE
+        TracyPlot("RAM", static_cast<int64_t>(ramInUse()));
+        TracyPlot("VRAM", static_cast<int64_t>(vramInUse()));
+#endif // TRACY_ENABLE
 
         func();
     }

--- a/src/engine/openspaceengine_lua.inl
+++ b/src/engine/openspaceengine_lua.inl
@@ -308,4 +308,20 @@ namespace {
 #endif // WIN32
 }
 
+/**
+ * Returns the number of bytes of video memory that is currently being used. This function
+ * only works on Windows.
+ */
+[[codegen::luawrap]] double vramInUse() {
+    return static_cast<double>(openspace::global::openSpaceEngine->vramInUse());
+}
+
+/**
+ * Returns the number of bytes of system memory that is currently being used. This
+ * function only works on Windows.
+ */
+[[codegen::luawrap]] double ramInUse() {
+    return static_cast<double>(openspace::global::openSpaceEngine->ramInUse());
+}
+
 #include "openspaceengine_lua_codegen.cpp"

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -572,6 +572,10 @@ void RenderEngine::updateScreenSpaceRenderables() {
     ZoneScoped;
 
     for (std::unique_ptr<ScreenSpaceRenderable>& ssr : *global::screenSpaceRenderables) {
+#ifdef TRACY_ENABLE
+        TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
+        TracyPlot("VRAM", static_cast<int64_t>(global::openSpaceEngine->vramInUse()));
+#endif // TRACY_ENABLE
         ssr->update();
     }
 }
@@ -706,6 +710,10 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
             .gamma = _gamma
         };
         for (ScreenSpaceRenderable* ssr : ssrs) {
+#ifdef TRACY_ENABLE
+            TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
+            TracyPlot("VRAM", static_cast<int64_t>(global::openSpaceEngine->vramInUse()));
+#endif // TRACY_ENABLE
             ssr->render(data);
         }
         glDisable(GL_BLEND);

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -745,6 +745,10 @@ void SceneGraphNode::traversePostOrder(const std::function<void(SceneGraphNode*)
 void SceneGraphNode::update(const UpdateData& data) {
     ZoneScoped;
     ZoneName(identifier().c_str(), identifier().size());
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(global::openSpaceEngine->vramInUse()));
+#endif // TRACY_ENABLE
 
     if (_state != State::Initialized && _state != State::GLInitialized) {
         return;
@@ -795,6 +799,10 @@ void SceneGraphNode::update(const UpdateData& data) {
 void SceneGraphNode::render(const RenderData& data, RendererTasks& tasks) {
     ZoneScoped;
     ZoneName(identifier().c_str(), identifier().size());
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(global::openSpaceEngine->vramInUse()));
+#endif // TRACY_ENABLE
 
     if (_state != State::GLInitialized) {
         return;

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -29,6 +29,7 @@
 #include <modules/base/translation/statictranslation.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/engine/globals.h>
+#include <openspace/engine/openspaceengine.h>
 #include <openspace/engine/windowdelegate.h>
 #include <openspace/rendering/helper.h>
 #include <openspace/rendering/renderable.h>
@@ -629,6 +630,11 @@ SceneGraphNode::~SceneGraphNode() {}
 void SceneGraphNode::initialize() {
     ZoneScoped;
     ZoneName(identifier().c_str(), identifier().size());
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(global::openSpaceEngine->vramInUse()));
+#endif // TRACY_ENABLE
+
 
     LDEBUG(std::format("Initializing: {}", identifier()));
 
@@ -657,7 +663,11 @@ void SceneGraphNode::initialize() {
 void SceneGraphNode::initializeGL() {
     ZoneScoped;
     ZoneName(identifier().c_str(), identifier().size());
-    TracyGpuZone("initializeGL")
+    TracyGpuZone("initializeGL");
+#ifdef TRACY_ENABLE
+    TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
+    TracyPlot("VRAM", static_cast<int64_t>(global::openSpaceEngine->vramInUse()));
+#endif // TRACY_ENABLE
 
     LDEBUG(std::format("Initializing GL: {}", identifier()));
 


### PR DESCRIPTION
This PR adds two new Lua functions `openspace.ramInUse()` and `openspace.vramInUse()` that report the amount of system memory and video memory used by OpenSpace (in bytes).

This value is also reported in the "Memory Information" ImGUI panel:
![image](https://github.com/user-attachments/assets/e436caef-7488-451a-875f-2d8e0e7b049e)

And as a plot in Tracy:
![image](https://github.com/user-attachments/assets/b2877612-f7d4-4288-acec-6c47242b4473)
