### PR TITLE
Do not hide requestedUnit of dashboarditem distance in UI

### DIFF
--- a/modules/base/dashboard/dashboarditemdistance.cpp
+++ b/modules/base/dashboard/dashboarditemdistance.cpp
@@ -86,14 +86,15 @@ namespace {
         "If this value is enabled, the distance is displayed in nuanced units, such as "
         "km, AU, light years, parsecs, etc. If this value is disabled, the unit can be "
         "explicitly requested.",
-        openspace::properties::Property::Visibility::User
+        openspace::properties::Property::Visibility::AdvancedUser
     };
 
     constexpr openspace::properties::Property::PropertyInfo RequestedUnitInfo = {
         "RequestedUnit",
         "Requested Unit",
         "If the simplification is disabled, this distance unit is used as a destination "
-        "to convert the meters into."
+        "to convert the meters into.",
+        openspace::properties::Property::Visibility::AdvancedUser
     };
 
     constexpr openspace::properties::Property::PropertyInfo FormatStringInfo = {

--- a/modules/base/dashboard/dashboarditemdistance.cpp
+++ b/modules/base/dashboard/dashboarditemdistance.cpp
@@ -253,13 +253,6 @@ DashboardItemDistance::DashboardItemDistance(const ghoul::Dictionary& dictionary
     addProperty(_destination.nodeName);
 
     _doSimplification = p.simplification.value_or(_doSimplification);
-    _doSimplification.onChange([this]() {
-        _requestedUnit.setVisibility(
-            _doSimplification ?
-            properties::Property::Visibility::Hidden :
-            properties::Property::Visibility::User
-        );
-    });
     addProperty(_doSimplification);
 
     for (const DistanceUnit u : DistanceUnits) {
@@ -273,7 +266,6 @@ DashboardItemDistance::DashboardItemDistance(const ghoul::Dictionary& dictionary
         const DistanceUnit unit = distanceUnitFromString(*p.requestedUnit);
         _requestedUnit = static_cast<int>(unit);
     }
-    _requestedUnit.setVisibility(properties::Property::Visibility::Hidden);
     addProperty(_requestedUnit);
 
     _formatString = p.formatString.value_or(_formatString);


### PR DESCRIPTION
We want to be able to change this property during runtime, from the UI. 

Very small change, but I made this a PR just because I want someone to approve the visibility level change of the properties (changed both the related properties to advanced)