### PR TITLE
Automatically reload texture for `RenderableSphereImageLocal` when file changes

### DIFF
--- a/modules/base/rendering/renderablesphereimagelocal.h
+++ b/modules/base/rendering/renderablesphereimagelocal.h
@@ -27,6 +27,8 @@
 
 #include <modules/base/rendering/renderablesphere.h>
 
+#include <openspace/rendering/texturecomponent.h>
+
 namespace ghoul::opengl { class Texture; }
 
 namespace openspace {
@@ -40,6 +42,7 @@ class RenderableSphereImageLocal : public RenderableSphere {
 public:
     RenderableSphereImageLocal(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
     void initializeGL() override;
     void deinitializeGL() override;
 
@@ -53,14 +56,10 @@ protected:
     void bindTexture() override;
 
 private:
-    void loadTexture();
 
     properties::StringProperty _texturePath;
 
-    std::unique_ptr<ghoul::filesystem::File> _textureFile;
-    std::unique_ptr<ghoul::opengl::Texture> _texture;
-    bool _isLoadingLazily = false;
-    bool _textureIsDirty = false;
+    std::unique_ptr<TextureComponent> _texture;
 };
 
 } // namespace openspace

--- a/modules/exoplanets/rendering/renderableorbitdisc.h
+++ b/modules/exoplanets/rendering/renderableorbitdisc.h
@@ -25,11 +25,12 @@
 #ifndef __OPENSPACE_MODULE_EXOPLANETS___RENDERABLEORBITDISC___H__
 #define __OPENSPACE_MODULE_EXOPLANETS___RENDERABLEORBITDISC___H__
 
+#include <openspace/rendering/renderable.h>
+
 #include <openspace/properties/stringproperty.h>
 #include <openspace/properties/scalar/floatproperty.h>
 #include <openspace/properties/vector/vec2property.h>
 #include <openspace/properties/vector/vec3property.h>
-#include <openspace/rendering/renderable.h>
 #include <openspace/rendering/texturecomponent.h>
 #include <openspace/util/planegeometry.h>
 #include <openspace/util/updatestructures.h>


### PR DESCRIPTION
Utilize the existing `TextureComponent` to clean up the code and make the texture reload automatically if the file is changed on disk. 

Note that the `LazyLoading` input parameter has been removed. However, it was never actually used.