### PR TITLE
Use composable Lua types in Property definitions.  Allow OptionProperty to receive either indices or descriptions

### DIFF
--- a/include/openspace/properties/list/doublelistproperty.h
+++ b/include/openspace/properties/list/doublelistproperty.h
@@ -35,7 +35,7 @@ public:
         std::vector<double> values = std::vector<double>());
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<std::vector<double>>::operator std::vector<double>;
     using TemplateProperty<std::vector<double>>::operator=;

--- a/include/openspace/properties/list/intlistproperty.h
+++ b/include/openspace/properties/list/intlistproperty.h
@@ -35,7 +35,7 @@ public:
         std::vector<int> values = std::vector<int>());
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<std::vector<int>>::operator std::vector<int>;
     using TemplateProperty<std::vector<int>>::operator=;

--- a/include/openspace/properties/list/stringlistproperty.h
+++ b/include/openspace/properties/list/stringlistproperty.h
@@ -36,7 +36,7 @@ public:
         std::vector<std::string> values = std::vector<std::string>());
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<std::vector<std::string>>::operator std::vector<std::string>;
     using TemplateProperty<std::vector<std::string>>::operator=;

--- a/include/openspace/properties/matrix/dmat2property.h
+++ b/include/openspace/properties/matrix/dmat2property.h
@@ -42,7 +42,7 @@ public:
         glm::dmat2x2 stepValue = ghoul::createFillMat2x2<double>(0.01));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::dmat2x2>::operator=;
 };

--- a/include/openspace/properties/matrix/dmat3property.h
+++ b/include/openspace/properties/matrix/dmat3property.h
@@ -42,7 +42,7 @@ public:
         glm::dmat3x3 stepValue = ghoul::createFillMat3x3<double>(0.01));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::dmat3x3>::operator=;
 };

--- a/include/openspace/properties/matrix/dmat4property.h
+++ b/include/openspace/properties/matrix/dmat4property.h
@@ -42,7 +42,7 @@ public:
         glm::dmat4x4 stepValue = ghoul::createFillMat4x4<double>(0.01));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::dmat4x4>::operator=;
 };

--- a/include/openspace/properties/matrix/mat2property.h
+++ b/include/openspace/properties/matrix/mat2property.h
@@ -42,7 +42,7 @@ public:
         glm::mat2x2 stepValue = ghoul::createFillMat2x2<float>(0.01f));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::mat2x2>::operator=;
 };

--- a/include/openspace/properties/matrix/mat3property.h
+++ b/include/openspace/properties/matrix/mat3property.h
@@ -42,7 +42,7 @@ public:
         glm::mat3x3 stepValue = ghoul::createFillMat3x3<float>(0.01f));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::mat3x3>::operator=;
 };

--- a/include/openspace/properties/matrix/mat4property.h
+++ b/include/openspace/properties/matrix/mat4property.h
@@ -42,7 +42,7 @@ public:
         glm::mat4x4 stepValue = ghoul::createFillMat4x4<float>(0.01f));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::mat4x4>::operator=;
 };

--- a/include/openspace/properties/numericalproperty.h
+++ b/include/openspace/properties/numericalproperty.h
@@ -35,9 +35,6 @@ public:
     NumericalProperty(Property::PropertyInfo info, T value, T minimumValue,
         T maximumValue, T steppingValue, float exponent = 1.f);
 
-    virtual std::string_view className() const override = 0;
-    virtual int typeLua() const override = 0;
-
     T minValue() const;
     void setMinValue(T value);
 

--- a/include/openspace/properties/optionproperty.h
+++ b/include/openspace/properties/optionproperty.h
@@ -82,6 +82,8 @@ public:
      * \return The name of this class for reflection purposes
      */
     std::string_view className() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
