### PR TITLE
Add Lua function `openspace.navigation.setFocus(identifier, shouldRetarget, shouldResetVelocities)`

### DIFF
--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -104,11 +104,10 @@ public:
     void setCamera(Camera* camera);
     void clearPreviousState();
 
-    void setFocusNode(const SceneGraphNode* focusNode,
-        bool resetVelocitiesOnChange = true);
-    void setFocusNode(const std::string& focusNode, bool resetVelocitiesOnChange = true);
-    void setAnchorNode(const std::string& anchorNode);
-    void setAimNode(const std::string& aimNode);
+    void setFocusNode(const SceneGraphNode* node, bool resetVelocities = true);
+    void setFocusNode(const std::string& identifier, bool resetVelocities= true);
+    void setAnchorNode(const std::string& identifier);
+    void setAimNode(const std::string& identifier);
 
     void startRetargetAnchor();
     void startRetargetAim();
@@ -149,7 +148,7 @@ public:
      */
     glm::dvec3 pushToSurfaceOfAnchor(const glm::dvec3& cameraPosition) const;
 
-    void updateAnchor();
+    void updateAnchorOnSync();
     std::vector<Syncable*> syncables();
 
     /**
@@ -176,8 +175,7 @@ private:
         properties::FloatProperty friction;
     };
 
-    void setAnchorNode(const SceneGraphNode* anchorNode,
-        bool resetVelocitiesOnChange = true);
+    void setAnchorNode(const SceneGraphNode* anchorNode);
     void setAimNode(const SceneGraphNode* aimNode);
 
     void updatePreviousAnchorState();
@@ -255,6 +253,7 @@ private:
     std::optional<glm::dvec3>_previousAnchorNodePosition;
     std::optional<glm::dquat> _previousAnchorNodeRotation;
     std::optional<glm::dvec3> _previousAimNodePosition;
+    bool _resetVelocitiesOnAnchorChange = true;
 
     double _currentCameraToSurfaceDistance = 0.0;
     bool _directlySetStereoDistance = false;

--- a/include/openspace/navigation/orbitalnavigator.h
+++ b/include/openspace/navigation/orbitalnavigator.h
@@ -105,7 +105,7 @@ public:
     void clearPreviousState();
 
     void setFocusNode(const SceneGraphNode* node, bool resetVelocities = true);
-    void setFocusNode(const std::string& identifier, bool resetVelocities= true);
+    void setFocusNode(const std::string& identifier, bool resetVelocities = true);
     void setAnchorNode(const std::string& identifier);
     void setAimNode(const std::string& identifier);
 
@@ -175,8 +175,8 @@ private:
         properties::FloatProperty friction;
     };
 
-    void setAnchorNode(const SceneGraphNode* anchorNode);
-    void setAimNode(const SceneGraphNode* aimNode);
+    void updateAnchorNode(const SceneGraphNode* anchorNode);
+    void updateAimNode(const SceneGraphNode* aimNode);
 
     void updatePreviousAnchorState();
     void updatePreviousAimState();

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1183,7 +1183,7 @@ void OpenSpaceEngine::postSynchronizationPreDraw() {
     global::luaConsole->update();
 
     if (!master) {
-        global::navigationHandler->orbitalNavigator().updateAnchor();
+        global::navigationHandler->orbitalNavigator().updateAnchorOnSync();
         _scene->camera()->invalidateCache();
     }
 

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -807,6 +807,7 @@ scripting::LuaLibrary NavigationHandler::luaLibrary() {
             codegen::lua::ListAllJoysticks,
             codegen::lua::TargetNextInterestingAnchor,
             codegen::lua::TargetPreviousInterestingAnchor,
+            codegen::lua::SetFocusNode,
             codegen::lua::DistanceToFocus,
             codegen::lua::DistanceToFocusBoundingSphere,
             codegen::lua::DistanceToFocusInteractionSphere

--- a/src/navigation/navigationhandler.cpp
+++ b/src/navigation/navigationhandler.cpp
@@ -807,7 +807,7 @@ scripting::LuaLibrary NavigationHandler::luaLibrary() {
             codegen::lua::ListAllJoysticks,
             codegen::lua::TargetNextInterestingAnchor,
             codegen::lua::TargetPreviousInterestingAnchor,
-            codegen::lua::SetFocusNode,
+            codegen::lua::SetFocus,
             codegen::lua::DistanceToFocus,
             codegen::lua::DistanceToFocusBoundingSphere,
             codegen::lua::DistanceToFocusInteractionSphere

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -205,10 +205,22 @@ namespace {
 }
 
 /**
- * TODO
+ * Set the current focus node for the navigation, or re-focus on it if it was already the
+ * focus node.
+ *
+ * Per default, the camera will retarget to center the focus node in the view. The
+ * velocities will also be reset so that the camera stops moving after any retargetting
+ * is done. However, both of these behaviors may be skipped using the optional arguments.
+ *
+ * \param identifier The identifier of the scene graph node to focus
+ * \param shouldRetarget If true, retarget the camera to look at the focus node
+ * \param shouldResetVelocities If true, reset the camera velocities so that the camera
+ *                              stops after its done retagetting (or immediately if
+ *                              retargetting is not done)
+ *
  */
