### PR TITLE
Spice transform: add a "time offset" option

### DIFF
--- a/data/assets/examples/rotation/spicerotation/timeoffset.asset
+++ b/data/assets/examples/rotation/spicerotation/timeoffset.asset
@@ -1,0 +1,37 @@
+-- Time offset
+-- This asset creates a rotation provided by a SPICE kernel and applies it to a
+-- SceneGraphNode that only displays coordinate axes. The rotation of the coordinate axes
+-- are determined by SPICE, in this case pretending that the coordinate axes are rotating
+-- at the same rate as Earth. In this specific example, the orientation is offset 8h back
+-- compared to the actual in-game time in OpenSpace.
+
+-- Load the default SPICE kernels, which is the planetary constants and the DE430 kernel
+asset.require("spice/core")
+
+local Node = {
+  Identifier = "SpiceRotation_Example_TimeOffset",
+  Transform = {
+    Rotation = {
+      Type = "SpiceRotation",
+      SourceFrame = "IAU_EARTH",
+      DestinationFrame = "GALACTIC",
+      TimeOffset = -8 * 60 * 60
+    }
+  },
+  Renderable = {
+    Type = "RenderableCartesianAxes"
+  },
+  GUI = {
+    Name = "SpiceRotation - Time Offset",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)
+

--- a/data/assets/examples/translation/spicetranslation/timeoffset.asset
+++ b/data/assets/examples/translation/spicetranslation/timeoffset.asset
@@ -1,0 +1,37 @@
+-- Fixed Date
+-- This asset creates a time-varying translation with information from a SPICE kernel and
+-- applies it to a SceneGraphNode that only displays coordinate axes. The position of the
+-- coordinate axes are determined by SPICE, in this case pretending that the axes are
+-- orbiting the same way the Moon does around Earth. In this specific example, the position
+-- is offset 8h back compared to the actual in-game time in OpenSpace.
+-- For more information about SPICE see: https://naif.jpl.nasa.gov/naif/
+
+-- Load the default SPICE kernels, which are the planetary constants and the DE430 kernel
+asset.require("spice/core")
+
+local Node = {
+  Identifier = "SpiceTranslation_Example_TimeOffset",
+  Transform = {
+    Translation = {
+      Type = "SpiceTranslation",
+      Target = "MOON",
+      Observer = "EARTH",
+      TimeOffset = -8 * 60 * 60
+    }
+  },
+  Renderable = {
+    Type = "RenderableCartesianAxes"
+  },
+  GUI = {
+    Name = "SpiceTranslation - Time Offset",
+    Path = "/Examples"
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)

--- a/modules/space/rotation/spicerotation.h
+++ b/modules/space/rotation/spicerotation.h
@@ -28,6 +28,7 @@
 #include <openspace/scene/rotation.h>
 
 #include <openspace/properties/stringproperty.h>
+#include <openspace/properties/scalar/floatproperty.h>
 #include <openspace/scene/timeframe.h>
 #include <optional>
 
@@ -48,6 +49,7 @@ private:
     properties::StringProperty _sourceFrame;
     properties::StringProperty _destinationFrame;
     properties::StringProperty _fixedDate;
+    properties::FloatProperty _timeOffset;
 
     ghoul::mm_unique_ptr<TimeFrame> _timeFrame;
     std::optional<double> _fixedEphemerisTime;

--- a/modules/space/translation/spicetranslation.h
+++ b/modules/space/translation/spicetranslation.h
@@ -28,6 +28,7 @@
 #include <openspace/scene/translation.h>
 
 #include <openspace/properties/stringproperty.h>
+#include <openspace/properties/scalar/floatproperty.h>
 #include <optional>
 
 namespace openspace {
@@ -45,6 +46,7 @@ private:
     properties::StringProperty _observer;
     properties::StringProperty _frame;
     properties::StringProperty _fixedDate;
+    properties::FloatProperty _timeOffset;
 
     // We are accessing these values every frame and when retrieving a string from the
     // StringProperty, it allocates some new memory, which we want to prevent. Until the


### PR DESCRIPTION
Lets SpiceTranslation and SpiceRotation compute the transformation with a given time offset compared to the simulation time (or fixed date if one is configured).

Closes #3531.