### PR TITLE
Docs for `RenderableConstellationLines` and `RenderableConstellationBounds`

### DIFF
--- a/modules/space/rendering/renderableconstellationbounds.cpp
+++ b/modules/space/rendering/renderableconstellationbounds.cpp
@@ -48,7 +48,7 @@ namespace {
         "File",
         "Vertex File Path",
         "A file that contains the vertex locations of the constellations bounds, as RA "
-        "DEC coordinates on the celestial sphere.",
+        "Dec coordinates on the celestial sphere.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -64,10 +64,10 @@ namespace {
     // constellation.
     //
     // The shapes are defined in a file where each line specifies a vertex location in RA
-    // DEC coordinates on the celestial sphere. Each coordinate must also be marked with
+    // Dec coordinates on the celestial sphere. Each coordinate must also be marked with
     // an abbreviation for the corresponding constellation that the shapes encapsulates.
-    // This gives each line the format: `RA DEC ABBR`. Right ascension should be specified
-    // in hours and declination in degrees.
+    // This gives each line the following order: `RA Dec Abbreviation`. Right ascension should be specified
+    // in hours, minutes, and seconds, and declination in degrees.
     //
     // An example of a line corresponding to a vertex location may look like this:
     // `23.5357132 +35.1897736 AND`, where `AND` is the identifier of the constellation.

--- a/modules/space/rendering/renderableconstellationbounds.cpp
+++ b/modules/space/rendering/renderableconstellationbounds.cpp
@@ -59,17 +59,16 @@ namespace {
         openspace::properties::Property::Visibility::NoviceUser
     };
 
-    // This renderable can be used to draw bounding shapes on the night sky, where each
-    // shape encapsulates a group of night sky objects, such as the stars of a
+    // This `Renderable` type can be used to draw bounding shapes on the night sky, where
+    // each shape encapsulates a group of night sky objects, such as the stars of a
     // constellation.
     //
     // The shapes are defined in a file where each line specifies a vertex location in RA
     // Dec coordinates on the celestial sphere. Each coordinate must also be marked with
     // an abbreviation for the corresponding constellation that the shapes encapsulates.
-    // This gives each line the following order: `RA Dec Abbreviation`. Right ascension should be specified
-    // in hours, minutes, and seconds, and declination in degrees.
-    //
-    // An example of a line corresponding to a vertex location may look like this:
+    // This gives each line the following order: `RA Dec Abbreviation`. The units for the
+    // coordinate values are hours for RA, and degrees for Dec. An example of a line
+    // corresponding to a vertex location may look like this:
     // `23.5357132 +35.1897736 AND`, where `AND` is the identifier of the constellation.
     // In this case it is short for Andromeda.
     //
@@ -80,10 +79,12 @@ namespace {
     // for the `AND` abbreviation in the example above, the line would look like this:
     // `AND Andromeda`.
     //
-    // If labels were added, the full names may also be used for the text of the label.
-    // This happens if a row in the label file includes an `id` that matches the
-    // abbreviation of the constellation, in which case the text specified in the label
-    // file is overwritten.
+    // If labels were added, the full names in the `NamesFile` may also be used for the
+    // text of the labels. Note that labels are added using a different file, where each
+    // line may or may not include an identifier for that specific label, marked by `id`
+    // in the file. If a row in the label file has an `id` that matches the abbreviation
+    // of the constellation, the text of that label is replaced with the full name from
+    // the `NamesFile`.
     struct [[codegen::Dictionary(RenderableConstellationBounds)]] Parameters {
         // [[codegen::verbatim(VertexInfo.description)]]
         std::filesystem::path file;

--- a/modules/space/rendering/renderableconstellationbounds.cpp
+++ b/modules/space/rendering/renderableconstellationbounds.cpp
@@ -47,7 +47,8 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo VertexInfo = {
         "File",
         "Vertex File Path",
-        "A file that contains the vertex locations of the constellations bounds.",
+        "A file that contains the vertex locations of the constellations bounds, as RA "
+        "DEC coordinates on the celestial sphere.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -58,6 +59,26 @@ namespace {
         openspace::properties::Property::Visibility::NoviceUser
     };
 
+    // This renderable can be used to draw bounding shapes on the night sky, where each
+    // shape encapsulates a group of night sky objects, such as the stars of a
+    // constellation.
+    //
+    // The shapes are defined in a file where each line specifies a vertex location in RA
+    // DEC coordinates on the celestial sphere. Each coordinate must also be marked with
+    // an abbreviation for the corresponding constellation that the shapes encapsulates.
+    // This gives each line the format: `RA DEC ABBR`. Right ascension should be specified
+    // in hours and declination in degrees.
+    //
+    // An example of a line corresponding to a vertex location may look like this:
+    // `23.5357132 +35.1897736 AND`, where `AND` is the identifier of the constellation.
+    // In this case it is short for Andromeda.
+    //
+    // The abbreviations act as identifiers of the individual constellations and can
+    // be mapped to full names in the optional `NamesFile`. The names in this file are
+    // then the ones that will show in the user interface, for example. A line in the
+    // file should first include the abbreviation and then the full name. For example,
+    // for the `AND` abbreviation in the example above, the line would look like this:
+    // `AND Andromeda`.
     struct [[codegen::Dictionary(RenderableConstellationBounds)]] Parameters {
         // [[codegen::verbatim(VertexInfo.description)]]
         std::filesystem::path file;
@@ -289,7 +310,7 @@ bool RenderableConstellationBounds::loadVertexFile() {
         // Likewise, the declination is stored in degrees and needs to be converted
         dec = glm::radians(dec);
 
-        // Convert the (right ascension, declination) to rectangular coordinates)
+        // Convert the (right ascension, declination) to rectangular coordinates.
         // The 1.0 is the distance of the celestial sphere, we will scale that in the
         // render function
         std::array<double, 3> rectangularValues;

--- a/modules/space/rendering/renderableconstellationbounds.cpp
+++ b/modules/space/rendering/renderableconstellationbounds.cpp
@@ -79,6 +79,11 @@ namespace {
     // file should first include the abbreviation and then the full name. For example,
     // for the `AND` abbreviation in the example above, the line would look like this:
     // `AND Andromeda`.
+    //
+    // If labels were added, the full names may also be used for the text of the label.
+    // This happens if a row in the label file includes an `id` that matches the
+    // abbreviation of the constellation, in which case the text specified in the label
+    // file is overwritten.
     struct [[codegen::Dictionary(RenderableConstellationBounds)]] Parameters {
         // [[codegen::verbatim(VertexInfo.description)]]
         std::filesystem::path file;

--- a/modules/space/rendering/renderableconstellationlines.cpp
+++ b/modules/space/rendering/renderableconstellationlines.cpp
@@ -78,6 +78,29 @@ namespace {
         openspace::properties::Property::Visibility::User
     };
 
+    // @TODO (2025-01-07, emmbr) I did not add any description of the file format below,
+    // since we intend for this to be changed in a relatively near future. When that is
+    // done, update the description.
+    // @TODO (2025-01-07, emmbr) Also need to update description of names file and labels
+    // as part of the labels rewrite
+
+    // This renderable can be used to draw constellations using lines. Each constellation
+    // corresponds to a group of lines between 3D positions that represent the star
+    // positions.
+    //
+    // Which groups (constellations) to show can be controlled through the `Selection`
+    // parameter.
+    //
+    // Each constellation is given an abbreviation that acts as the identifier of the
+    // constellation. These abbreviations and can be mapped to full names in the
+    // optional `NamesFile`. The names in this file are then the ones that will show
+    // in the user interface. A line in the `NamesFile` should first include the
+    // abbreviation and then the full name. For example: `AND Andromeda`.
+    //
+    // If labels were added, the full names may also be used for the text of the label.
+    // This happens if a row in the label file includes an `id` that matches the
+    // abbreviation of the constellation, in which case the text specified in the label
+    // file is overwritten.
     struct [[codegen::Dictionary(RenderableConstellationLines)]] Parameters {
         // [[codegen::verbatim(FileInfo.description)]]
         std::filesystem::path file;

--- a/modules/space/rendering/renderableconstellationlines.cpp
+++ b/modules/space/rendering/renderableconstellationlines.cpp
@@ -94,10 +94,12 @@ namespace {
     // in the user interface. A line in the `NamesFile` should first include the
     // abbreviation and then the full name. For example: `AND Andromeda`.
     //
-    // If labels were added, the full names may also be used for the text of the label.
-    // This happens if a row in the label file includes an `id` that matches the
-    // abbreviation of the constellation, in which case the text specified in the label
-    // file is overwritten.
+    // If labels were added, the full names in the `NamesFile` may also be used for the
+    // text of the labels. Note that labels are added using a different file, where each
+    // line may or may not include an identifier for that specific label, marked by `id`
+    // in the file. If a row in the label file has an `id` that matches the abbreviation
+    // of the constellation, the text of that label is replaced with the full name from
+    // the `NamesFile`.
     struct [[codegen::Dictionary(RenderableConstellationLines)]] Parameters {
         // [[codegen::verbatim(FileInfo.description)]]
         std::filesystem::path file;

--- a/modules/space/rendering/renderableconstellationlines.cpp
+++ b/modules/space/rendering/renderableconstellationlines.cpp
@@ -88,9 +88,6 @@ namespace {
     // corresponds to a group of lines between 3D positions that represent the star
     // positions.
     //
-    // Which groups (constellations) to show can be controlled through the `Selection`
-    // parameter.
-    //
     // Each constellation is given an abbreviation that acts as the identifier of the
     // constellation. These abbreviations and can be mapped to full names in the
     // optional `NamesFile`. The names in this file are then the ones that will show

--- a/modules/space/rendering/renderableconstellationlines.cpp
+++ b/modules/space/rendering/renderableconstellationlines.cpp
@@ -89,7 +89,7 @@ namespace {
     // positions.
     //
     // Each constellation is given an abbreviation that acts as the identifier of the
-    // constellation. These abbreviations and can be mapped to full names in the
+    // constellation. These abbreviations can be mapped to full names in the
     // optional `NamesFile`. The names in this file are then the ones that will show
     // in the user interface. A line in the `NamesFile` should first include the
     // abbreviation and then the full name. For example: `AND Andromeda`.

--- a/modules/space/rendering/renderableconstellationsbase.cpp
+++ b/modules/space/rendering/renderableconstellationsbase.cpp
@@ -51,14 +51,14 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo LineWidthInfo = {
         "LineWidth",
         "Line Width",
-        "The line width of the constellation.",
+        "The line width to use for the constellation shape.",
         openspace::properties::Property::Visibility::NoviceUser
     };
 
     constexpr openspace::properties::Property::PropertyInfo SelectionInfo = {
         "ConstellationSelection",
         "Constellation Selection",
-        "The constellations that are selected are displayed on the celestial sphere.",
+        "The selected constellations are displayed on the celestial sphere.",
         openspace::properties::Property::Visibility::NoviceUser
     };
 
@@ -75,7 +75,8 @@ namespace {
         // [[codegen::verbatim(LineWidthInfo.description)]]
         std::optional<float> lineWidth;
 
-        // [[codegen::verbatim(SelectionInfo.description)]]
+        // A list of constellations (given as abbreviations) to show. If empty or
+        // excluded, all constellations will be shown.
         std::optional<std::vector<std::string>> selection;
 
         // [[codegen::verbatim(LabelsInfo.description)]]

--- a/modules/space/rendering/renderableconstellationsbase.cpp
+++ b/modules/space/rendering/renderableconstellationsbase.cpp
@@ -51,7 +51,7 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo LineWidthInfo = {
         "LineWidth",
         "Line Width",
-        "The line width to use for the constellation shape.",
+        "The line width used for the constellation shape.",
         openspace::properties::Property::Visibility::NoviceUser
     };
 


### PR DESCRIPTION
Add descriptions of the renderables that are related to constellations. 

No examples added here, as I believe we intend to change how these renderables work slightly in the future and making clear examples didn't feel wort the effort. 

Also note that for the same reason I did not add a description about the file format for the constellation lines, as I believe that we intend to get rid of this format in the future. 

The length of these descriptions say something about the complexity of the abbreviation system and how the `NamesFile` is used. Maybe we should have a separate docs page that explain this, that we can link to from here instead. But now we at least have some description here, in the place where the user would be looking to try to understand how the renderables work. 