### PR TITLE
Add the ability to limit-rate the dashboard updating

### DIFF
--- a/include/openspace/rendering/dashboard.h
+++ b/include/openspace/rendering/dashboard.h
@@ -28,6 +28,7 @@
 #include <openspace/properties/propertyowner.h>
 
 #include <openspace/properties/scalar/boolproperty.h>
+#include <openspace/properties/scalar/intproperty.h>
 #include <openspace/properties/vector/ivec2property.h>
 #include <openspace/rendering/dashboarditem.h>
 #include <ghoul/glm.h>
@@ -63,8 +64,10 @@ public:
 private:
     properties::BoolProperty _isEnabled;
     properties::IVec2Property _startPositionOffset;
+    properties::IntProperty _refreshRate;
 
     std::vector<std::unique_ptr<DashboardItem>> _items;
+    std::chrono::high_resolution_clock::time_point _lastRefresh;
 };
 
 } // openspace

--- a/include/openspace/rendering/dashboard.h
+++ b/include/openspace/rendering/dashboard.h
@@ -44,6 +44,14 @@ public:
     Dashboard();
     virtual ~Dashboard() override = default;
 
+    /**
+     * Renders all of the items of this Dashboard at the provided \p penPosition. The
+     * position is provided in pixels with the top-left corner being located at (0,0). The
+     * rendering of the DashboardItems will update the \p penPosition according to where
+     * the next item should be placed.
+     *
+     * \param penPosition The location at which we want to render the dashboard items
+     */
     void render(glm::vec2& penPosition);
 
     void addDashboardItem(std::unique_ptr<DashboardItem> item);
@@ -67,7 +75,7 @@ private:
     properties::IntProperty _refreshRate;
 
     std::vector<std::unique_ptr<DashboardItem>> _items;
-    std::chrono::high_resolution_clock::time_point _lastRefresh;
+    std::chrono::steady_clock::time_point _lastRefresh;
 };
 
 } // openspace

--- a/include/openspace/rendering/dashboarditem.h
+++ b/include/openspace/rendering/dashboarditem.h
@@ -45,6 +45,7 @@ public:
     explicit DashboardItem(const ghoul::Dictionary& dictionary);
 
     bool isEnabled() const;
+    virtual void update() = 0;
     virtual void render(glm::vec2& penPosition) = 0;
 
     virtual glm::vec2 size() const = 0;

--- a/include/openspace/rendering/dashboarditem.h
+++ b/include/openspace/rendering/dashboarditem.h
@@ -46,6 +46,17 @@ public:
 
     bool isEnabled() const;
     virtual void update() = 0;
+
+    /**
+     * Renders this DashboardItem at the provided \p penPosition. The position indicates
+     * where this DashboardItem should render itself and is provided in pixel-coordinates
+     * with the top-left corner of the screen being at (0,0). Each derived subclass shall
+     * update the \p penPosition according to the items that it should render. If, for
+     * example, a single line of text is rendered, the \p penPosition shall be updated by
+     * one line's worth of vertical separation.
+     *
+     * \p penPosition The position at which this DashboardItem should be rendered
+     */
     virtual void render(glm::vec2& penPosition) = 0;
 
     virtual glm::vec2 size() const = 0;

--- a/include/openspace/rendering/dashboardtextitem.h
+++ b/include/openspace/rendering/dashboardtextitem.h
@@ -42,6 +42,8 @@ public:
     explicit DashboardTextItem(const ghoul::Dictionary& dictionary, float fontSize = 10.f,
         const std::string& fontName = "Mono");
 
+    void render(glm::vec2& penPosition) override;
+
     static documentation::Documentation Documentation();
 
 protected:
@@ -49,6 +51,7 @@ protected:
     properties::FloatProperty _fontSize;
 
     std::shared_ptr<ghoul::fontrendering::Font> _font;
+    std::string _buffer;
 };
 
 } // openspace

--- a/modules/base/dashboard/dashboarditemangle.cpp
+++ b/modules/base/dashboard/dashboarditemangle.cpp
@@ -248,10 +248,10 @@ DashboardItemAngle::DashboardItemAngle(const ghoul::Dictionary& dictionary)
     }
     addProperty(_destination.nodeName);
 
-    _buffer.resize(128);
+    _localBuffer.resize(128);
 }
 
