### PR TITLE
Polish `RenderableCartesianAxes` - documentation, examples, and make fading work correctly

### DIFF
--- a/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes.asset
+++ b/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes.asset
@@ -1,6 +1,6 @@
 -- Basic
--- This asset creates a SceneGraphNode that only displays coordinate axes. The
--- parent is not set which defaults to placing the axes at the center the Sun.
+-- This example creates a SceneGraphNode that only displays coordinate axes. The
+-- parent is not set which defaults to placing the axes at the center of the Sun.
 
 local Node = {
   Identifier = "RenderableCartesianAxes_Example",

--- a/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_customcolor.asset
+++ b/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_customcolor.asset
@@ -1,7 +1,7 @@
 -- Custom Colors
 -- This example creates a set of cartesian coordinate axes with specified colors, instead
 -- of using the default which is red (X), green (Y), and blue (Z). The parent is not set
--- which defaults to placing the axes at the center of the Sun.
+-- which defaults to placing the axes at the center of the Solar System.
 
 local Node = {
   Identifier = "RenderableCartesianAxes_Example_CustomColors",

--- a/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_customcolor.asset
+++ b/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_customcolor.asset
@@ -1,0 +1,32 @@
+-- Custom Colors
+-- This example creates a set of cartesian coordinate axes with specified colors, instead
+-- of using the default which is red (X), green (Y), and blue (Z). The parent is not set
+-- which defaults to placing the axes at the center of the Sun.
+
+local Node = {
+  Identifier = "RenderableCartesianAxes_Example_CustomColors",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 30000000
+    }
+  },
+  Renderable = {
+    Type = "RenderableCartesianAxes",
+    XColor = { 0.0, 1.0, 1.0 }, -- Cyan
+    YColor = { 1.0, 0.0, 1.0 }, -- Magenta
+    ZColor = { 1.0, 1.0, 0.0 }  -- Yellow
+  },
+  GUI = {
+    Name = "RenderableCartesianAxes - Custom Colors",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_parent.asset
+++ b/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_parent.asset
@@ -1,0 +1,29 @@
+-- With Parent
+-- This example creates a SceneGraphNode that displays coordinate axes of the given parent
+-- node, in this case Earth.
+
+local Node = {
+  Identifier = "RenderableCartesianAxes_Example_Parent",
+  Parent = "Earth",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 30000000
+    }
+  },
+  Renderable = {
+    Type = "RenderableCartesianAxes"
+  },
+  GUI = {
+    Name = "RenderableCartesianAxes - With Parent",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_parent.asset
+++ b/data/assets/examples/renderable/renderablecartesianaxes/cartesianaxes_parent.asset
@@ -2,9 +2,11 @@
 -- This example creates a SceneGraphNode that displays coordinate axes of the given parent
 -- node, in this case Earth.
 
+local earth = asset.require("scene/solarsystem/planets/earth/earth")
+
 local Node = {
   Identifier = "RenderableCartesianAxes_Example_Parent",
-  Parent = "Earth",
+  Parent = earth.Earth.Identifier,
   Transform = {
     Scale = {
       Type = "StaticScale",

--- a/modules/base/rendering/renderablecartesianaxes.cpp
+++ b/modules/base/rendering/renderablecartesianaxes.cpp
@@ -95,6 +95,9 @@ RenderableCartesianAxes::RenderableCartesianAxes(const ghoul::Dictionary& dictio
     , _zColor(ZColorInfo, glm::vec3(0.f, 0.f, 1.f), glm::vec3(0.f), glm::vec3(1.f))
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
+
+    addProperty(Fadeable::_opacity);
+
     _xColor = p.xColor.value_or(_xColor);
     _xColor.setViewOption(properties::Property::ViewOptions::Color);
     addProperty(_xColor);
@@ -195,6 +198,7 @@ void RenderableCartesianAxes::render(const RenderData& data, RendererTasks&) {
     _program->setUniform("xColor", _xColor);
     _program->setUniform("yColor", _yColor);
     _program->setUniform("zColor", _zColor);
+    _program->setUniform("opacity", opacity());
 
     // Changes GL state:
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/modules/base/rendering/renderablecartesianaxes.cpp
+++ b/modules/base/rendering/renderablecartesianaxes.cpp
@@ -65,9 +65,9 @@ namespace {
     //
     // To add the axes, create a scene graph node with the RenderableCartesianAxes
     // renderable and add it as a child to the other scene graph node, i.e. specify the
-    // other node as the Parent of the node with this renderable. Also, the axes have to
+    // other node as the `Parent` of the node with this renderable. Also, the axes have to
     // be scaled to match the parent object for the axes to be visible in the scene, for
-    // example using a StaticScale.
+    // example using a [StaticScale](#base_scale_static).
     struct [[codegen::Dictionary(RenderableCartesianAxes)]] Parameters {
         // [[codegen::verbatim(XColorInfo.description)]]
         std::optional<glm::vec3> xColor [[codegen::color()]];

--- a/modules/base/shaders/axes_fs.glsl
+++ b/modules/base/shaders/axes_fs.glsl
@@ -31,7 +31,7 @@ in vec3 vs_positionModelSpace;
 uniform vec3 xColor;
 uniform vec3 yColor;
 uniform vec3 zColor;
-
+uniform float opacity;
 
 Fragment getFragment() {
   Fragment frag;
@@ -44,7 +44,7 @@ Fragment getFragment() {
   frag.color.rgb = colorComponents.x * xColor +
     colorComponents.y * yColor +
     colorComponents.z * zColor;
-  frag.color.a = 1.0;
+  frag.color.a = opacity;
 
   frag.depth = vs_screenSpaceDepth;
   frag.gPosition = vs_positionViewSpace;


### PR DESCRIPTION
* Add opacity property and make axes fade like every other renderable
* Small update to existing documentation to utilize Markdown features and links to other classes
* Add examples for specifying a Parent node and using custom colors 