### PR TITLE
Add a new DashboardItem to show the camera orientation

### DIFF
--- a/data/assets/examples/dashboarditem/dashboarditemcameraorientation/cameraorientation.asset
+++ b/data/assets/examples/dashboarditem/dashboarditemcameraorientation/cameraorientation.asset
@@ -1,0 +1,16 @@
+-- Basic
+-- This example adds a dashboard item to the main dashboard that shows the current camera
+-- orientation
+
+local Item = {
+  Identifier = "DashboardItemCameraOrientation_Example",
+  Type = "DashboardItemCameraOrientation"
+}
+
+asset.onInitialize(function()
+  openspace.dashboard.addDashboardItem(Item)
+end)
+
+asset.onDeinitialize(function()
+  openspace.dashboard.removeDashboardItem(Item)
+end)

--- a/data/assets/examples/dashboarditem/dashboarditemcameraorientation/cameraorientation.asset
+++ b/data/assets/examples/dashboarditem/dashboarditemcameraorientation/cameraorientation.asset
@@ -1,6 +1,6 @@
 -- Basic
 -- This example adds a dashboard item to the main dashboard that shows the current camera
--- orientation
+-- orientation.
 
 local Item = {
   Identifier = "DashboardItemCameraOrientation_Example",

--- a/modules/base/CMakeLists.txt
+++ b/modules/base/CMakeLists.txt
@@ -26,6 +26,7 @@ include(${PROJECT_SOURCE_DIR}/support/cmake/module_definition.cmake)
 
 set(HEADER_FILES
   dashboard/dashboarditemangle.h
+  dashboard/dashboarditemcameraorientation.h
   dashboard/dashboarditemdate.h
   dashboard/dashboarditemdistance.h
   dashboard/dashboarditemelapsedtime.h
@@ -93,6 +94,7 @@ source_group("Header Files" FILES ${HEADER_FILES})
 
 set(SOURCE_FILES
   dashboard/dashboarditemangle.cpp
+  dashboard/dashboarditemcameraorientation.cpp
   dashboard/dashboarditemdate.cpp
   dashboard/dashboarditemdistance.cpp
   dashboard/dashboarditemelapsedtime.cpp

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -25,6 +25,7 @@
 #include <modules/base/basemodule.h>
 
 #include <modules/base/dashboard/dashboarditemangle.h>
+#include <modules/base/dashboard/dashboarditemcameraorientation.h>
 #include <modules/base/dashboard/dashboarditemdate.h>
 #include <modules/base/dashboard/dashboarditemdistance.h>
 #include <modules/base/dashboard/dashboarditemelapsedtime.h>
@@ -115,6 +116,9 @@ void BaseModule::internalInitialize(const ghoul::Dictionary&) {
     ghoul_assert(fDashboard, "Dashboard factory was not created");
 
     fDashboard->registerClass<DashboardItemAngle>("DashboardItemAngle");
+    fDashboard->registerClass<DashboardItemCameraOrientation>(
+        "DashboardItemCameraOrientation"
+    );
     fDashboard->registerClass<DashboardItemDate>("DashboardItemDate");
     fDashboard->registerClass<DashboardItemDistance>("DashboardItemDistance");
     fDashboard->registerClass<DashboardItemElapsedTime>("DashboardItemElapsedTime");
@@ -228,6 +232,7 @@ void BaseModule::internalDeinitializeGL() {
 std::vector<documentation::Documentation> BaseModule::documentations() const {
     return {
         DashboardItemAngle::Documentation(),
+        DashboardItemCameraOrientation::Documentation(),
         DashboardItemDate::Documentation(),
         DashboardItemDistance::Documentation(),
         DashboardItemElapsedTime::Documentation(),

--- a/modules/base/dashboard/dashboarditemcameraorientation.cpp
+++ b/modules/base/dashboard/dashboarditemcameraorientation.cpp
@@ -32,6 +32,9 @@
 #include <ghoul/font/font.h>
 
 namespace {
+    // This `DashboardItem` shows the current camera orientation in the yaw, pitch, and
+    // roll directions in degrees. Note that the camera's orientation is relative to the
+    // global coordinate system used in the system.
     struct [[codegen::Dictionary(DashboardItemCameraOrientation)]] Parameters {
     };
 #include "dashboarditemcameraorientation_codegen.cpp"

--- a/modules/base/dashboard/dashboarditemcameraorientation.cpp
+++ b/modules/base/dashboard/dashboarditemcameraorientation.cpp
@@ -57,10 +57,11 @@ void DashboardItemCameraOrientation::update() {
     const Camera* camera = global::renderEngine->scene()->camera();
     const glm::dquat orientation = camera->rotationQuaternion();
     const glm::dvec3 pitchYawRoll = glm::eulerAngles(orientation);
+    const glm::dvec3 pitchYawRollDeg = glm::degrees(pitchYawRoll);
 
     _buffer = std::format(
         "Yaw: {:.2f}\nPitch: {:.2f}\nRoll: {:.2f}",
-        pitchYawRoll.y, pitchYawRoll.x, pitchYawRoll.z
+        pitchYawRollDeg.y, pitchYawRollDeg.x, pitchYawRollDeg.z
     );
 }
 

--- a/modules/base/dashboard/dashboarditemcameraorientation.cpp
+++ b/modules/base/dashboard/dashboarditemcameraorientation.cpp
@@ -1,0 +1,73 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <modules/base/dashboard/dashboarditemcameraorientation.h>
+
+#include <openspace/camera/camera.h>
+#include <openspace/documentation/documentation.h>
+#include <openspace/engine/globals.h>
+#include <openspace/rendering/renderengine.h>
+#include <openspace/scene/scene.h>
+#include <ghoul/font/font.h>
+
+namespace {
+    struct [[codegen::Dictionary(DashboardItemCameraOrientation)]] Parameters {
+    };
+#include "dashboarditemcameraorientation_codegen.cpp"
+} // namespace
+
+namespace openspace {
+
+documentation::Documentation DashboardItemCameraOrientation::Documentation() {
+    return codegen::doc<Parameters>(
+        "base_dashboarditem_cameraorientation",
+        DashboardTextItem::Documentation()
+    );
+}
+
+DashboardItemCameraOrientation::DashboardItemCameraOrientation(
+                                                      const ghoul::Dictionary& dictionary)
+    : DashboardTextItem(dictionary)
+{}
+
+void DashboardItemCameraOrientation::update() {
+    ZoneScoped;
+
+    const Camera* camera = global::renderEngine->scene()->camera();
+    const glm::dquat orientation = camera->rotationQuaternion();
+    const glm::dvec3 pitchYawRoll = glm::eulerAngles(orientation);
+
+    _buffer = std::format(
+        "Yaw: {:.2f}\nPitch: {:.2f}\nRoll: {:.2f}",
+        pitchYawRoll.y, pitchYawRoll.x, pitchYawRoll.z
+    );
+}
+
+glm::vec2 DashboardItemCameraOrientation::size() const {
+    ZoneScoped;
+
+    return _font->boundingBox("Yaw: 0.00\nPitch: 0.00\nRoll: 0.00");
+}
+
+} // namespace openspace

--- a/modules/base/dashboard/dashboarditemcameraorientation.h
+++ b/modules/base/dashboard/dashboarditemcameraorientation.h
@@ -1,0 +1,46 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_MODULE_BASE___DASHBOARDITEMCAMERAORIENTATION___H__
+#define __OPENSPACE_MODULE_BASE___DASHBOARDITEMCAMERAORIENTATION___H__
+
+#include <openspace/rendering/dashboardtextitem.h>
+
+namespace openspace {
+
+class DashboardItemCameraOrientation : public DashboardTextItem {
+public:
+    explicit DashboardItemCameraOrientation(const ghoul::Dictionary& dictionary);
+    ~DashboardItemCameraOrientation() override = default;
+
+    void update() override;
+
+    glm::vec2 size() const override;
+
+    static documentation::Documentation Documentation();
+};
+
+} // namespace openspace
+
+#endif // __OPENSPACE_MODULE_BASE___DASHBOARDITEMCAMERAORIENTATION___H__


### PR DESCRIPTION
Shows the orientation in Yaw/Pitch/Roll.  Added this as we had screenshots submitted as bugs and trying to recreate it, we have information about the camera location, but not the orientation.