-void DashboardItemAngle::render(glm::vec2& penPosition) {
+void DashboardItemAngle::update() {
     ZoneScoped;
 
     std::pair<glm::dvec3, std::string> sourceInfo = positionAndLabel(_source);
@@ -261,19 +261,14 @@ void DashboardItemAngle::render(glm::vec2& penPosition) {
     const glm::dvec3 a = referenceInfo.first - sourceInfo.first;
     const glm::dvec3 b = destinationInfo.first - sourceInfo.first;
 
-    std::fill(_buffer.begin(), _buffer.end(), char(0));
+    std::fill(_localBuffer.begin(), _localBuffer.end(), char(0));
     if (glm::length(a) == 0.0 || glm::length(b) == 0) {
         char* end = std::format_to(
-            _buffer.data(),
+            _localBuffer.data(),
             "Could not compute angle at {} between {} and {}",
             sourceInfo.second, destinationInfo.second, referenceInfo.second
         );
-        const std::string_view text = std::string_view(
-            _buffer.data(),
-            end - _buffer.data()
-        );
-        penPosition.y -= _font->height();
-        RenderFont(*_font, penPosition, text);
+        _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
     }
     else {
         const double angle = glm::degrees(
@@ -281,15 +276,11 @@ void DashboardItemAngle::render(glm::vec2& penPosition) {
         );
 
         char* end = std::format_to(
-            _buffer.data(),
+            _localBuffer.data(),
             "Angle at {} between {} and {}: {} degrees",
             sourceInfo.second, destinationInfo.second, referenceInfo.second, angle
         );
-        const std::string_view text = std::string_view(
-            _buffer.data(), end - _buffer.data()
-        );
-        penPosition.y -= _font->height();
-        RenderFont(*_font, penPosition, text);
+        _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
     }
 }
 

--- a/modules/base/dashboard/dashboarditemangle.h
+++ b/modules/base/dashboard/dashboarditemangle.h
@@ -42,7 +42,7 @@ public:
     explicit DashboardItemAngle(const ghoul::Dictionary& dictionary);
     ~DashboardItemAngle() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 
@@ -61,7 +61,7 @@ private:
     Component _reference;
     Component _destination;
 
-    std::vector<char> _buffer;
+    std::vector<char> _localBuffer;
 };
 
 } // namespace openspace

--- a/modules/base/dashboard/dashboarditemdate.cpp
+++ b/modules/base/dashboard/dashboarditemdate.cpp
@@ -84,7 +84,7 @@ DashboardItemDate::DashboardItemDate(const ghoul::Dictionary& dictionary)
     addProperty(_timeFormat);
 }
 
