### PR TITLE
Use a pointing hand GLFW cursor for the web grab cursor

### DIFF
--- a/modules/webbrowser/src/browserclient.cpp
+++ b/modules/webbrowser/src/browserclient.cpp
@@ -128,6 +128,12 @@ bool BrowserClient::DisplayHandler::OnCursorChange(CefRefPtr<CefBrowser>, CefCur
         case cef_cursor_type_t::CT_NOTALLOWED:
             newCursor = WindowDelegate::Cursor::NotAllowed;
             break;
+        case cef_cursor_type_t::CT_GRAB:
+        case cef_cursor_type_t::CT_GRABBING:
+            // There is no "grabbing" cursors in GLFW, so use the pointing hand instead,
+            // to make web objects that use drag-n-drop look more interactive
+            newCursor = WindowDelegate::Cursor::PointingHand;
+            break;
         default:
             newCursor = WindowDelegate::Cursor::Arrow;
             break;


### PR DESCRIPTION
This changes the cursor to a pointing hand whenever a "grab" or "grabbing" is requested from the browsers. 

Note that there seemingly is no grab cursor in GLFW ([source](https://www.glfw.org/docs/latest/group__shapes.html)), and we currently use the regular "pointer" as default. Changing from a regular pointer to a pointing hand makes it much clearer that things that represent "drag handles" can be interacted with, IMO.   

Website: 

https://github.com/user-attachments/assets/5fe19313-a146-43ae-b092-eddd0a1ec51b


OpenSpace

https://github.com/user-attachments/assets/152e51cc-3c79-4ee9-aa10-2a743b4de126

