### PR TITLE
Move the OpenSpaceData folder by default into the user folder

### DIFF
--- a/openspace.cfg
+++ b/openspace.cfg
@@ -120,7 +120,7 @@ Paths = {
     SCRIPTS = "${BASE}/scripts",
     SHADERS = "${BASE}/shaders",
     TEMPORARY = "${BASE}/temp",
-    GLOBEBROWSING = os.getenv("OPENSPACE_GLOBEBROWSING") or "${BASE}/../OpenSpaceData"
+    GLOBEBROWSING = os.getenv("OPENSPACE_GLOBEBROWSING") or "${USER}/globebrowsing"
 }
 
 ModuleConfigurations = {


### PR DESCRIPTION
It is not by default placed in `user/globebrowsing`

Closes #3512