### PR TITLE
cmake: honor OPENSPACE_HAVE_TESTS at more places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,11 +183,6 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/modules")
 end_header("End: Configuring Modules")
 
 
-add_subdirectory(support/coding/codegen/tests)
-set_target_properties(run_test_codegen PROPERTIES FOLDER "Unit Tests/support")
-set_target_properties(codegentest PROPERTIES FOLDER "Unit Tests")
-
-
 begin_header("Configuring Applications")
 add_subdirectory(apps)
 end_header("End: Configuring Applications")
@@ -200,6 +195,10 @@ endif ()
 
 option(OPENSPACE_HAVE_TESTS "Activate the OpenSpace unit tests" ON)
 if (OPENSPACE_HAVE_TESTS)
+  add_subdirectory(support/coding/codegen/tests)
+  set_target_properties(run_test_codegen PROPERTIES FOLDER "Unit Tests/support")
+  set_target_properties(codegentest PROPERTIES FOLDER "Unit Tests")
+
   begin_header("Generating OpenSpace unit test")
   add_subdirectory(tests)
   end_header()

--- a/apps/OpenSpace/CMakeLists.txt
+++ b/apps/OpenSpace/CMakeLists.txt
@@ -116,6 +116,10 @@ set(SGCT_DEP_INCLUDE_FMT OFF CACHE BOOL "" FORCE)
 set(SGCT_DEP_INCLUDE_SCN OFF CACHE BOOL "" FORCE)
 set(SGCT_DEP_INCLUDE_CATCH2 OFF CACHE BOOL "" FORCE)
 
+if (NOT OPENSPACE_HAVE_TESTS)
+  # Unless overriden, disable sgct tests if OpenSpace tests are disabled
+  set(SGCT_BUILD_TESTS FALSE CACHE BOOL "Enable ghoul unit tests")
+endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ext/sgct)
 target_link_libraries(OpenSpace PRIVATE sgct)
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -45,6 +45,10 @@ if (APPLE)
 endif ()
 
 # Ghoul
+if (NOT OPENSPACE_HAVE_TESTS)
+  # Unless overriden, disable ghoul tests if OpenSpace tests are disabled
+  set(GHOUL_HAVE_TESTS FALSE CACHE BOOL "Enable ghoul unit tests")
+endif()
 add_subdirectory(ghoul)
 if (TARGET GhoulTest)
   set_target_properties(GhoulTest PROPERTIES FOLDER "Unit Tests")


### PR DESCRIPTION
- don't build the codegen unit tests if the OpenSpace unit tests are disabled
- propagate the value of this option to Ghoul's corresponding option