+
     using IntProperty::operator=;
 
     /**
@@ -160,6 +162,7 @@ public:
 
 private:
     static const std::string OptionsKey;
+    int fromLuaConversion(lua_State* state) const override;
     std::string generateAdditionalJsonDescription() const override;
 
     /// The list of options which have been registered with this OptionProperty

--- a/include/openspace/properties/property.h
+++ b/include/openspace/properties/property.h
@@ -27,6 +27,7 @@
 
 #include <ghoul/misc/dictionary.h>
 #include <ghoul/misc/easing.h>
+#include <ghoul/lua/lua_types.h>
 #include <functional>
 #include <string>
 #include <string_view>
@@ -195,15 +196,12 @@ public:
     /**
      * Returns the Lua type that will be put onto the stack in the Property::getLua method
      * and which will be consumed by the Property::setLuaValue method. The returned value
-     * can belong to the set of Lua types: `LUA_TNONE`, `LUA_TNIL`, `LUA_TBOOLEAN`,
-     * `LUA_TLIGHTUSERDATA`, `LUA_TNUMBER`, `LUA_TSTRING`, `LUA_TTABLE`, `LUA_TFUNCTION`,
-     * `LUA_TUSERDATA`, or `LUA_TTHREAD`. The default implementation will return
-     * `LUA_TNONE`.
+     * can be a combination of any value contained in the `LuaTypes`.
      *
      * \return The Lua type that will be consumed or produced by the Property::getLuaValue
      *         and Property::setLuaValue methods.
      */
-    virtual int typeLua() const;
+    virtual ghoul::lua::LuaTypes typeLua() const = 0;
 
     /**
      * This method encodes the encapsulated \p value of this Property as a `std::string`.

--- a/include/openspace/properties/scalar/boolproperty.h
+++ b/include/openspace/properties/scalar/boolproperty.h
@@ -38,7 +38,7 @@ public:
     BoolProperty(Property::PropertyInfo info, bool value = false);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<bool>::operator=;
 

--- a/include/openspace/properties/scalar/doubleproperty.h
+++ b/include/openspace/properties/scalar/doubleproperty.h
@@ -41,7 +41,7 @@ public:
         double maxValue = std::numeric_limits<double>::max(), double stepValue = 0.01);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<double>::operator=;
 };

--- a/include/openspace/properties/scalar/floatproperty.h
+++ b/include/openspace/properties/scalar/floatproperty.h
@@ -41,7 +41,7 @@ public:
         float maxValue = std::numeric_limits<float>::max(), float stepValue = 0.01f);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<float>::operator=;
 };

--- a/include/openspace/properties/scalar/intproperty.h
+++ b/include/openspace/properties/scalar/intproperty.h
@@ -41,7 +41,7 @@ public:
         int maxValue = std::numeric_limits<int>::max(), int stepValue = 1);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<int>::operator=;
 

--- a/include/openspace/properties/scalar/longproperty.h
+++ b/include/openspace/properties/scalar/longproperty.h
@@ -42,7 +42,7 @@ public:
         long stepValue = long(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<long>::operator=;
 };

--- a/include/openspace/properties/scalar/shortproperty.h
+++ b/include/openspace/properties/scalar/shortproperty.h
@@ -42,7 +42,7 @@ public:
         short stepValue = short(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<short>::operator=;
 };

--- a/include/openspace/properties/scalar/uintproperty.h
+++ b/include/openspace/properties/scalar/uintproperty.h
@@ -42,7 +42,7 @@ public:
         unsigned int stepValue = 1);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<unsigned int>::operator=;
 

--- a/include/openspace/properties/scalar/ulongproperty.h
+++ b/include/openspace/properties/scalar/ulongproperty.h
@@ -42,7 +42,7 @@ public:
         unsigned long stepValue = 1ul);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<unsigned long>::operator=;
 };

--- a/include/openspace/properties/scalar/ushortproperty.h
+++ b/include/openspace/properties/scalar/ushortproperty.h
@@ -42,7 +42,7 @@ public:
         unsigned short stepValue = 1);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<unsigned short>::operator=;
 };

--- a/include/openspace/properties/selectionproperty.h
+++ b/include/openspace/properties/selectionproperty.h
@@ -38,7 +38,7 @@ public:
     SelectionProperty(Property::PropertyInfo info);
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     /**
      * This method sets the stored value to the provided value `val`. If the value is

--- a/include/openspace/properties/stringproperty.h
+++ b/include/openspace/properties/stringproperty.h
@@ -34,7 +34,7 @@ public:
     StringProperty(Property::PropertyInfo info, std::string value = "");
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<std::string>::operator=;
 

--- a/include/openspace/properties/templateproperty.h
+++ b/include/openspace/properties/templateproperty.h
@@ -67,14 +67,6 @@ public:
     TemplateProperty(Property::PropertyInfo info, T value);
 
     /**
-     * Returns the class name for this TemplateProperty. This method has to be specialized
-     * for each new type.
-     *
-     * \return The class name for the TemplateProperty
-     */
-    virtual std::string_view className() const override = 0;
-
-    /**
      * Returns the `std::type_info` describing the template parameter `T`. It can be used
      * to test against a ghoul::any value before trying to assign it.
      *
@@ -99,9 +91,6 @@ public:
      * \param state The Lua state from which the value will be decoded
      */
     virtual void setLuaValue(lua_State* state) override;
