### PR TITLE
Docs and examples for `RenderableBoxGrid`

### DIFF
--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid.asset
@@ -1,0 +1,31 @@
+-- Basic
+-- This example adds a box grid, which is a 3D box rendered using grid lines, to the
+-- scene.
+--
+-- Per default the box will be given a size of 1x1x1 meter, and here it has been scaled
+-- up by a factor of 100. It will hence have a size of 100x100x100 meters.
+
+local Node = {
+  Identifier = "RenderableBoxGrid_Example",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 100
+    }
+  },
+  Renderable = {
+    Type = "RenderableBoxGrid"
+  },
+  GUI = {
+    Name = "RenderableBoxGrid - Basic",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid.asset
@@ -2,7 +2,7 @@
 -- This example adds a box grid, which is a 3D box rendered using grid lines, to the
 -- scene.
 --
--- Per default the box will be given a size of 1x1x1 meter, and here it is scaled up by a
+-- Per default, the box will be given a size of 1x1x1 meters, and here it is scaled up by a
 -- factor of 100. It will hence have a size of 100x100x100 meters.
 
 local Node = {

--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid.asset
@@ -2,8 +2,8 @@
 -- This example adds a box grid, which is a 3D box rendered using grid lines, to the
 -- scene.
 --
--- Per default the box will be given a size of 1x1x1 meter, and here it has been scaled
--- up by a factor of 100. It will hence have a size of 100x100x100 meters.
+-- Per default the box will be given a size of 1x1x1 meter, and here it is scaled up by a
+-- factor of 100. It will hence have a size of 100x100x100 meters.
 
 local Node = {
   Identifier = "RenderableBoxGrid_Example",

--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid_size.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid_size.asset
@@ -1,0 +1,32 @@
+-- With Non-uniform Size
+-- This example created a box grid with a non-uniform size. The size has been set so the
+-- box is two times larger in the Y-direction.
+--
+-- The `Size` values are given in meters, and here the box has been scaled up by a factor
+-- of 100. So, the box will have a size of 100 times the `Size` values.
+
+local Node = {
+  Identifier = "RenderableBoxGrid_Example_Size",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 100
+    }
+  },
+  Renderable = {
+    Type = "RenderableBoxGrid",
+    Size = { 1.0, 2.0, 1.0 }
+  },
+  GUI = {
+    Name = "RenderableBoxGrid - Non-uniform Size",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid_size.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid_size.asset
@@ -1,5 +1,5 @@
 -- With Non-uniform Size
--- This example created a box grid with a non-uniform size. The size has been set so the
+-- This example creates a box grid with a non-uniform size. The size has been set so the
 -- box is two times larger in the Y-direction.
 --
 -- The `Size` values are given in meters, and here the box is scaled up by a factor of

--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid_size.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid_size.asset
@@ -2,8 +2,8 @@
 -- This example created a box grid with a non-uniform size. The size has been set so the
 -- box is two times larger in the Y-direction.
 --
--- The `Size` values are given in meters, and here the box has been scaled up by a factor
--- of 100. So, the box will have a size of 100 times the `Size` values.
+-- The `Size` values are given in meters, and here the box is scaled up by a factor of
+-- 100. So, the box will have a size of 100 times the `Size` values.
 
 local Node = {
   Identifier = "RenderableBoxGrid_Example_Size",

--- a/data/assets/examples/renderable/renderableboxgrid/boxgrid_styled.asset
+++ b/data/assets/examples/renderable/renderableboxgrid/boxgrid_styled.asset
@@ -1,0 +1,24 @@
+-- Styled
+-- This example creates a box grid where the grid lines are styled to have a specific
+-- color and line width.
+
+local Node = {
+  Identifier = "RenderableBoxGrid_Example_Styled",
+  Renderable = {
+    Type = "RenderableBoxGrid",
+    LineWidth = 4.0,
+    Color = { 1.0, 1.0, 0.0 }
+  },
+  GUI = {
+    Name = "RenderableBoxGrid - Styled",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/modules/base/rendering/grids/renderableboxgrid.cpp
+++ b/modules/base/rendering/grids/renderableboxgrid.cpp
@@ -63,6 +63,10 @@ namespace {
         "The labels for the grid."
     };
 
+    // A RenderableBoxGrid creates a 3D box that is rendered using grid lines.
+    //
+    // Per default the box is given a uniform size of 1x1x1 meters. It can then be scaled
+    // to the desired size. Alternatively, the size in each dimension can be specified.
     struct [[codegen::Dictionary(RenderableBoxGrid)]] Parameters {
         // [[codegen::verbatim(ColorInfo.description)]]
         std::optional<glm::vec3> color [[codegen::color()]];

--- a/modules/base/rendering/grids/renderableboxgrid.cpp
+++ b/modules/base/rendering/grids/renderableboxgrid.cpp
@@ -57,12 +57,6 @@ namespace {
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
-    const openspace::properties::PropertyOwner::PropertyOwnerInfo LabelsInfo = {
-        "Labels",
-        "Labels",
-        "The labels for the grid."
-    };
-
     // A RenderableBoxGrid creates a 3D box that is rendered using grid lines.
     //
     // Per default the box is given a uniform size of 1x1x1 meters. It can then be scaled
@@ -76,10 +70,6 @@ namespace {
 
         // [[codegen::verbatim(SizeInfo.description)]]
         std::optional<glm::vec3> size;
-
-        // [[codegen::verbatim(LabelsInfo.description)]]
-        std::optional<ghoul::Dictionary> labels
-            [[codegen::reference("labelscomponent")]];
     };
 #include "renderableboxgrid_codegen.cpp"
 } // namespace
@@ -110,24 +100,10 @@ RenderableBoxGrid::RenderableBoxGrid(const ghoul::Dictionary& dictionary)
     _size = p.size.value_or(_size);
     _size.onChange([this]() { _gridIsDirty = true; });
     addProperty(_size);
-
-    if (p.labels.has_value()) {
-        _labels = std::make_unique<LabelsComponent>(*p.labels);
-        _hasLabels = true;
-        addPropertySubOwner(_labels.get());
-        // Fading of the labels should also depend on the fading of the renderable
-        _labels->setParentFadeable(this);
-    }
 }
 
 bool RenderableBoxGrid::isReady() const {
-    return _hasLabels ? _gridProgram && _labels->isReady() : _gridProgram != nullptr;
-}
-
-void RenderableBoxGrid::initialize() {
-    if (_hasLabels) {
-        _labels->initialize();
-    }
+    return _gridProgram != nullptr;
 }
 
 void RenderableBoxGrid::initializeGL() {
@@ -199,31 +175,6 @@ void RenderableBoxGrid::render(const RenderData& data, RendererTasks&) {
     global::renderEngine->openglStateCache().resetBlendState();
     global::renderEngine->openglStateCache().resetLineState();
     global::renderEngine->openglStateCache().resetDepthState();
-
-    // Draw labels
-    if (_hasLabels && _labels->enabled()) {
-        const glm::vec3 lookup = data.camera.lookUpVectorWorldSpace();
-        const glm::vec3 viewDirection = data.camera.viewDirectionWorldSpace();
-        glm::vec3 right = glm::cross(viewDirection, lookup);
-        const glm::vec3 up = glm::cross(right, viewDirection);
-
-        const glm::dmat4 worldToModelTransform = glm::inverse(modelTransform);
-        glm::vec3 orthoRight = glm::normalize(
-            glm::vec3(worldToModelTransform * glm::vec4(right, 0.0))
-        );
-
-        if (orthoRight == glm::vec3(0.0)) {
-            const glm::vec3 otherVector = glm::vec3(lookup.y, lookup.x, lookup.z);
-            right = glm::cross(viewDirection, otherVector);
-            orthoRight = glm::normalize(
-                glm::vec3(worldToModelTransform * glm::vec4(right, 0.0))
-            );
-        }
-        const glm::vec3 orthoUp = glm::normalize(
-            glm::vec3(worldToModelTransform * glm::dvec4(up, 0.0))
-        );
-        _labels->render(data, modelViewProjectionTransform, orthoRight, orthoUp);
-    }
 }
 
 void RenderableBoxGrid::update(const UpdateData&) {

--- a/modules/base/rendering/grids/renderableboxgrid.h
+++ b/modules/base/rendering/grids/renderableboxgrid.h
@@ -29,7 +29,6 @@
 
 #include <openspace/properties/scalar/floatproperty.h>
 #include <openspace/properties/vector/vec3property.h>
-#include <openspace/rendering/labelscomponent.h>
 #include <ghoul/opengl/ghoul_gl.h>
 
 namespace ghoul::opengl {
@@ -44,7 +43,6 @@ class RenderableBoxGrid : public Renderable {
 public:
     RenderableBoxGrid(const ghoul::Dictionary& dictionary);
 
-    void initialize() override;
     void initializeGL() override;
     void deinitializeGL() override;
 
@@ -73,10 +71,6 @@ protected:
 
     GLenum _mode = GL_LINE_STRIP;
     std::vector<Vertex> _varray;
-
-    // Labels
-    bool _hasLabels = false;
-    std::unique_ptr<LabelsComponent> _labels;
 };
 
 }// namespace openspace


### PR DESCRIPTION
Adds examples for `RenderableBoxGrid`, as well as a short description for the docs page. 

Edit:  Concluded to remove the Labels component. Below are the notes I added in the PR originally. 
❗ Breaking change:  `RenderableBoxGrid` no longer supports labels 
> _OBS!_ I noticed that the renderable has the option to add a labels component.  However, we don't use this feature anywhere, and when doing a (very small and not at all thorough) attempt to add labels I couldn't get them to show. 
> 
> Do we want to keep the Labels Component feature for `RenderableBoxGrid`? My suggestion would be to remove it for now, since it's not used and adding labels is a bit unintuitive* with the current label code. And then add it again once the labels code has been rewritten (and we add labels to all the grid types 🙂). Thoughts?
> 
> (* The reason I find adding the label unintuitive is that it requires a separate file, and it's not clear how that file connects to the rendered box)

