### PR TITLE
Specify background and text colors for actions

### DIFF
--- a/include/openspace/interaction/action.h
+++ b/include/openspace/interaction/action.h
@@ -25,7 +25,9 @@
 #ifndef __OPENSPACE_CORE___ACTION___H__
 #define __OPENSPACE_CORE___ACTION___H__
 
+#include <ghoul/glm.h>
 #include <ghoul/misc/boolean.h>
+#include <optional>
 #include <string>
 
 namespace openspace::interaction {
@@ -58,6 +60,16 @@ struct Action {
     /// interface. The individual path components are separated by '/' with a leading '/'
     /// for the root path
     std::string guiPath = "/";
+
+    /// This variable, if specified, will be used as a hint to any potential user
+    /// interface as a desired background color. This can be used, for example, by the
+    /// user to visually group similar Actions together
+    std::optional<glm::vec4> color;
+
+    /// This variable, if specified, will be used as a hint to any potential user
+    /// interface as a desired text color. This can be used, for example, by the user to
+    /// visually group similar Actions together
+    std::optional<glm::vec4> textColor;
 
     /// If this value is set to `Yes`, the execution of this action is restricted to the
     /// current OpenSpace instance. If it is `No`, it is synchronized to other OpenSpace

--- a/src/documentation/documentationengine.cpp
+++ b/src/documentation/documentationengine.cpp
@@ -68,6 +68,8 @@ namespace {
     constexpr const char* ActionTitle = "Actions";
     constexpr const char* GuiNameKey = "guiName";
     constexpr const char* CommandKey = "command";
+    constexpr const char* ColorKey = "color";
+    constexpr const char* TextColorKey = "textColor";
 
     // Factory
     constexpr const char* MembersKey = "members";
@@ -705,6 +707,12 @@ nlohmann::json DocumentationEngine::generateActionJson() const {
         d[GuiNameKey] = action.name;
         d[DocumentationKey] = action.documentation;
         d[CommandKey] = action.command;
+        if (action.color.has_value()) {
+            d[ColorKey] = std::format("{}", action.color);
+        }
+        if (action.textColor.has_value()) {
+            d[TextColorKey] = std::format("{}", action.textColor);
+        }
         res[DataKey].push_back(d);
     }
     sortJson(res[DataKey], NameKey);

--- a/src/interaction/actionmanager_lua.inl
+++ b/src/interaction/actionmanager_lua.inl
@@ -88,6 +88,16 @@ struct [[codegen::Dictionary(Action)]] Action {
     // not provided, the default value is /
     std::optional<std::string> guiPath;
 
+    /// This parameter, if specified, will be used as a hint to any potential user
+    /// interface as a desired background color. This can be used, for example, to
+    /// visually group similar Actions together
+    std::optional<glm::vec4> color [[codegen::color()]];
+
+    /// This parameter, if specified, will be used as a hint to any potential user
+    /// interface as a desired text color. This can be used, for example, to visually
+    /// group similar Actions together
+    std::optional<glm::vec4> textColor [[codegen::color()]];
+
     // Determines whether the provided command will be executed locally or will be sent to
     // connected computers in a cluster or parallel connection environment
     std::optional<bool> isLocal;
@@ -115,6 +125,8 @@ struct [[codegen::Dictionary(Action)]] Action {
     a.command = std::move(action.command);
     a.name = action.name.value_or(a.name);
     a.documentation = action.documentation.value_or(a.documentation);
+    a.color = action.color;
+    a.textColor = action.textColor;
     a.guiPath = action.guiPath.value_or(a.guiPath);
     if (!a.guiPath.starts_with('/')) {
         throw ghoul::RuntimeError(
@@ -151,6 +163,12 @@ struct [[codegen::Dictionary(Action)]] Action {
     res.setValue("Command", action.command);
     res.setValue("Name", action.name);
     res.setValue("Documentation", action.documentation);
+    if (action.color.has_value()) {
+        res.setValue("Color", glm::dvec4(*action.color));
+    }
+    if (action.textColor.has_value()) {
+        res.setValue("TextColor", glm::dvec4(*action.textColor));
+    }
     res.setValue("GuiPath", action.guiPath);
     res.setValue("IsLocal", action.isLocal == interaction::Action::IsLocal::Yes);
     return res;
@@ -172,6 +190,12 @@ struct [[codegen::Dictionary(Action)]] Action {
         d.setValue("Command", a.command);
         d.setValue("Name", a.name);
         d.setValue("Documentation", a.documentation);
+        if (a.color.has_value()) {
+            d.setValue("Color", glm::dvec4(*a.color));
+        }
+        if (a.textColor.has_value()) {
+            d.setValue("TextColor", glm::dvec4(*a.textColor));
+        }
         d.setValue("GuiPath", a.guiPath);
         d.setValue("IsLocal", a.isLocal == interaction::Action::IsLocal::Yes);
         res.push_back(d);


### PR DESCRIPTION
Add the ability to the backend to specify a background color and a text color for actions.  Addresses the backend work for #3538