-
-    /// \see Property::typeLua
-    virtual int typeLua() const override = 0;
 
     /**
      * This method encodes the stored value into a std::string object. The resulting

--- a/include/openspace/properties/triggerproperty.h
+++ b/include/openspace/properties/triggerproperty.h
@@ -61,6 +61,8 @@ public:
      */
     void setLuaValue(lua_State* state) override;
 
+    ghoul::lua::LuaTypes typeLua() const;
+
     /**
      * Triggers this TriggerProperty.
      */

--- a/include/openspace/properties/vector/dvec2property.h
+++ b/include/openspace/properties/vector/dvec2property.h
@@ -40,7 +40,7 @@ public:
         glm::dvec2 stepValue = glm::dvec2(0.01));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::dvec2>::operator=;
 };

--- a/include/openspace/properties/vector/dvec3property.h
+++ b/include/openspace/properties/vector/dvec3property.h
@@ -40,7 +40,7 @@ public:
         glm::dvec3 stepValue = glm::dvec3(0.01));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::dvec3>::operator=;
 };

--- a/include/openspace/properties/vector/dvec4property.h
+++ b/include/openspace/properties/vector/dvec4property.h
@@ -40,7 +40,7 @@ public:
         glm::dvec4 stepValue = glm::dvec4(0.01));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::dvec4>::operator=;
 };

--- a/include/openspace/properties/vector/ivec2property.h
+++ b/include/openspace/properties/vector/ivec2property.h
@@ -40,7 +40,7 @@ public:
         glm::ivec2 stepValue = glm::ivec2(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::ivec2>::operator=;
 };

--- a/include/openspace/properties/vector/ivec3property.h
+++ b/include/openspace/properties/vector/ivec3property.h
@@ -40,7 +40,7 @@ public:
         glm::ivec3 stepValue = glm::ivec3(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::ivec3>::operator=;
 };

--- a/include/openspace/properties/vector/ivec4property.h
+++ b/include/openspace/properties/vector/ivec4property.h
@@ -40,7 +40,7 @@ public:
         glm::ivec4 stepValue = glm::ivec4(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::ivec4>::operator=;
 };

--- a/include/openspace/properties/vector/uvec2property.h
+++ b/include/openspace/properties/vector/uvec2property.h
@@ -40,7 +40,7 @@ public:
         glm::uvec2 stepValue = glm::uvec2(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::uvec2>::operator=;
 };

--- a/include/openspace/properties/vector/uvec3property.h
+++ b/include/openspace/properties/vector/uvec3property.h
@@ -40,7 +40,7 @@ public:
         glm::uvec3 stepValue = glm::uvec3(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::uvec3>::operator=;
 };

--- a/include/openspace/properties/vector/uvec4property.h
+++ b/include/openspace/properties/vector/uvec4property.h
@@ -40,7 +40,7 @@ public:
         glm::uvec4 stepValue = glm::uvec4(1));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::uvec4>::operator=;
 };

