### PR TITLE
Add jump to time lua function

### DIFF
--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -89,6 +89,7 @@ public:
     bool isKeyFrameInteractionEnabled() const;
     float jumpToFadeDuration() const;
     float interpolationTime() const;
+    float fadeJumpThreshold() const;
 
     // Callback functions
     void keyboardCallback(Key key, KeyModifier modifier, KeyAction action);
@@ -210,6 +211,7 @@ private:
     properties::BoolProperty _disableJoystickInputs;
     properties::BoolProperty _useKeyFrameInteraction;
     properties::FloatProperty _jumpToFadeDuration;
+    properties::FloatProperty _fadeJumpThreshold;
 };
 
 } // namespace openspace::interaction

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -100,6 +100,16 @@ namespace {
         "again.",
         openspace::properties::Property::Visibility::User
     };
+
+    constexpr openspace::properties::Property::PropertyInfo FadeJumpThresholdInfo = {
+        "FadeJumpThreshold",
+        "Fade Jump Threshold",
+        "The threshold that determines when a transition should fade instead of "
+        "interpolate. If the time difference exceeds this threshold, the rendering will "
+        "fade to black, set time, and then fade in again. Otherwise the transition will "
+        "interpolate without fading.",
+        openspace::properties::Property::Visibility::User
+    };
 } // namespace
 
 namespace openspace::interaction {
@@ -111,6 +121,7 @@ NavigationHandler::NavigationHandler()
     , _disableJoystickInputs(DisableJoystickInputInfo, false)
     , _useKeyFrameInteraction(FrameInfo, false)
     , _jumpToFadeDuration(JumpToFadeDurationInfo, 1.f, 0.f, 10.f)
+    , _fadeJumpThreshold(FadeJumpThresholdInfo, 86400.f, 0.f, 86400.f, 1.f)
 {
     addPropertySubOwner(_orbitalNavigator);
     addPropertySubOwner(_pathNavigator);
@@ -120,6 +131,7 @@ NavigationHandler::NavigationHandler()
     addProperty(_disableJoystickInputs);
     addProperty(_useKeyFrameInteraction);
     addProperty(_jumpToFadeDuration);
+    addProperty(_fadeJumpThreshold);
 }
 
 NavigationHandler::~NavigationHandler() {}
@@ -188,6 +200,10 @@ float NavigationHandler::jumpToFadeDuration() const {
 
 float NavigationHandler::interpolationTime() const {
     return _orbitalNavigator.retargetInterpolationTime();
+}
+
+float NavigationHandler::fadeJumpThreshold() const {
+    return _fadeJumpThreshold;
 }
 
 void NavigationHandler::setInterpolationTime(float durationInSeconds) {

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -216,6 +216,7 @@ scripting::LuaLibrary Time::luaLibrary() {
             codegen::lua::SetTime,
             codegen::lua::InterpolateTime,
             codegen::lua::InterpolateTimeRelative,
+            codegen::lua::JumpToTime,
             codegen::lua::CurrentTime,
             codegen::lua::CurrentTimeUTC,
             codegen::lua::CurrentTimeSpice,


### PR DESCRIPTION
Adds a lua function to interpolate or fade to a specified time example use: 
Automatically decide if it should interpolate or fade using default values
`openspace.time.jumpToTime('1968-12-24T22:20:00.000')`

Sets the threshold to 12h the fade duration to 2 seconds and the interpolation duration to 10 seconds
`openspace.time.jumpToTime('1968-12-24T10:20:00.000', 43200, 2, 10)`