-[[codegen::luawrap]] void setFocusNode(std::string identifier, bool shouldRetarget = true,
-                                       bool shouldResetVelocities = true)
+[[codegen::luawrap]] void setFocus(std::string identifier, bool shouldRetarget = true,
+                                   bool shouldResetVelocities = true)
 {
     using namespace openspace;
     SceneGraphNode* node = sceneGraphNode(identifier);

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -205,6 +205,28 @@ namespace {
 }
 
 /**
+ * TODO
+ */
+[[codegen::luawrap]] void setFocusNode(std::string identifier, bool shouldRetarget = true,
+                                       bool shouldResetVelocities = true)
+{
+    using namespace openspace;
+    SceneGraphNode* node = sceneGraphNode(identifier);
+    if (!node) {
+        throw ghoul::lua::LuaError("Unknown node: " + identifier);
+    }
+
+    global::navigationHandler->orbitalNavigator().setFocusNode(
+        node,
+        shouldResetVelocities
+    );
+
+    if (shouldRetarget) {
+        global::navigationHandler->orbitalNavigator().startRetargetAnchor();
+    }
+}
+
+/**
  * Bind an axis of a joystick to be used as a certain type, and optionally define
  * detailed settings for the axis.
  *

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -209,14 +209,14 @@ namespace {
  * focus node.
  *
  * Per default, the camera will retarget to center the focus node in the view. The
- * velocities will also be reset so that the camera stops moving after any retargetting
+ * velocities will also be reset so that the camera stops moving after any retargeting
  * is done. However, both of these behaviors may be skipped using the optional arguments.
  *
  * \param identifier The identifier of the scene graph node to focus
  * \param shouldRetarget If true, retarget the camera to look at the focus node
  * \param shouldResetVelocities If true, reset the camera velocities so that the camera
- *                              stops after its done retargetting (or immediately if
- *                              retargetting is not done)
+ *                              stops after its done retargeting (or immediately if
+ *                              retargeting is not done)
  *
  */
 [[codegen::luawrap]] void setFocus(std::string identifier, bool shouldRetarget = true,

--- a/src/navigation/navigationhandler_lua.inl
+++ b/src/navigation/navigationhandler_lua.inl
@@ -215,7 +215,7 @@ namespace {
  * \param identifier The identifier of the scene graph node to focus
  * \param shouldRetarget If true, retarget the camera to look at the focus node
  * \param shouldResetVelocities If true, reset the camera velocities so that the camera
- *                              stops after its done retagetting (or immediately if
+ *                              stops after its done retargetting (or immediately if
  *                              retargetting is not done)
  *
  */

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -1093,8 +1093,7 @@ void OrbitalNavigator::setFocusNode(const std::string& identifier, bool resetVel
     _aim = std::string();
 }
 
-void OrbitalNavigator::updateAnchorNode(const SceneGraphNode* anchorNode)
-{
+void OrbitalNavigator::updateAnchorNode(const SceneGraphNode* anchorNode) {
     if (!_anchorNode) {
         _directlySetStereoDistance = true;
     }

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -1090,7 +1090,7 @@ void OrbitalNavigator::setFocusNode(const SceneGraphNode* node, bool resetVeloci
 void OrbitalNavigator::setFocusNode(const std::string& identifier, bool resetVelocities) {
     _resetVelocitiesOnAnchorChange = resetVelocities;
     _anchor = identifier;
-    _aim = std::string("");
+    _aim = std::string();
 }
 
 void OrbitalNavigator::updateAnchorNode(const SceneGraphNode* anchorNode)
@@ -1099,7 +1099,7 @@ void OrbitalNavigator::updateAnchorNode(const SceneGraphNode* anchorNode)
         _directlySetStereoDistance = true;
     }
 
-    bool changedAnchor = _anchorNode != anchorNode;
+    const bool changedAnchor = _anchorNode != anchorNode;
     _anchorNode = anchorNode;
     _syncedAnchorNode = anchorNode ? anchorNode->identifier() : "";
 

--- a/src/navigation/orbitalnavigator.cpp
+++ b/src/navigation/orbitalnavigator.cpp
@@ -530,7 +530,7 @@ OrbitalNavigator::OrbitalNavigator()
         SceneGraphNode* node = sceneGraphNode(_anchor.value());
         if (node) {
             const SceneGraphNode* previousAnchor = _anchorNode;
-            setAnchorNode(node);
+            updateAnchorNode(node);
             global::eventEngine->publishEvent<events::EventFocusNodeChanged>(
                 previousAnchor,
                 node
@@ -545,12 +545,12 @@ OrbitalNavigator::OrbitalNavigator()
 
     _aim.onChange([this]() {
         if (_aim.value().empty()) {
-            setAimNode(nullptr);
+            updateAimNode(nullptr);
             return;
         }
         SceneGraphNode* node = sceneGraphNode(_aim.value());
         if (node) {
-            setAimNode(node);
+            updateAimNode(node);
         }
         else {
             LERROR(std::format(
@@ -1093,7 +1093,7 @@ void OrbitalNavigator::setFocusNode(const std::string& identifier, bool resetVel
     _aim = std::string("");
 }
 
-void OrbitalNavigator::setAnchorNode(const SceneGraphNode* anchorNode)
+void OrbitalNavigator::updateAnchorNode(const SceneGraphNode* anchorNode)
 {
     if (!_anchorNode) {
         _directlySetStereoDistance = true;
@@ -1124,7 +1124,7 @@ void OrbitalNavigator::clearPreviousState() {
     _previousAimNodePosition = std::nullopt;
 }
 
-void OrbitalNavigator::setAimNode(const SceneGraphNode* aimNode) {
+void OrbitalNavigator::updateAimNode(const SceneGraphNode* aimNode) {
     _retargetAimInterpolator.end();
     _aimNode = aimNode;
     updatePreviousAimState();


### PR DESCRIPTION
Add a Lua API function for setting the focus node, which includes options to control whether to retarget and/or reset camera velocities

Will be used by the new UI to greatly simplify the code in the navigation panel, and can hopefully be useful in general for our users as well. Maybe in the ShowBuilder, for example?

The code for dealing with the anchor/aim updates has always been confusing, so I also did some minor tidying among the function names to try to reduce that confusion.  