--- a/include/openspace/properties/vector/vec2property.h
+++ b/include/openspace/properties/vector/vec2property.h
@@ -40,7 +40,7 @@ public:
         glm::vec2 stepValue = glm::vec2(0.01f));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::vec2>::operator=;
 };

--- a/include/openspace/properties/vector/vec3property.h
+++ b/include/openspace/properties/vector/vec3property.h
@@ -40,7 +40,7 @@ public:
         glm::vec3 stepValue = glm::vec3(0.01f));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::vec3>::operator=;
 };

--- a/include/openspace/properties/vector/vec4property.h
+++ b/include/openspace/properties/vector/vec4property.h
@@ -40,7 +40,7 @@ public:
         glm::vec4 stepValue = glm::vec4(0.01f));
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<glm::vec4>::operator=;
 };

--- a/modules/volume/transferfunctionproperty.cpp
+++ b/modules/volume/transferfunctionproperty.cpp
@@ -36,8 +36,8 @@ std::string_view TransferFunctionProperty::className() const {
     return "TransferFunctionProperty";
 }
 
-int TransferFunctionProperty::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes TransferFunctionProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 openspace::volume::TransferFunction

--- a/modules/volume/transferfunctionproperty.h
+++ b/modules/volume/transferfunctionproperty.h
@@ -36,7 +36,7 @@ public:
         volume::TransferFunction value = volume::TransferFunction());
 
     std::string_view className() const override;
-    int typeLua() const override;
+    ghoul::lua::LuaTypes typeLua() const override;
 
     using TemplateProperty<volume::TransferFunction>::operator=;
 

--- a/src/properties/list/doublelistproperty.cpp
+++ b/src/properties/list/doublelistproperty.cpp
@@ -41,8 +41,8 @@ std::string_view DoubleListProperty::className() const {
     return "DoubleListProperty";
 }
 
-int DoubleListProperty::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DoubleListProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 std::string DoubleListProperty::toStringConversion() const {

--- a/src/properties/list/intlistproperty.cpp
+++ b/src/properties/list/intlistproperty.cpp
@@ -40,8 +40,8 @@ std::string_view IntListProperty::className() const {
     return "IntListProperty";
 }
 
-int IntListProperty::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes IntListProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 std::string IntListProperty::toStringConversion() const {

--- a/src/properties/list/stringlistproperty.cpp
+++ b/src/properties/list/stringlistproperty.cpp
@@ -41,8 +41,8 @@ std::string_view StringListProperty::className() const {
     return "StringListProperty";
 }
 
-int StringListProperty::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes StringListProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 std::string StringListProperty::toStringConversion() const {

--- a/src/properties/matrix/dmat2property.cpp
+++ b/src/properties/matrix/dmat2property.cpp
@@ -45,8 +45,8 @@ std::string_view DMat2Property::className() const {
     return "DMat2Property";
 }
 
-int DMat2Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DMat2Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 }  // namespace openspace::properties

--- a/src/properties/matrix/dmat3property.cpp
+++ b/src/properties/matrix/dmat3property.cpp
@@ -45,8 +45,8 @@ std::string_view DMat3Property::className() const {
     return "DMat3Property";
 }
 
-int DMat3Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DMat3Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 }  // namespace openspace::properties

--- a/src/properties/matrix/dmat4property.cpp
+++ b/src/properties/matrix/dmat4property.cpp
@@ -45,8 +45,8 @@ std::string_view DMat4Property::className() const {
     return "DMat4Property";
 }
 
-int DMat4Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DMat4Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 }  // namespace openspace::properties

--- a/src/properties/matrix/mat2property.cpp
+++ b/src/properties/matrix/mat2property.cpp
@@ -45,8 +45,8 @@ std::string_view Mat2Property::className() const {
     return "Mat2Property";
 }
 
-int Mat2Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes Mat2Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 }  // namespace openspace::properties