-void DashboardItemDate::render(glm::vec2& penPosition) {
+void DashboardItemDate::update() {
     ZoneScoped;
 
     std::string time = SpiceManager::ref().dateFromEphemerisTime(
@@ -93,13 +93,8 @@ void DashboardItemDate::render(glm::vec2& penPosition) {
     );
 
     try {
-        penPosition.y -= _font->height();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_formatString.value(), std::make_format_args(time))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_formatString.value(), std::make_format_args(time));
     }
     catch (const std::format_error&) {
         LERRORC("DashboardItemDate", "Illegal format string");

--- a/modules/base/dashboard/dashboarditemdate.h
+++ b/modules/base/dashboard/dashboarditemdate.h
@@ -38,7 +38,7 @@ public:
     explicit DashboardItemDate(const ghoul::Dictionary& dictionary);
     ~DashboardItemDate() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/base/dashboard/dashboarditemdistance.cpp
+++ b/modules/base/dashboard/dashboarditemdistance.cpp
@@ -260,7 +260,7 @@ DashboardItemDistance::DashboardItemDistance(const ghoul::Dictionary& dictionary
     _formatString = p.formatString.value_or(_formatString);
     addProperty(_formatString);
 
-    _buffer.resize(256);
+    _localBuffer.resize(256);
 }
 
 std::pair<glm::dvec3, std::string> DashboardItemDistance::positionAndLabel(
@@ -321,7 +321,7 @@ std::pair<glm::dvec3, std::string> DashboardItemDistance::positionAndLabel(
     }
 }
 
-void DashboardItemDistance::render(glm::vec2& penPosition) {
+void DashboardItemDistance::update() {
     ZoneScoped;
 
     std::pair<glm::dvec3, std::string> sourceInfo = positionAndLabel(
@@ -344,11 +344,11 @@ void DashboardItemDistance::render(glm::vec2& penPosition) {
         dist = std::pair(convertedD, nameForDistanceUnit(unit, convertedD != 1.0));
     }
 
-    std::fill(_buffer.begin(), _buffer.end(), char(0));
+    std::fill(_localBuffer.begin(), _localBuffer.end(), char(0));
     try {
         // @CPP26(abock): This can be replaced with std::runtime_format
         char* end = std::vformat_to(
-            _buffer.data(),
+            _localBuffer.data(),
             _formatString.value(),
             std::make_format_args(
                 sourceInfo.second,
@@ -358,9 +358,7 @@ void DashboardItemDistance::render(glm::vec2& penPosition) {
             )
         );
 
-        penPosition.y -= _font->height();
-        const std::string_view t = std::string_view(_buffer.data(), end - _buffer.data());
-        RenderFont(*_font, penPosition, t);
+        _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
     }
     catch (const std::format_error&) {
         LERRORC("DashboardItemDate", "Illegal format string");

--- a/modules/base/dashboard/dashboarditemdistance.h
+++ b/modules/base/dashboard/dashboarditemdistance.h
@@ -43,7 +43,7 @@ public:
     explicit DashboardItemDistance(const ghoul::Dictionary& dictionary);
     ~DashboardItemDistance() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 
@@ -66,7 +66,7 @@ private:
     Component _source;
     Component _destination;
 
-    std::vector<char> _buffer;
+    std::vector<char> _localBuffer;
 };
 
 } // namespace openspace

--- a/modules/base/dashboard/dashboarditemelapsedtime.cpp
+++ b/modules/base/dashboard/dashboarditemelapsedtime.cpp
@@ -136,12 +136,10 @@ DashboardItemElapsedTime::DashboardItemElapsedTime(const ghoul::Dictionary& dict
     addProperty(_lowestTimeUnit);
 }
 
-void DashboardItemElapsedTime::render(glm::vec2& penPosition) {
+void DashboardItemElapsedTime::update() {
     ZoneScoped;
 
     const double delta = global::timeManager->time().j2000Seconds() - _referenceJ2000;
-
-    penPosition.y -= _font->height();
 
     if (_simplifyTime) {
         using namespace std::chrono;
@@ -161,21 +159,13 @@ void DashboardItemElapsedTime::render(glm::vec2& penPosition) {
         // Remove the " " at the end
         time = time.substr(0, time.size() - 1);
 
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_formatString.value(), std::make_format_args(time))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_formatString.value(), std::make_format_args(time));
     }
     else {
         std::string time = std::format("{} s", delta);
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_formatString.value(), std::make_format_args(time))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_formatString.value(), std::make_format_args(time));
     }
 }
 

--- a/modules/base/dashboard/dashboarditemelapsedtime.h
+++ b/modules/base/dashboard/dashboarditemelapsedtime.h
@@ -40,7 +40,7 @@ public:
     explicit DashboardItemElapsedTime(const ghoul::Dictionary& dictionary);
     ~DashboardItemElapsedTime() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/base/dashboard/dashboarditemframerate.cpp
+++ b/modules/base/dashboard/dashboarditemframerate.cpp
@@ -200,11 +200,10 @@ DashboardItemFramerate::DashboardItemFramerate(const ghoul::Dictionary& dictiona
         _shouldClearCache = true;
     });
     addProperty(_clearCache);
-
-    _buffer.resize(128);
+    _localBuffer.resize(128);
 }
 
-void DashboardItemFramerate::render(glm::vec2& penPosition) {
+void DashboardItemFramerate::update() {
     ZoneScoped;
 
     if (_shouldClearCache) {
@@ -224,28 +223,21 @@ void DashboardItemFramerate::render(glm::vec2& penPosition) {
 
     const FrametimeType frametimeType = FrametimeType(_frametimeType.value());
 
-    std::fill(_buffer.begin(), _buffer.end(), char(0));
+    std::fill(_localBuffer.begin(), _localBuffer.end(), char(0));
     char* end = format(
-        _buffer,
+        _localBuffer,
         frametimeType,
         _minDeltaTimeCache,
         _maxDeltaTimeCache
     );
-    const std::string_view text = std::string_view(_buffer.data(), end - _buffer.data());
-
-    const int nLines = text.empty() ?
-        0 :
-        static_cast<int>((std::count(text.begin(), text.end(), '\n') + 1));
-
-    penPosition.y -= _font->height() * static_cast<float>(nLines);
-    RenderFont(*_font, penPosition, text);
+    _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
 }
 
 glm::vec2 DashboardItemFramerate::size() const {
     ZoneScoped;
 
     const FrametimeType t = FrametimeType(_frametimeType.value());
-    char* end = format(_buffer, t, _minDeltaTimeCache, _maxDeltaTimeCache);
+    char* end = format(_localBuffer, t, _minDeltaTimeCache, _maxDeltaTimeCache);
     const std::string_view res = std::string_view(_buffer.data(), end - _buffer.data());
 
     if (res.empty()) {

--- a/modules/base/dashboard/dashboarditemframerate.h
+++ b/modules/base/dashboard/dashboarditemframerate.h
@@ -40,8 +40,9 @@ class DashboardItemFramerate : public DashboardTextItem {
 public:
     explicit DashboardItemFramerate(const ghoul::Dictionary& dictionary);
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
     glm::vec2 size() const override;
+
     static documentation::Documentation Documentation();
 
 private:
@@ -51,7 +52,7 @@ private:
     double _minDeltaTimeCache = 1.0;
     double _maxDeltaTimeCache = -1.0;
     bool _shouldClearCache = true;
-    mutable std::vector<char> _buffer;
+    mutable std::vector<char> _localBuffer;
 };
 
 } // openspace

--- a/modules/base/dashboard/dashboarditeminputstate.cpp
+++ b/modules/base/dashboard/dashboarditeminputstate.cpp
@@ -123,7 +123,7 @@ DashboardItemInputState::DashboardItemInputState(const ghoul::Dictionary& dictio
     addProperty(_showJoystick);
 }
 
-void DashboardItemInputState::render(glm::vec2& penPosition) {
+void DashboardItemInputState::update() {
     ZoneScoped;
 
     std::vector<std::string> text;
@@ -167,9 +167,7 @@ void DashboardItemInputState::render(glm::vec2& penPosition) {
     }
 
     if (!text.empty()) {
-        penPosition.y -= _font->height();
-        const std::string t = ghoul::join(std::move(text), "\n");
-        RenderFont(*_font, penPosition, t);
+        _buffer = ghoul::join(std::move(text), "\n");
     }
 }
 

--- a/modules/base/dashboard/dashboarditeminputstate.h
+++ b/modules/base/dashboard/dashboarditeminputstate.h
@@ -39,7 +39,7 @@ public:
     explicit DashboardItemInputState(const ghoul::Dictionary& dictionary);
     ~DashboardItemInputState() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/base/dashboard/dashboarditemmission.cpp
+++ b/modules/base/dashboard/dashboarditemmission.cpp
@@ -66,6 +66,8 @@ DashboardItemMission::DashboardItemMission(const ghoul::Dictionary& dictionary)
     : DashboardTextItem(dictionary, 15.f)
 {}
 
+void DashboardItemMission::update() {}
+
 void DashboardItemMission::render(glm::vec2& penPosition) {
     ZoneScoped;
 

--- a/modules/base/dashboard/dashboarditemmission.h
+++ b/modules/base/dashboard/dashboarditemmission.h
@@ -36,6 +36,7 @@ public:
     explicit DashboardItemMission(const ghoul::Dictionary& dictionary);
     ~DashboardItemMission() override = default;
 
+    void update() override;
     void render(glm::vec2& penPosition) override;
 
     glm::vec2 size() const override;

--- a/modules/base/dashboard/dashboarditemparallelconnection.cpp
+++ b/modules/base/dashboard/dashboarditemparallelconnection.cpp
@@ -32,8 +32,6 @@
 #include <openspace/scene/scenegraphnode.h>
 #include <openspace/util/distanceconversion.h>
 #include <ghoul/font/font.h>
-#include <ghoul/font/fontmanager.h>
-#include <ghoul/font/fontrenderer.h>
 #include <ghoul/misc/profiling.h>
 
 namespace openspace {
@@ -50,7 +48,7 @@ DashboardItemParallelConnection::DashboardItemParallelConnection(
     : DashboardTextItem(dictionary)
 {}
 
-void DashboardItemParallelConnection::render(glm::vec2& penPosition) {
+void DashboardItemParallelConnection::update() {
     ZoneScoped;
 
     const ParallelConnection::Status status = global::parallelPeer->status();
@@ -59,49 +57,43 @@ void DashboardItemParallelConnection::render(glm::vec2& penPosition) {
 
     int nLines = 1;
 
-    std::string connectionInfo;
     int nClients = static_cast<int>(nConnections);
     if (status == ParallelConnection::Status::Host) {
         nClients--;
         constexpr std::string_view Singular = "Hosting session with {} client";
         constexpr std::string_view Plural = "Hosting session with {} clients";
 
-        connectionInfo =
+        _buffer =
             (nClients == 1) ?
             std::format(Singular, nClients) :
             std::format(Plural, nClients);
     }
     else if (status == ParallelConnection::Status::ClientWithHost) {
         nClients--;
-        connectionInfo = "Session hosted by '" + hostName + "'";
+        _buffer = "Session hosted by '" + hostName + "'";
     }
     else if (status == ParallelConnection::Status::ClientWithoutHost) {
-        connectionInfo = "Host is disconnected";
+        _buffer = "Host is disconnected";
     }
 
     if (status == ParallelConnection::Status::ClientWithHost ||
         status == ParallelConnection::Status::ClientWithoutHost)
     {
-        connectionInfo += "\n";
+        _buffer += "\n";
 
         if (nClients > 2) {
             constexpr std::string_view Plural = "You and {} more clients are tuned in";
-            connectionInfo += std::format(Plural, nClients - 1);
+            _buffer += std::format(Plural, nClients - 1);
         }
         else if (nClients == 2) {
             constexpr std::string_view Singular = "You and {} more client are tuned in";
-            connectionInfo += std::format(Singular, nClients - 1);
+            _buffer += std::format(Singular, nClients - 1);
         }
         else if (nClients == 1) {
-            connectionInfo += "You are the only client";
+            _buffer += "You are the only client";
         }
 
         nLines = 2;
-    }
-
-    if (!connectionInfo.empty()) {
-        penPosition.y -= _font->height() * nLines;
-        RenderFont(*_font, penPosition, connectionInfo);
     }
 }
 

--- a/modules/base/dashboard/dashboarditemparallelconnection.h
+++ b/modules/base/dashboard/dashboarditemparallelconnection.h
@@ -36,7 +36,7 @@ public:
     explicit DashboardItemParallelConnection(const ghoul::Dictionary& dictionary);
     ~DashboardItemParallelConnection() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/base/dashboard/dashboarditempropertyvalue.cpp
+++ b/modules/base/dashboard/dashboarditempropertyvalue.cpp
@@ -107,7 +107,7 @@ DashboardItemPropertyValue::DashboardItemPropertyValue(
     addProperty(_displayString);
 }
 
-void DashboardItemPropertyValue::render(glm::vec2& penPosition) {
+void DashboardItemPropertyValue::update() {
     ZoneScoped;
 
     if (_propertyIsDirty) {
@@ -119,209 +119,136 @@ void DashboardItemPropertyValue::render(glm::vec2& penPosition) {
         return;
     }
     const std::string_view type = _property->className();
-    penPosition.y -= _font->height();
     if (type == "DoubleProperty") {
         double value = static_cast<properties::DoubleProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(value))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(value));
     }
     else if (type == "FloatProperty") {
         float value = static_cast<properties::FloatProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(value))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(value));
     }
     else if (type == "IntProperty") {
         int value = static_cast<properties::IntProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(value))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(value));
     }
     else if (type == "LongProperty") {
         long value = static_cast<properties::LongProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(value))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(value));
     }
     else if (type == "ShortProperty") {
         short value = static_cast<properties::ShortProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(value))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(value));
     }
     else if (type == "UIntProperty") {
         unsigned int v = static_cast<properties::UIntProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v));
     }
     else if (type == "ULongProperty") {
         unsigned long v = static_cast<properties::ULongProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v));
     }
     else if (type == "UShortProperty") {
         unsigned short v = static_cast<properties::UShortProperty*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v));
     }
     else if (type == "DVec2Property") {
         glm::dvec2 v = static_cast<properties::DVec2Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v.x, v.y));
     }
     else if (type == "DVec3Property") {
         glm::dvec3 v = static_cast<properties::DVec3Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y, v.z))
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z)
         );
     }
     else if (type == "DVec4Property") {
         glm::dvec4 v = static_cast<properties::DVec4Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(
-                _displayString.value(),
-                std::make_format_args(v.x, v.y, v.z, v.w)
-            )
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z, v.w)
         );
     }
     else if (type == "IVec2Property") {
         glm::ivec2 v = static_cast<properties::IVec2Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v.x, v.y));
     }
     else if (type == "IVec3Property") {
         glm::ivec3 v = static_cast<properties::IVec3Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y, v.z))
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z)
         );
     }
     else if (type == "IVec4Property") {
         glm::ivec4 v = static_cast<properties::IVec4Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(
-                _displayString.value(),
-                std::make_format_args(v.x, v.y, v.z, v.w)
-            )
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z, v.w)
         );
     }
     else if (type == "UVec2Property") {
         glm::uvec2 v = static_cast<properties::UVec2Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v.x, v.y));
     }
     else if (type == "UVec3Property") {
         glm::uvec3 v = static_cast<properties::UVec3Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y, v.z))
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z)
         );
     }
     else if (type == "UVec4Property") {
         glm::uvec4 v = static_cast<properties::UVec4Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(
-                _displayString.value(),
-                std::make_format_args(v.x, v.y, v.z, v.w)
-            )
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z, v.w)
         );
     }
     else if (type == "Vec2Property") {
         glm::vec2 v = static_cast<properties::Vec2Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(v.x, v.y));
     }
     else if (type == "Vec3Property") {
         glm::vec3 v = static_cast<properties::Vec3Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(v.x, v.y, v.z))
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z)
         );
     }
     else if (type == "Vec4Property") {
         glm::vec4 v = static_cast<properties::Vec4Property*>(_property)->value();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(
-                _displayString.value(),
-                std::make_format_args(v.x, v.y, v.z, v.w)
-            )
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(
+            _displayString.value(),
+            std::make_format_args(v.x, v.y, v.z, v.w)
         );
     }
     else {
         // Fallback if we don't have a special case above
 
         std::string value = _property->stringValue();
-        RenderFont(
-            *_font,
-            penPosition,
-            // @CPP26(abock): This can be replaced with std::runtime_format
-            std::vformat(_displayString.value(), std::make_format_args(value))
-        );
+        // @CPP26(abock): This can be replaced with std::runtime_format
+        _buffer = std::vformat(_displayString.value(), std::make_format_args(value));
     }
 }
 