--- a/src/properties/matrix/mat3property.cpp
+++ b/src/properties/matrix/mat3property.cpp
@@ -45,8 +45,8 @@ std::string_view Mat3Property::className() const {
     return "Mat3Property";
 }
 
-int Mat3Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes Mat3Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 }  // namespace openspace::properties

--- a/src/properties/matrix/mat4property.cpp
+++ b/src/properties/matrix/mat4property.cpp
@@ -45,8 +45,8 @@ std::string_view Mat4Property::className() const {
     return "Mat4Property";
 }
 
-int Mat4Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes Mat4Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 }  // namespace openspace::properties

--- a/src/properties/optionproperty.cpp
+++ b/src/properties/optionproperty.cpp
@@ -50,6 +50,12 @@ std::string_view OptionProperty::className() const {
     return "OptionProperty";
 }
 
+ghoul::lua::LuaTypes OptionProperty::typeLua() const {
+    return ghoul::lua::LuaTypes(
+        ghoul::lua::LuaTypes::Number | ghoul::lua::LuaTypes::String
+    );
+}
+
 OptionProperty::DisplayType OptionProperty::displayType() const {
     return _displayType;
 }
@@ -148,6 +154,33 @@ std::string OptionProperty::getDescriptionByValue(int value) {
     }
     else {
         return "";
+    }
+}
+
+int OptionProperty::fromLuaConversion(lua_State* state) const {
+    if (ghoul::lua::hasValue<double>(state)) {
+        return static_cast<int>(ghoul::lua::value<double>(state));
+    }
+    else if (ghoul::lua::hasValue<int>(state)) {
+        return ghoul::lua::value<int>(state);
+    }
+    else if (ghoul::lua::hasValue<std::string>(state)) {
+        std::string value = ghoul::lua::value<std::string>(state);
+        const auto it = std::find_if(
+            _options.cbegin(),
+            _options.cend(),
+            [&value](const Option& option) { return option.description == value; }
+        );
+        if (it == _options.cend()) {
+            throw ghoul::RuntimeError(
+                std::format("Could not find option '{}'", value),
+                uri()
+            );
+        }
+        return it->value;
+    }
+    else {
+        throw ghoul::RuntimeError("Error extracting value in OptionProperty");
     }
 }
 

--- a/src/properties/property.cpp
+++ b/src/properties/property.cpp
@@ -91,8 +91,8 @@ const std::type_info& Property::type() const {
     return typeid(void);
 }
 
-int Property::typeLua() const {
-    return LUA_TNIL;
+ghoul::lua::LuaTypes Property::typeLua() const {
+    return ghoul::lua::LuaTypes::None;
 }
 
 std::string Property::stringValue() const {

--- a/src/properties/scalar/boolproperty.cpp
+++ b/src/properties/scalar/boolproperty.cpp
@@ -37,8 +37,8 @@ std::string_view BoolProperty::className() const {
     return "BoolProperty";
 }
 
-int BoolProperty::typeLua() const {
-    return LUA_TBOOLEAN;
+ghoul::lua::LuaTypes BoolProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Boolean;
 }
 
 bool BoolProperty::fromLuaConversion(lua_State* state) const {

--- a/src/properties/scalar/doubleproperty.cpp
+++ b/src/properties/scalar/doubleproperty.cpp
@@ -37,8 +37,8 @@ std::string_view DoubleProperty::className() const {
     return "DoubleProperty";
 }
 
-int DoubleProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes DoubleProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 } // namespace openspace::properties

--- a/src/properties/scalar/floatproperty.cpp
+++ b/src/properties/scalar/floatproperty.cpp
@@ -37,8 +37,8 @@ std::string_view FloatProperty::className() const {
     return "FloatProperty";
 }
 
-int FloatProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes FloatProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 } // namespace openspace::properties

--- a/src/properties/scalar/intproperty.cpp
+++ b/src/properties/scalar/intproperty.cpp
@@ -37,8 +37,8 @@ std::string_view IntProperty::className() const {
     return "IntProperty";
 }
 
-int IntProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes IntProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 int IntProperty::fromLuaConversion(lua_State* state) const {

--- a/src/properties/scalar/longproperty.cpp
+++ b/src/properties/scalar/longproperty.cpp
@@ -37,8 +37,8 @@ std::string_view LongProperty::className() const {
     return "LongProperty";
 }
 
-int LongProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes LongProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 } // namespace openspace::properties

--- a/src/properties/scalar/shortproperty.cpp
+++ b/src/properties/scalar/shortproperty.cpp
@@ -37,8 +37,8 @@ std::string_view ShortProperty::className() const {
     return "ShortProperty";
 }
 
-int ShortProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes ShortProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 } // namespace openspace::properties

--- a/src/properties/scalar/uintproperty.cpp
+++ b/src/properties/scalar/uintproperty.cpp
@@ -44,8 +44,8 @@ std::string_view UIntProperty::className() const {
     return "UIntProperty";
 }
 
-int UIntProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes UIntProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 unsigned int UIntProperty::fromLuaConversion(lua_State* state) const {

--- a/src/properties/scalar/ulongproperty.cpp
+++ b/src/properties/scalar/ulongproperty.cpp
@@ -44,8 +44,8 @@ std::string_view ULongProperty::className() const {
     return "ULongProperty";
 }
 
-int ULongProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes ULongProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 } // namespace openspace::properties

--- a/src/properties/scalar/ushortproperty.cpp
+++ b/src/properties/scalar/ushortproperty.cpp
@@ -44,8 +44,8 @@ std::string_view UShortProperty::className() const {
     return "UShortProperty";
 }
 
-int UShortProperty::typeLua() const {
-    return LUA_TNUMBER;
+ghoul::lua::LuaTypes UShortProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Number;
 }
 
 } // namespace openspace::properties

--- a/src/properties/selectionproperty.cpp
+++ b/src/properties/selectionproperty.cpp
@@ -47,8 +47,8 @@ std::string_view SelectionProperty::className() const {
     return "SelectionProperty";
 }
 