--- a/modules/base/dashboard/dashboarditempropertyvalue.h
+++ b/modules/base/dashboard/dashboarditempropertyvalue.h
@@ -40,7 +40,7 @@ public:
     DashboardItemPropertyValue(const ghoul::Dictionary& dictionary);
     ~DashboardItemPropertyValue() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/base/dashboard/dashboarditemsimulationincrement.cpp
+++ b/modules/base/dashboard/dashboarditemsimulationincrement.cpp
@@ -154,7 +154,7 @@ DashboardItemSimulationIncrement::DashboardItemSimulationIncrement(
     addProperty(_regularFormat);
 }
 
-void DashboardItemSimulationIncrement::render(glm::vec2& penPosition) {
+void DashboardItemSimulationIncrement::update() {
     ZoneScoped;
 
     const double targetDt = global::timeManager->targetDeltaTime();
@@ -188,35 +188,26 @@ void DashboardItemSimulationIncrement::render(glm::vec2& penPosition) {
     std::string pauseText = global::timeManager->isPaused() ? " (Paused)" : "";
 
     try {
-        penPosition.y -= _font->height();
         if (targetDt != currentDt && !global::timeManager->isPaused()) {
             // We are in the middle of a transition
-            RenderFont(
-                *_font,
-                penPosition,
-                // @CPP26(abock): This can be replaced with std::runtime_format
-                std::vformat(
-                    _transitionFormat.value(),
-                    std::make_format_args(
-                        targetDeltaTime.first, targetDeltaTime.second,
-                        pauseText,
-                        currentDeltaTime.first, currentDeltaTime.second
-                    )
+            // @CPP26(abock): This can be replaced with std::runtime_format
+            _buffer = std::vformat(
+                _transitionFormat.value(),
+                std::make_format_args(
+                    targetDeltaTime.first, targetDeltaTime.second,
+                    pauseText,
+                    currentDeltaTime.first, currentDeltaTime.second
                 )
             );
         }
         else {
-            RenderFont(
-                *_font,
-                penPosition,
-                // @CPP26(abock): This can be replaced with std::runtime_format
-                std::vformat(
-                    _regularFormat.value(),
-                    std::make_format_args(
-                        targetDeltaTime.first,
-                        targetDeltaTime.second,
-                        pauseText
-                    )
+            // @CPP26(abock): This can be replaced with std::runtime_format
+            _buffer = std::vformat(
+                _regularFormat.value(),
+                std::make_format_args(
+                    targetDeltaTime.first,
+                    targetDeltaTime.second,
+                    pauseText
                 )
             );
         }

--- a/modules/base/dashboard/dashboarditemsimulationincrement.h
+++ b/modules/base/dashboard/dashboarditemsimulationincrement.h
@@ -40,7 +40,7 @@ public:
     explicit DashboardItemSimulationIncrement(const ghoul::Dictionary& dictionary);
     ~DashboardItemSimulationIncrement() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
     glm::vec2 size() const override;
 
     static documentation::Documentation Documentation();

--- a/modules/base/dashboard/dashboarditemspacing.cpp
+++ b/modules/base/dashboard/dashboarditemspacing.cpp
@@ -60,6 +60,8 @@ DashboardItemSpacing::DashboardItemSpacing(const ghoul::Dictionary& dictionary)
     addProperty(_spacing);
 }
 
+void DashboardItemSpacing::update() {}
+
 void DashboardItemSpacing::render(glm::vec2& penPosition) {
     penPosition.y -= _spacing;
 }

--- a/modules/base/dashboard/dashboarditemspacing.h
+++ b/modules/base/dashboard/dashboarditemspacing.h
@@ -38,6 +38,7 @@ public:
     explicit DashboardItemSpacing(const ghoul::Dictionary& dictionary);
     ~DashboardItemSpacing() override = default;
 
+    void update() override;
     void render(glm::vec2& penPosition) override;
 
     glm::vec2 size() const override;

--- a/modules/base/dashboard/dashboarditemtext.cpp
+++ b/modules/base/dashboard/dashboarditemtext.cpp
@@ -28,8 +28,6 @@
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/globals.h>
 #include <ghoul/font/font.h>
-#include <ghoul/font/fontmanager.h>
-#include <ghoul/font/fontrenderer.h>
 #include <ghoul/misc/profiling.h>
 #include <optional>
 
@@ -66,11 +64,8 @@ DashboardItemText::DashboardItemText(const ghoul::Dictionary& dictionary)
     addProperty(_text);
 }
 
-void DashboardItemText::render(glm::vec2& penPosition) {
-    ZoneScoped;
-
-    penPosition.y -= _font->height();
-    RenderFont(*_font, penPosition, _text.value());
+void DashboardItemText::update() {
+    _buffer = _text.value();
 }
 
 glm::vec2 DashboardItemText::size() const {

--- a/modules/base/dashboard/dashboarditemtext.h
+++ b/modules/base/dashboard/dashboarditemtext.h
@@ -38,7 +38,7 @@ public:
     explicit DashboardItemText(const ghoul::Dictionary& dictionary);
     ~DashboardItemText() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/base/dashboard/dashboarditemvelocity.cpp
+++ b/modules/base/dashboard/dashboarditemvelocity.cpp
@@ -34,8 +34,6 @@
 #include <openspace/scene/scenegraphnode.h>
 #include <openspace/util/distanceconversion.h>
 #include <ghoul/font/font.h>
-#include <ghoul/font/fontmanager.h>
-#include <ghoul/font/fontrenderer.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/profiling.h>
 
@@ -109,15 +107,15 @@ DashboardItemVelocity::DashboardItemVelocity(const ghoul::Dictionary& dictionary
     addProperty(_requestedUnit);
 }
 
-void DashboardItemVelocity::render(glm::vec2& penPosition) {
+void DashboardItemVelocity::update() {
     ZoneScoped;
 
     const glm::dvec3 currentPos = global::renderEngine->scene()->camera()->positionVec3();
     const glm::dvec3 dt = currentPos - _prevPosition;
+    _prevPosition = currentPos;
+
     const double speedPerFrame = glm::length(dt);
-
     const double secondsPerFrame = global::windowDelegate->averageDeltaTime();
-
     const double speedPerSecond = speedPerFrame / secondsPerFrame;
 
     std::pair<double, std::string_view> dist;
@@ -130,14 +128,7 @@ void DashboardItemVelocity::render(glm::vec2& penPosition) {
         dist = std::pair(convertedD, nameForDistanceUnit(unit, convertedD != 1.0));
     }
 
-    penPosition.y -= _font->height();
-    RenderFont(
-        *_font,
-        penPosition,
-        std::format("Camera velocity: {:.4f} {}/s", dist.first, dist.second)
-    );
-
-    _prevPosition = currentPos;
+    _buffer = std::format("Camera velocity: {:.4f} {}/s", dist.first, dist.second);
 }
 
 glm::vec2 DashboardItemVelocity::size() const {

--- a/modules/base/dashboard/dashboarditemvelocity.h
+++ b/modules/base/dashboard/dashboarditemvelocity.h
@@ -42,7 +42,7 @@ public:
     explicit DashboardItemVelocity(const ghoul::Dictionary& dictionary);
     ~DashboardItemVelocity() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 

--- a/modules/globebrowsing/src/dashboarditemglobelocation.cpp
+++ b/modules/globebrowsing/src/dashboarditemglobelocation.cpp
@@ -136,11 +136,11 @@ DashboardItemGlobeLocation::DashboardItemGlobeLocation(
     addProperty(_significantDigits);
 
     _font = global::fontManager->font(_fontName, _fontSize);
-    _buffer.resize(128);
+    _localBuffer.resize(128);
     updateFormatString();
 }
 
-void DashboardItemGlobeLocation::render(glm::vec2& penPosition) {
+void DashboardItemGlobeLocation::update() {
     ZoneScoped;
 
     GlobeBrowsingModule* module = global::moduleEngine->module<GlobeBrowsingModule>();
@@ -152,14 +152,14 @@ void DashboardItemGlobeLocation::render(glm::vec2& penPosition) {
 
     std::pair<double, std::string_view> dist = simplifyDistance(altitude);
 
-    std::fill(_buffer.begin(), _buffer.end(), char(0));
+    std::fill(_localBuffer.begin(), _localBuffer.end(), char(0));
     char* end = nullptr;
     switch (_displayFormat.value()) {
         case static_cast<int>(DisplayFormat::DecimalDegrees):
         {
             // @CPP26(abock): This can be replaced with std::runtime_format
             end = std::vformat_to(
-                _buffer.data(),
+                _localBuffer.data(),
                 _formatString,
                 std::make_format_args(lat, lon, dist.first, dist.second)
             );
@@ -188,7 +188,7 @@ void DashboardItemGlobeLocation::render(glm::vec2& penPosition) {
 
             // @CPP26(abock): This can be replaced with std::runtime_format
             end = std::vformat_to(
-                _buffer.data(),
+                _localBuffer.data(),
                 _formatString,
                 std::make_format_args(
                     latDeg, latMin, latSec, isNorth ? "N" : "S",
@@ -201,9 +201,7 @@ void DashboardItemGlobeLocation::render(glm::vec2& penPosition) {
         }
     }
 
-    penPosition.y -= _font->height();
-    const std::string_view text = std::string_view(_buffer.data(), end - _buffer.data());
-    RenderFont(*_font, penPosition, text);
+    _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
 }
 
 glm::vec2 DashboardItemGlobeLocation::size() const {

--- a/modules/globebrowsing/src/dashboarditemglobelocation.h
+++ b/modules/globebrowsing/src/dashboarditemglobelocation.h
@@ -41,7 +41,7 @@ public:
     explicit DashboardItemGlobeLocation(const ghoul::Dictionary& dictionary);
     ~DashboardItemGlobeLocation() override = default;
 
-    void render(glm::vec2& penPosition) override;
+    void update() override;
 
     glm::vec2 size() const override;
 
@@ -57,7 +57,7 @@ private:
     properties::IntProperty _significantDigits;
 
     std::string _formatString;
-    std::vector<char> _buffer;
+    std::vector<char> _localBuffer;
 };
 
 } // namespace openspace

--- a/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.cpp
+++ b/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.cpp
@@ -123,6 +123,8 @@ DashboardItemInstruments::DashboardItemInstruments(const ghoul::Dictionary& dict
     addProperty(_activeFlash);
 }
 
+void DashboardItemInstruments::update() {}
+
 void DashboardItemInstruments::render(glm::vec2& penPosition) {
     ZoneScoped;
 

--- a/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.h
+++ b/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.h
@@ -38,6 +38,7 @@ public:
     explicit DashboardItemInstruments(const ghoul::Dictionary& dictionary);
     ~DashboardItemInstruments() override = default;
 
+    void update() override;
     void render(glm::vec2& penPosition) override;
 
     glm::vec2 size() const override;

--- a/src/rendering/dashboard.cpp
+++ b/src/rendering/dashboard.cpp
@@ -53,8 +53,8 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo RefreshRateInfo = {
         "RefreshRate",
         "Refresh Rate (in ms)",
-        "The number of milliseconds between refreshes of the dashboard items. If the value is 0 
-        "the dashboard is refreshed at the same rate as the main rendering.",
+        "The number of milliseconds between refreshes of the dashboard items. If the "
+        "value is 0 the dashboard is refreshed at the same rate as the main rendering.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 } // namespace
@@ -148,9 +148,8 @@ void Dashboard::render(glm::vec2& penPosition) {
         return;
     }
 
-    auto now = std::chrono::high_resolution_clock::now();
-    // count returns values in nanoseconds, _refreshRate is in milliseconds
-    const bool needsUpdate = (now - _lastRefresh).count() > _refreshRate * 1e6;
+    auto now = std::chrono::steady_clock::now();
+    bool needsUpdate = (now - _lastRefresh) > std::chrono::milliseconds(_refreshRate);
     if (needsUpdate) {
         _lastRefresh = now;
     }

--- a/src/rendering/dashboard.cpp
+++ b/src/rendering/dashboard.cpp
@@ -53,9 +53,8 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo RefreshRateInfo = {
         "RefreshRate",
         "Refresh Rate (in ms)",
-        "If this value is bigger than 0, the value represents the number of milliseconds "
-        "between refreshs of the dashboard items. If the value is 0 the dashbaord is "
-        "refreshed at the same rate as the main rendering.",
+        "The number of milliseconds between refreshes of the dashboard items. If the value is 0 
+        "the dashboard is refreshed at the same rate as the main rendering.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 } // namespace

--- a/src/rendering/dashboardtextitem.cpp
+++ b/src/rendering/dashboardtextitem.cpp
@@ -27,7 +27,9 @@
 #include <openspace/documentation/documentation.h>
 #include <openspace/documentation/verifier.h>
 #include <openspace/engine/globals.h>
+#include <ghoul/font/font.h>
 #include <ghoul/font/fontmanager.h>
+#include <ghoul/font/fontrenderer.h>
 #include <optional>
 
 namespace {
@@ -83,6 +85,12 @@ DashboardTextItem::DashboardTextItem(const ghoul::Dictionary& dictionary, float 
     addProperty(_fontSize);
 
     _font = global::fontManager->font(_fontName, _fontSize);
+}
+
+void DashboardTextItem::render(glm::vec2& penPosition) {
+    const size_t lines = std::count(_buffer.begin(), _buffer.end(), '\n') + 1;
+    penPosition.y -= _font->height() * lines;
+    RenderFont(*_font, penPosition, _buffer);
 }
 
 } // namespace openspace

--- a/src/rendering/dashboardtextitem.cpp
+++ b/src/rendering/dashboardtextitem.cpp
@@ -88,6 +88,10 @@ DashboardTextItem::DashboardTextItem(const ghoul::Dictionary& dictionary, float 
 }
 
 void DashboardTextItem::render(glm::vec2& penPosition) {
+    if (_buffer.empty()) {
+        return;
+    }
+
     const size_t lines = std::count(_buffer.begin(), _buffer.end(), '\n') + 1;
     penPosition.y -= _font->height() * lines;
     RenderFont(*_font, penPosition, _buffer);


### PR DESCRIPTION
Adds the ability to limit the update rate of the entire dashboard. Two of the dashboard items are not affected by it as they construct their content too dynamically to cache it between updates, but those (DashboardItemInstruments, DashboardItemMission) are also used seldomly enough and also in need of a bigger rewrite

Closes #3517