-int SelectionProperty::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes SelectionProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 void SelectionProperty::setValue(std::set<std::string> val) {

--- a/src/properties/stringproperty.cpp
+++ b/src/properties/stringproperty.cpp
@@ -38,8 +38,8 @@ std::string_view StringProperty::className() const {
     return "StringProperty";
 }
 
-int StringProperty::typeLua() const {
-    return LUA_TSTRING;
+ghoul::lua::LuaTypes StringProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::String;
 }
 
 std::string StringProperty::fromLuaConversion(lua_State* state) const {

--- a/src/properties/triggerproperty.cpp
+++ b/src/properties/triggerproperty.cpp
@@ -38,6 +38,10 @@ void TriggerProperty::setLuaValue(lua_State*) {
     notifyChangeListeners();
 }
 
+ghoul::lua::LuaTypes TriggerProperty::typeLua() const {
+    return ghoul::lua::LuaTypes::Nil;
+}
+
 void TriggerProperty::trigger() {
     notifyChangeListeners();
 }

--- a/src/properties/vector/dvec2property.cpp
+++ b/src/properties/vector/dvec2property.cpp
@@ -45,8 +45,8 @@ std::string_view DVec2Property::className() const {
     return "DVec2Property";
 }
 
-int DVec2Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DVec2Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/dvec3property.cpp
+++ b/src/properties/vector/dvec3property.cpp
@@ -45,8 +45,8 @@ std::string_view DVec3Property::className() const {
     return "DVec3Property";
 }
 
-int DVec3Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DVec3Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/dvec4property.cpp
+++ b/src/properties/vector/dvec4property.cpp
@@ -45,8 +45,8 @@ std::string_view DVec4Property::className() const {
     return "DVec4Property";
 }
 
-int DVec4Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes DVec4Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/ivec2property.cpp
+++ b/src/properties/vector/ivec2property.cpp
@@ -45,8 +45,8 @@ std::string_view IVec2Property::className() const {
     return "IVec2Property";
 }
 
-int IVec2Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes IVec2Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/ivec3property.cpp
+++ b/src/properties/vector/ivec3property.cpp
@@ -45,8 +45,8 @@ std::string_view IVec3Property::className() const {
     return "IVec3Property";
 }
 
-int IVec3Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes IVec3Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/ivec4property.cpp
+++ b/src/properties/vector/ivec4property.cpp
@@ -45,8 +45,8 @@ std::string_view IVec4Property::className() const {
     return "IVec4Property";
 }
 
-int IVec4Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes IVec4Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/uvec2property.cpp
+++ b/src/properties/vector/uvec2property.cpp
@@ -45,8 +45,8 @@ std::string_view UVec2Property::className() const {
     return "UVec2Property";
 }
 
-int UVec2Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes UVec2Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/uvec3property.cpp
+++ b/src/properties/vector/uvec3property.cpp
@@ -45,8 +45,8 @@ std::string_view UVec3Property::className() const {
     return "UVec3Property";
 }
 
-int UVec3Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes UVec3Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/uvec4property.cpp
+++ b/src/properties/vector/uvec4property.cpp
@@ -45,8 +45,8 @@ std::string_view UVec4Property::className() const {
     return "UVec4Property";
 }
 
-int UVec4Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes UVec4Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/vec2property.cpp
+++ b/src/properties/vector/vec2property.cpp
@@ -44,8 +44,8 @@ std::string_view Vec2Property::className() const {
     return "Vec2Property";
 }
 
-int Vec2Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes Vec2Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/vec3property.cpp
+++ b/src/properties/vector/vec3property.cpp
@@ -44,8 +44,8 @@ std::string_view Vec3Property::className() const {
     return "Vec3Property";
 }
 
-int Vec3Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes Vec3Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/properties/vector/vec4property.cpp
+++ b/src/properties/vector/vec4property.cpp
@@ -44,8 +44,8 @@ std::string_view Vec4Property::className() const {
     return "Vec4Property";
 }
 
-int Vec4Property::typeLua() const {
-    return LUA_TTABLE;
+ghoul::lua::LuaTypes Vec4Property::typeLua() const {
+    return ghoul::lua::LuaTypes::Table;
 }
 
 } // namespace openspace::properties

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -208,7 +208,7 @@ void applyRegularExpression(lua_State* L, const std::string& regex,
     using ghoul::lua::errorLocation;
     using ghoul::lua::luaTypeToString;
 
-    const int type = lua_type(L, -1);
+    const ghoul::lua::LuaTypes type = ghoul::lua::fromLuaType(lua_type(L, -1));
 
     std::vector<properties::Property*> matchingProps = findMatchesInAllProperties(
         regex,
@@ -221,7 +221,7 @@ void applyRegularExpression(lua_State* L, const std::string& regex,
     bool foundMatching = false;
     for (properties::Property* prop : matchingProps) {
         // Check that the types match
-        if (type != prop->typeLua()) {
+        if (!typeMatch(type, prop->typeLua())) {
             LERRORC(
                 "property_setValue",
                 std::format(
@@ -299,8 +299,8 @@ int setPropertyCallSingle(properties::Property& prop, const std::string& uri,
     using ghoul::lua::errorLocation;
     using ghoul::lua::luaTypeToString;
 
-    const int type = lua_type(L, -1);
-    if (type != prop.typeLua()) {
+    const ghoul::lua::LuaTypes type = ghoul::lua::fromLuaType(lua_type(L, -1));
+    if (!typeMatch(type, prop.typeLua())) {
         LERRORC(
             "property_setValue",
             std::format(


### PR DESCRIPTION
This change enables OptionProperties to be set using the description of a value, in addition to than just via indices.

For example:
```lua
openspace.setPropertyValueSingle("Dashboard.ElapsedTime.LowestTimeUnit", "Hour")
```
instead of (this is still valid)
```lua
openspace.setPropertyValueSingle("Dashboard.ElapsedTime.LowestTimeUnit", 4.000000)
```


Closes issue #3518 