### PR TITLE
Add ScreenSpaceRenderableRenderable class

### DIFF
--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable.asset
@@ -1,10 +1,10 @@
 -- Basic
--- Create a screenspace image plane that shows the content of a local image file on disk.
--- In this case we use a test image from the OpenSpace/data folder.
+-- Creates a screenspace image that shows a spherical grid as an example for any
+-- [Renderable](#renderable) that can be displayed.
 
 local Object = {
   Type = "ScreenSpaceRenderableRenderable",
-  Identifier = "Test",
+  Identifier = "ScreenSpaceRenderableRenderable_Example",
   Renderable = {
     Type = "RenderableSphericalGrid",
     Opacity = 1.0,

--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_axes.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_axes.asset
@@ -6,7 +6,7 @@
 
 local Object = {
   Type = "ScreenSpaceRenderableRenderable",
-  Identifier = "ScreenSpaceImageOnline_Axes",
+  Identifier = "ScreenSpaceRenderableRenderable_Example_Axes",
   Renderable = {
     Type = "RenderableCartesianAxes"
   },

--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_axes.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_axes.asset
@@ -1,0 +1,24 @@
+-- Axes
+-- Creates a screenspace image that renders three Cartesian axes into the screen space
+-- window. This example also modifies the original camera position to give an oblique view
+-- onto the axes and increases the field of view of the camera to a wider degree. We also
+-- set the background color to be fully opaque to make it easier to see the axes.
+
+local Object = {
+  Type = "ScreenSpaceRenderableRenderable",
+  Identifier = "ScreenSpaceImageOnline_Axes",
+  Renderable = {
+    Type = "RenderableCartesianAxes"
+  },
+  BackgroundColor = { 0.0, 0.0, 0.0, 1.0 },
+  CameraPosition = { 1.0, 1.0, 1.0 },
+  CameraFov = 80.0
+}
+
+asset.onInitialize(function()
+  openspace.addScreenSpaceRenderable(Object)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeScreenSpaceRenderable(Object)
+end)

--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model-distance.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model-distance.asset
@@ -1,8 +1,8 @@
--- Model
+-- Model Distance
 -- Creates a screen space window into which 3D model of the Eiffel tower is rendered. As
 -- the objects are rendered in meter scale, and the Eiffel tower is about 300m tall, we
--- both shrink the rendering to make the entire model fit into the view and also modify
--- the position of the camera.
+-- place the camera at a great distance to be able to see the entire Eiffel tower at the
+-- same time
 
 -- Download the model file for the Eiffel tower
 local modelFolder = asset.resource({
@@ -14,13 +14,7 @@ local modelFolder = asset.resource({
 
 local Object = {
   Type = "ScreenSpaceRenderableRenderable",
-  Identifier = "ScreenSpaceImageOnline_Model",
-  Transform = {
-    Scale = {
-      Type = "StaticScale",
-      Scale = 0.0002
-    }
-  },
+  Identifier = "ScreenSpaceImageOnline_ModelDistance",
   Renderable = {
     Type = "RenderableModel",
     GeometryFile = modelFolder .. "eiffeltower.osmodel",
@@ -34,8 +28,8 @@ local Object = {
     }
   },
   Scale = 1.25,
-  CameraPosition = { 0.0, 1.0, 2.0 },
-  CameraCenter = { 0.0, 0.5, 0.0 }
+  CameraPosition = { 0.0, 3500.0, 9000.0 },
+  CameraCenter = { 0.0, 2750.0, 0.0 }
 }
 
 asset.onInitialize(function()

--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model-distance.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model-distance.asset
@@ -2,7 +2,7 @@
 -- Creates a screen space window into which 3D model of the Eiffel tower is rendered. As
 -- the objects are rendered in meter scale, and the Eiffel tower is about 300m tall, we
 -- place the camera at a great distance to be able to see the entire Eiffel tower at the
--- same time
+-- same time.
 
 -- Download the model file for the Eiffel tower
 local modelFolder = asset.resource({
@@ -14,7 +14,7 @@ local modelFolder = asset.resource({
 
 local Object = {
   Type = "ScreenSpaceRenderableRenderable",
-  Identifier = "ScreenSpaceImageOnline_ModelDistance",
+  Identifier = "ScreenSpaceRenderableRenderable_Example_ModelDistance",
   Renderable = {
     Type = "RenderableModel",
     GeometryFile = modelFolder .. "eiffeltower.osmodel",

--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model.asset
@@ -1,0 +1,47 @@
+-- Model
+-- Creates a screenspace image that renders a 3D model of the Eiffel tower into the screen
+-- space window. As the objects are rendered in meter scale, and the Eiffel tower is about
+-- 300m tall, we both shrink the rendering to make the entire model fit into the view and
+-- also modify the position of the camera
+
+-- Download the model file for the Eiffel tower
+local modelFolder = asset.resource({
+  Name = "Scale Eiffel Tower",
+  Type = "HttpSynchronization",
+  Identifier = "scale_model_eiffel_tower",
+  Version = 1
+})
+
+local Object = {
+  Type = "ScreenSpaceRenderableRenderable",
+  Identifier = "ScreenSpaceImageOnline_Model",
+  Transform = {
+    Scale = {
+      Type = "StaticScale",
+      Scale = 0.0002
+    }
+  },
+  Renderable = {
+    Type = "RenderableModel",
+    GeometryFile = modelFolder .. "eiffeltower.osmodel",
+    RotationVector = { 0.0, 45.0, 0.0 },
+    LightSources = {
+      {
+        Identifier = "Camera",
+        Type = "CameraLightSource",
+        Intensity = 5.0
+      }
+    }
+  },
+  Scale = 1.25,
+  CameraPosition = { 0.0, 1.0, 2.0 },
+  CameraCenter = { 0.0, 0.5, 0.0 }
+}
+
+asset.onInitialize(function()
+  openspace.addScreenSpaceRenderable(Object)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeScreenSpaceRenderable(Object)
+end)

--- a/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacerenderablerenderable/renderablerenderable_model.asset
@@ -14,7 +14,7 @@ local modelFolder = asset.resource({
 
 local Object = {
   Type = "ScreenSpaceRenderableRenderable",
-  Identifier = "ScreenSpaceImageOnline_Model",
+  Identifier = "ScreenSpaceRenderableRenderable_Example_Model",
   Transform = {
     Scale = {
       Type = "StaticScale",

--- a/data/screenspacerenderablerenderable.asset
+++ b/data/screenspacerenderablerenderable.asset
@@ -1,0 +1,22 @@
+-- Basic
+-- Create a screenspace image plane that shows the content of a local image file on disk.
+-- In this case we use a test image from the OpenSpace/data folder.
+
+local Object = {
+  Type = "ScreenSpaceRenderableRenderable",
+  Identifier = "Test",
+  Renderable = {
+    Type = "RenderableSphericalGrid",
+    Opacity = 1.0,
+    Color = { 0.3, 0.84, 1.0 },
+    LineWidth = 2.0
+  }
+}
+
+asset.onInitialize(function()
+  openspace.addScreenSpaceRenderable(Object)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeScreenSpaceRenderable(Object)
+end)

--- a/modules/base/CMakeLists.txt
+++ b/modules/base/CMakeLists.txt
@@ -72,6 +72,7 @@ set(HEADER_FILES
   rendering/screenspaceframebuffer.h
   rendering/screenspaceimagelocal.h
   rendering/screenspaceimageonline.h
+  rendering/screenspacerenderablerenderable.h
   rotation/timelinerotation.h
   rotation/constantrotation.h
   rotation/fixedrotation.h
@@ -142,6 +143,7 @@ set(SOURCE_FILES
   rendering/screenspaceframebuffer.cpp
   rendering/screenspaceimagelocal.cpp
   rendering/screenspaceimageonline.cpp
+  rendering/screenspacerenderablerenderable.cpp
   rotation/timelinerotation.cpp
   rotation/constantrotation.cpp
   rotation/fixedrotation.cpp

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -68,6 +68,7 @@
 #include <modules/base/rendering/screenspaceimagelocal.h>
 #include <modules/base/rendering/screenspaceimageonline.h>
 #include <modules/base/rendering/screenspaceframebuffer.h>
+#include <modules/base/rendering/screenspacerenderablerenderable.h>
 #include <modules/base/rotation/constantrotation.h>
 #include <modules/base/rotation/fixedrotation.h>
 #include <modules/base/rotation/luarotation.h>
@@ -110,6 +111,9 @@ void BaseModule::internalInitialize(const ghoul::Dictionary&) {
     fSsRenderable->registerClass<ScreenSpaceImageLocal>("ScreenSpaceImageLocal");
     fSsRenderable->registerClass<ScreenSpaceImageOnline>("ScreenSpaceImageOnline");
     fSsRenderable->registerClass<ScreenSpaceFramebuffer>("ScreenSpaceFramebuffer");
+    fSsRenderable->registerClass<ScreenSpaceRenderableRenderable>(
+        "ScreenSpaceRenderableRenderable"
+    );
 
 
     ghoul::TemplateFactory<DashboardItem>* fDashboard =
@@ -281,6 +285,7 @@ std::vector<documentation::Documentation> BaseModule::documentations() const {
         ScreenSpaceFramebuffer::Documentation(),
         ScreenSpaceImageLocal::Documentation(),
         ScreenSpaceImageOnline::Documentation(),
+        ScreenSpaceRenderableRenderable::Documentation(),
 
         ConstantRotation::Documentation(),
         FixedRotation::Documentation(),

--- a/modules/base/rendering/screenspacedashboard.cpp
+++ b/modules/base/rendering/screenspacedashboard.cpp
@@ -101,7 +101,7 @@ bool ScreenSpaceDashboard::initializeGL() {
     ScreenSpaceFramebuffer::initializeGL();
 
     addRenderFunction([this]() {
-        glm::vec2 penPosition = glm::vec2(0.f, _size.value().w);
+        glm::vec2 penPosition = glm::vec2(0.f, _size.value().x);
 
         if (_useMainDashboard) {
             global::dashboard->render(penPosition);

--- a/modules/base/rendering/screenspaceframebuffer.cpp
+++ b/modules/base/rendering/screenspaceframebuffer.cpp
@@ -55,7 +55,7 @@ documentation::Documentation ScreenSpaceFramebuffer::Documentation() {
 
 ScreenSpaceFramebuffer::ScreenSpaceFramebuffer(const ghoul::Dictionary& dictionary)
     : ScreenSpaceRenderable(dictionary)
-    , _size(SizeInfo, glm::vec4(0), glm::vec4(0), glm::vec4(16384))
+    , _size(SizeInfo, glm::vec4(16), glm::vec4(16), glm::vec4(16384))
 {
     documentation::testSpecificationAndThrow(
         Documentation(),
@@ -73,11 +73,6 @@ ScreenSpaceFramebuffer::ScreenSpaceFramebuffer(const ghoul::Dictionary& dictiona
         else {
             setIdentifier("ScreenSpaceFramebuffer" + std::to_string(iIdentifier));
         }
-    }
-
-    if (_guiName.empty()) {
-        // Adding an extra space to the user-facing name as it looks nicer
-        setGuiName("ScreenSpaceFramebuffer " + std::to_string(iIdentifier));
     }
 
     const glm::vec2 resolution = global::windowDelegate->currentDrawBufferResolution();
@@ -114,15 +109,13 @@ void ScreenSpaceFramebuffer::render(const RenderData& renderData) {
 
     if (!_renderFunctions.empty()) {
         std::array<GLint, 4> viewport;
-        //glGetIntegerv(GL_VIEWPORT, viewport);
-        global::renderEngine->openglStateCache().viewport(viewport.data());
+        glGetIntegerv(GL_VIEWPORT, viewport.data());
         glViewport(
-            static_cast<GLint>(-size.x * xratio),
-            static_cast<GLint>(-size.y * yratio),
-            static_cast<GLsizei>(resolution.x * xratio),
-            static_cast<GLsizei>(resolution.y * yratio)
+            static_cast<GLint>(size.x),
+            static_cast<GLint>(size.y),
+            static_cast<GLsizei>(size.z),
+            static_cast<GLsizei>(size.w)
         );
-        global::renderEngine->openglStateCache().setViewportState(viewport.data());
 
         const GLint defaultFBO = ghoul::opengl::FramebufferObject::getActiveObject();
         _framebuffer->activate();

--- a/modules/base/rendering/screenspaceframebuffer.h
+++ b/modules/base/rendering/screenspaceframebuffer.h
@@ -27,7 +27,7 @@
 
 #include <openspace/rendering/screenspacerenderable.h>
 
-#include <openspace/properties/vector/vec4property.h>
+#include <openspace/properties/vector/vec2property.h>
 
 namespace ghoul::opengl {
     class FramebufferObject;
@@ -56,7 +56,7 @@ public:
     void render(const RenderData& renderData) override;
     bool isReady() const override;
 
-    void setSize(glm::vec4 size);
+    void setSize(glm::vec2 size);
     void addRenderFunction(RenderFunction renderFunction);
     void removeAllRenderFunctions();
 
@@ -64,7 +64,7 @@ public:
 
 protected:
     void createFramebuffer();
-    properties::Vec4Property _size;
+    properties::Vec2Property _size;
 
 private:
     void bindTexture() override;

--- a/modules/base/rendering/screenspacerenderablerenderable.cpp
+++ b/modules/base/rendering/screenspacerenderablerenderable.cpp
@@ -1,0 +1,146 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <modules/base/rendering/screenspacerenderablerenderable.h>
+
+#include <openspace/camera/camera.h>
+#include <openspace/util/updatestructures.h>
+
+namespace {
+    constexpr openspace::properties::Property::PropertyInfo CameraPositionInfo = {
+        "CameraPosition",
+        "Camera Position",
+        ""
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo CameraCenterInfo = {
+        "CameraCenter",
+        "Camera Center",
+        ""
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo CameraUpInfo = {
+        "CameraUp",
+        "Camera Up",
+        ""
+    };
+
+    constexpr openspace::properties::Property::PropertyInfo CameraFovInfo = {
+        "CameraFov",
+        "Camera Field-of-view",
+        ""
+    };
+
+    struct [[codegen::Dictionary(ScreenSpaceRenderableRenderable)]] Parameters {
+        std::optional<std::string> identifier [[codegen::private()]];
+
+        ghoul::Dictionary renderable [[codegen::reference("renderable")]];
+    };
+#include "screenspacerenderablerenderable_codegen.cpp"
+} // namespace
+
+namespace openspace {
+
+documentation::Documentation ScreenSpaceRenderableRenderable::Documentation() {
+    return codegen::doc<Parameters>("base_screenspace_renderable");
+}
+
+ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
+                                                      const ghoul::Dictionary& dictionary)
+    : ScreenSpaceFramebuffer(dictionary)
+    , _cameraPosition(
+        CameraPositionInfo,
+        glm::vec3(0.f, 0.f, 1.f),
+        glm::vec3(-50.f, -50.f, -50.f),
+        glm::vec3(50.f, 50.f, 50.f)
+    )
+    , _cameraCenter(CameraCenterInfo, glm::vec3(0.f), glm::vec3(-1.f), glm::vec3(1.f))
+    , _cameraUp(CameraUpInfo, glm::vec3(0.f, 1.f, 0.f), glm::vec3(-1.f), glm::vec3(1.f))
+    , _cameraFov(CameraFovInfo, 45.f, 5.f, 90.f)
+{
+    const Parameters p = codegen::bake<Parameters>(dictionary);
+
+    std::string identifier = p.identifier.value_or("ScreenSpaceRenderableRenderable");
+    setIdentifier(makeUniqueIdentifier(std::move(identifier)));
+
+    addProperty(_cameraPosition);
+    addProperty(_cameraCenter);
+    addProperty(_cameraUp);
+    addProperty(_cameraFov);
+
+    _renderable = Renderable::createFromDictionary(p.renderable);
+    _renderable->initialize();
+    addPropertySubOwner(_renderable.get());
+}
+
+ScreenSpaceRenderableRenderable::~ScreenSpaceRenderableRenderable() {}
+
+bool ScreenSpaceRenderableRenderable::initializeGL() {
+    ScreenSpaceFramebuffer::initializeGL();
+
+    _renderable->initializeGL();
+
+    addRenderFunction([this]() {
+        glClearColor(0.f, 0.f, 0.f, 1.f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        Camera camera;
+        glm::mat4 view = glm::lookAt(
+            _cameraPosition.value(),
+            _cameraCenter.value(),
+            _cameraUp.value()
+        );
+        camera.sgctInternal.setViewMatrix(view);
+
+        glm::mat4 proj = glm::perspectiveFov(
+            glm::radians(_cameraFov.value()),
+            _size.value().z,
+            _size.value().w,
+            0.1f,
+            20.f
+        );
+        camera.sgctInternal.setProjectionMatrix(proj);
+
+        openspace::RenderData renderData = {
+            .camera = camera,
+            .time = Time(0)
+        };
+        RendererTasks tasks;
+        _renderable->render(renderData, tasks);
+    });
+    return true;
+}
+
+bool ScreenSpaceRenderableRenderable::deinitializeGL() {
+    _renderable->deinitializeGL();
+    _renderable->deinitialize();
+    return ScreenSpaceFramebuffer::deinitializeGL();
+}
+
+void ScreenSpaceRenderableRenderable::update() {
+    UpdateData updateData;
+    _renderable->update(updateData);
+}
+
+} // namespace openspace

--- a/modules/base/rendering/screenspacerenderablerenderable.cpp
+++ b/modules/base/rendering/screenspacerenderablerenderable.cpp
@@ -63,8 +63,8 @@ namespace {
 
     constexpr openspace::properties::Property::PropertyInfo CameraFovInfo = {
         "CameraFov",
-        "Camera Field-of-view",
-        "The camera's field-of-view in degrees."
+        "Camera Field of view",
+        "The camera's field of view in degrees."
     };
 
     const openspace::properties::PropertyOwner::PropertyOwnerInfo TransformInfo = {
@@ -74,35 +74,47 @@ namespace {
         "Renderable."
     };
 
+    // This [ScreenSpaceRenderable](#core_screenspacerenderable) object can render any
+    // [Renderable](#renderable) type into an image that is shown in screen space. This
+    // can be used to display a rendered object as an overlay in front of the regular 3D
+    // rendering of the scene.
+    //
+    // Note to use this ScreenSpaceRenderable, it might be necessary to specify the `size`
+    // parameter, which determines the resolution of the inset window into which the
+    // Renderable is rendered. For many use cases, the default should suffice, however.
+    //
+    // A possible use-case for the ScreenSpaceRenderable would be to show a 3D model of a
+    // spacecraft without the need to place it at a position in the 3D scene with the need
+    // to fly to that object to talk about it.
     struct [[codegen::Dictionary(ScreenSpaceRenderableRenderable)]] Parameters {
         std::optional<std::string> identifier [[codegen::private()]];
 
-        // The [Renderable](#renderable) object that should be shown in this ScreenSpace
-        // object. See the list of creatable renderable objects for options that can be
-        // used for this type
+        // The [Renderable](#renderable) object that os shown in this ScreenSpace object.
+        // See the list of creatable renderable objects for options that can be used for
+        // this type.
         ghoul::Dictionary renderable [[codegen::reference("renderable")]];
 
         struct Transform {
-            // The [Translation](#core_transform_translation) object that should be used
-            // for the provided [Renderable](#renderable). If no value is specified, a
+            // The [Translation](#core_transform_translation) object that is used for the
+            // provided [Renderable](#renderable). If no value is specified, a
             // [StaticTranslation](#base_transform_translation_static) is created instead.
             std::optional<ghoul::Dictionary> translation
                 [[codegen::reference("core_transform_translation")]];
 
-            // The [Rotation](#core_transform_rotation) object that should be used for the
+            // The [Rotation](#core_transform_rotation) object that is used for the
             // provided [Renderable](#renderable). If no value is specified, a
             // [StaticRotation](#base_transform_rotation_static) is created instead.
             std::optional<ghoul::Dictionary> rotation
                 [[codegen::reference("core_transform_rotation")]];
 
-            // The [Scale](#core_transform_scale) object that should be used for the
-            // provided [Renderable](#renderable). If no value is specified, a
+            // The [Scale](#core_transform_scale) object that is used for the provided
+            // [Renderable](#renderable). If no value is specified, a
             // [StaticScale](#base_transform_scale_static) is created instead.
             std::optional<ghoul::Dictionary> scale
                 [[codegen::reference("core_transform_scale")]];
         };
-        // The collection of transformation that are applied to the
-        // [Renderable](#renderable) before it is shown on screen
+        // The collection of transformations that are applied to the
+        // [Renderable](#renderable) before it is shown on screen.
         std::optional<Transform> transform;
 
         // Specifies the start date that is used to control the renderable and the
@@ -245,8 +257,8 @@ bool ScreenSpaceRenderableRenderable::initializeGL() {
 
         glm::mat4 proj = glm::perspectiveFov(
             glm::radians(_cameraFov.value()),
-            _size.value().z,
-            _size.value().w,
+            _size.value().x,
+            _size.value().y,
             0.1f,
             20.f
         );

--- a/modules/base/rendering/screenspacerenderablerenderable.cpp
+++ b/modules/base/rendering/screenspacerenderablerenderable.cpp
@@ -25,37 +25,102 @@
 #include <modules/base/rendering/screenspacerenderablerenderable.h>
 
 #include <openspace/camera/camera.h>
+#include <openspace/rendering/renderable.h>
+#include <openspace/scene/rotation.h>
+#include <openspace/scene/scale.h>
+#include <openspace/scene/translation.h>
 #include <openspace/util/updatestructures.h>
 
 namespace {
+    constexpr openspace::properties::Property::PropertyInfo TimeInfo = {
+        "Time",
+        "Time",
+        "The time (in J2000 seconds) that is used to calculate transformations and the "
+        "renderable's data."
+    };
+
     constexpr openspace::properties::Property::PropertyInfo CameraPositionInfo = {
         "CameraPosition",
         "Camera Position",
-        ""
+        "Specifies the location of the virtual camera that is showing the renderable "
+        "class. This position is provided in meters."
     };
 
     constexpr openspace::properties::Property::PropertyInfo CameraCenterInfo = {
         "CameraCenter",
         "Camera Center",
-        ""
+        "The location of the camera's focal point. The camera's view direction will "
+        "always be pointing at the provided center location. This position is provided "
+        "in meters."
     };
 
     constexpr openspace::properties::Property::PropertyInfo CameraUpInfo = {
         "CameraUp",
         "Camera Up",
-        ""
+        "The direction that is 'up' for the provided camera. This value does not have "
+        "any units."
     };
 
     constexpr openspace::properties::Property::PropertyInfo CameraFovInfo = {
         "CameraFov",
         "Camera Field-of-view",
-        ""
+        "The camera's field-of-view in degrees."
+    };
+
+    const openspace::properties::PropertyOwner::PropertyOwnerInfo TransformInfo = {
+        "Transform",
+        "Transform",
+        "The Translation, Rotation, and Scale that are applied to the rendered "
+        "Renderable."
     };
 
     struct [[codegen::Dictionary(ScreenSpaceRenderableRenderable)]] Parameters {
         std::optional<std::string> identifier [[codegen::private()]];
 
+        // The [Renderable](#renderable) object that should be shown in this ScreenSpace
+        // object. See the list of creatable renderable objects for options that can be
+        // used for this type
         ghoul::Dictionary renderable [[codegen::reference("renderable")]];
+
+        struct Transform {
+            // The [Translation](#core_transform_translation) object that should be used
+            // for the provided [Renderable](#renderable). If no value is specified, a
+            // [StaticTranslation](#base_transform_translation_static) is created instead.
+            std::optional<ghoul::Dictionary> translation
+                [[codegen::reference("core_transform_translation")]];
+
+            // The [Rotation](#core_transform_rotation) object that should be used for the
+            // provided [Renderable](#renderable). If no value is specified, a
+            // [StaticRotation](#base_transform_rotation_static) is created instead.
+            std::optional<ghoul::Dictionary> rotation
+                [[codegen::reference("core_transform_rotation")]];
+
+            // The [Scale](#core_transform_scale) object that should be used for the
+            // provided [Renderable](#renderable). If no value is specified, a
+            // [StaticScale](#base_transform_scale_static) is created instead.
+            std::optional<ghoul::Dictionary> scale
+                [[codegen::reference("core_transform_scale")]];
+        };
+        // The collection of transformation that are applied to the
+        // [Renderable](#renderable) before it is shown on screen
+        std::optional<Transform> transform;
+
+        // Specifies the start date that is used to control the renderable and the
+        // transforms. If no value is specified the date of 2000 JAN 01 12:00:00 is used
+        // instead.
+        std::optional<std::string> time [[codegen::datetime()]];
+
+        // [[codegen::verbatim(CameraPositionInfo.description)]]
+        std::optional<glm::vec3> cameraPosition;
+
+        // [[codegen::verbatim(CameraCenterInfo.description)]]
+        std::optional<glm::vec3> cameraCenter;
+
+        // [[codegen::verbatim(CameraUpInfo.description)]]
+        std::optional<glm::vec3> cameraUp;
+
+        // [[codegen::verbatim(CameraFovInfo.description)]]
+        std::optional<float> cameraFov;
     };
 #include "screenspacerenderablerenderable_codegen.cpp"
 } // namespace
@@ -63,17 +128,26 @@ namespace {
 namespace openspace {
 
 documentation::Documentation ScreenSpaceRenderableRenderable::Documentation() {
-    return codegen::doc<Parameters>("base_screenspace_renderable");
+    return codegen::doc<Parameters>(
+        "base_screenspace_renderable",
+        ScreenSpaceFramebuffer::Documentation()
+    );
 }
 
 ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
                                                       const ghoul::Dictionary& dictionary)
     : ScreenSpaceFramebuffer(dictionary)
+    , _time(
+        TimeInfo,
+        0.0,
+        -std::numeric_limits<double>::max(),
+        std::numeric_limits<double>::max()
+    )
     , _cameraPosition(
         CameraPositionInfo,
-        glm::vec3(0.f, 0.f, 1.f),
-        glm::vec3(-50.f, -50.f, -50.f),
-        glm::vec3(50.f, 50.f, 50.f)
+        glm::vec3(0.f, 2.f, 2.f),
+        glm::vec3(-10.f, -10.f, -10.f),
+        glm::vec3(10.f, 10.f, 10.f)
     )
     , _cameraCenter(CameraCenterInfo, glm::vec3(0.f), glm::vec3(-1.f), glm::vec3(1.f))
     , _cameraUp(CameraUpInfo, glm::vec3(0.f, 1.f, 0.f), glm::vec3(-1.f), glm::vec3(1.f))
@@ -84,14 +158,65 @@ ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
     std::string identifier = p.identifier.value_or("ScreenSpaceRenderableRenderable");
     setIdentifier(makeUniqueIdentifier(std::move(identifier)));
 
+    if (p.time.has_value()) {
+        _time = Time(*p.time).j2000Seconds();
+    }
+    _time.onChange([this]() { _previousTime = _time; });
+    addProperty(_time);
+
+    _cameraPosition = p.cameraPosition.value_or(_cameraPosition);
     addProperty(_cameraPosition);
+    _cameraCenter = p.cameraCenter.value_or(_cameraCenter);
     addProperty(_cameraCenter);
+    _cameraUp = p.cameraUp.value_or(_cameraUp);
     addProperty(_cameraUp);
+    _cameraFov = p.cameraFov.value_or(_cameraFov);
     addProperty(_cameraFov);
 
     _renderable = Renderable::createFromDictionary(p.renderable);
     _renderable->initialize();
     addPropertySubOwner(_renderable.get());
+
+    _transform = ghoul::mm_unique_ptr<properties::PropertyOwner>(
+        new properties::PropertyOwner(TransformInfo)
+    );
+    addPropertySubOwner(_transform.get());
+
+    if (p.transform.has_value() && p.transform->translation.has_value()) {
+        _translation = Translation::createFromDictionary(*p.transform->translation);
+    }
+    else {
+        ghoul::Dictionary translation;
+        translation.setValue("Type", std::string("StaticTranslation"));
+        translation.setValue("Position", glm::dvec3(0.0));
+        _translation = Translation::createFromDictionary(translation);
+    }
+    _translation->initialize();
+    _transform->addPropertySubOwner(_translation.get());
+
+    if (p.transform.has_value() && p.transform->rotation.has_value()) {
+        _rotation = Rotation::createFromDictionary(*p.transform->rotation);
+    }
+    else {
+        ghoul::Dictionary rotation;
+        rotation.setValue("Type", std::string("StaticRotation"));
+        rotation.setValue("Rotation", glm::dvec3(0.0));
+        _rotation = Rotation::createFromDictionary(rotation);
+    }
+    _rotation->initialize();
+    _transform->addPropertySubOwner(_rotation.get());
+
+    if (p.transform.has_value() && p.transform->scale.has_value()) {
+        _scale = Scale::createFromDictionary(*p.transform->scale);
+    }
+    else {
+        ghoul::Dictionary scale;
+        scale.setValue("Type", std::string("StaticScale"));
+        scale.setValue("Scale", 1.0);
+        _scale = Scale::createFromDictionary(scale);
+    }
+    _scale->initialize();
+    _transform->addPropertySubOwner(_scale.get());
 }
 
 ScreenSpaceRenderableRenderable::~ScreenSpaceRenderableRenderable() {}
@@ -102,14 +227,19 @@ bool ScreenSpaceRenderableRenderable::initializeGL() {
     _renderable->initializeGL();
 
     addRenderFunction([this]() {
-        glClearColor(0.f, 0.f, 0.f, 1.f);
+        glm::vec4 bg = _backgroundColor;
+        glClearColor(bg.r, bg.g, bg.b, bg.a);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         Camera camera;
+        // @TODO (2025-03-24, abock): These two lines can be removed once #3573 is fixed
+        camera.setPositionVec3(glm::dvec3(0.0, 0.0, 0.0));
+        camera.setRotation(glm::dvec3(0.0, 0.0, 0.0));
+
         glm::mat4 view = glm::lookAt(
             _cameraPosition.value(),
             _cameraCenter.value(),
-            _cameraUp.value()
+            glm::normalize(_cameraUp.value())
         );
         camera.sgctInternal.setViewMatrix(view);
 
@@ -124,7 +254,12 @@ bool ScreenSpaceRenderableRenderable::initializeGL() {
 
         openspace::RenderData renderData = {
             .camera = camera,
-            .time = Time(0)
+            .time = Time(_time),
+            .modelTransform = {
+                .translation = _translation->position(),
+                .rotation = _rotation->matrix(),
+                .scale = _scale->scaleValue()
+            }
         };
         RendererTasks tasks;
         _renderable->render(renderData, tasks);
@@ -139,7 +274,20 @@ bool ScreenSpaceRenderableRenderable::deinitializeGL() {
 }
 
 void ScreenSpaceRenderableRenderable::update() {
-    UpdateData updateData;
+    UpdateData updateData = {
+        .time = Time(_time),
+        .previousFrameTime = Time(_previousTime)
+    };
+
+    _translation->update(updateData);
+    updateData.modelTransform.translation = _translation->position();
+
+    _rotation->update(updateData);
+    updateData.modelTransform.rotation = _rotation->matrix();
+
+    _scale->update(updateData);
+    updateData.modelTransform.scale = _scale->scaleValue();
+
     _renderable->update(updateData);
 }
 

--- a/modules/base/rendering/screenspacerenderablerenderable.cpp
+++ b/modules/base/rendering/screenspacerenderablerenderable.cpp
@@ -79,9 +79,10 @@ namespace {
     // can be used to display a rendered object as an overlay in front of the regular 3D
     // rendering of the scene.
     //
-    // Note to use this ScreenSpaceRenderable, it might be necessary to specify the `size`
-    // parameter, which determines the resolution of the inset window into which the
-    // Renderable is rendered. For many use cases, the default should suffice, however.
+    // Note that to use this `ScreenSpaceRenderable`, it might be necessary to specify the
+    // `size` parameter, which determines the resolution of the inset window into which
+    // the Renderable is rendered. For many use cases, the default should suffice,
+    // however.
     //
     // A possible use-case for the ScreenSpaceRenderable would be to show a 3D model of a
     // spacecraft without the need to place it at a position in the 3D scene with the need
@@ -89,7 +90,7 @@ namespace {
     struct [[codegen::Dictionary(ScreenSpaceRenderableRenderable)]] Parameters {
         std::optional<std::string> identifier [[codegen::private()]];
 
-        // The [Renderable](#renderable) object that os shown in this ScreenSpace object.
+        // The [Renderable](#renderable) object that is shown in this ScreenSpace object.
         // See the list of creatable renderable objects for options that can be used for
         // this type.
         ghoul::Dictionary renderable [[codegen::reference("renderable")]];

--- a/modules/base/rendering/screenspacerenderablerenderable.h
+++ b/modules/base/rendering/screenspacerenderablerenderable.h
@@ -22,45 +22,42 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#ifndef __OPENSPACE_MODULE_BASE___SCREENSPACEDASHBOARD___H__
-#define __OPENSPACE_MODULE_BASE___SCREENSPACEDASHBOARD___H__
+#ifndef __OPENSPACE_MODULE_BASE___SCREENSPACERENDERABLERENDERABLE___H__
+#define __OPENSPACE_MODULE_BASE___SCREENSPACERENDERABLERENDERABLE___H__
 
-#include <modules/base/rendering/screenspaceframebuffer.h>
+#include <modules/base//rendering/screenspaceframebuffer.h>
 
-#include <openspace/properties/scalar/boolproperty.h>
-#include <openspace/rendering/dashboard.h>
-
-namespace ghoul::fontrendering {
-    class Font;
-    class FontRenderer;
-} // namespace ghoul::fontrendering
+#include <openspace/properties/scalar/floatproperty.h>
+#include <openspace/properties/vector/vec3property.h>
 
 namespace openspace {
 
-namespace documentation { struct Documentation; }
-namespace scripting { struct LuaLibrary; }
+class Renderable;
 
-class ScreenSpaceDashboard : public ScreenSpaceFramebuffer {
+namespace documentation { struct Documentation; }
+
+class ScreenSpaceRenderableRenderable : public ScreenSpaceFramebuffer {
 public:
-    explicit ScreenSpaceDashboard(const ghoul::Dictionary& dictionary);
-    virtual ~ScreenSpaceDashboard() override = default;
+    using RenderFunction = std::function<void()>;
+
+    explicit ScreenSpaceRenderableRenderable(const ghoul::Dictionary& dictionary);
+    virtual ~ScreenSpaceRenderableRenderable() override;
 
     bool initializeGL() override;
-
+    bool deinitializeGL() override;
     void update() override;
-
-    Dashboard& dashboard();
-    const Dashboard& dashboard() const;
-
-    static scripting::LuaLibrary luaLibrary();
 
     static documentation::Documentation Documentation();
 
 private:
-    Dashboard _dashboard;
-    properties::BoolProperty _useMainDashboard;
+    ghoul::mm_unique_ptr<Renderable> _renderable = nullptr;
+
+    properties::Vec3Property _cameraPosition;
+    properties::Vec3Property _cameraCenter;
+    properties::Vec3Property _cameraUp;
+    properties::FloatProperty _cameraFov;
 };
 
-} // namespace openspace
+} //namespace openspace
 
-#endif // __OPENSPACE_MODULE_BASE___SCREENSPACEDASHBOARD___H__
+#endif // __OPENSPACE_MODULE_BASE___SCREENSPACERENDERABLERENDERABLE___H__

--- a/modules/base/rendering/screenspacerenderablerenderable.h
+++ b/modules/base/rendering/screenspacerenderablerenderable.h
@@ -27,12 +27,19 @@
 
 #include <modules/base//rendering/screenspaceframebuffer.h>
 
+#include <openspace/properties/scalar/boolproperty.h>
+#include <openspace/properties/scalar/doubleproperty.h>
 #include <openspace/properties/scalar/floatproperty.h>
 #include <openspace/properties/vector/vec3property.h>
 
 namespace openspace {
 
+namespace properties { class PropertyOwner; }
+
 class Renderable;
+class Rotation;
+class Scale;
+class Translation;
 
 namespace documentation { struct Documentation; }
 
@@ -50,8 +57,14 @@ public:
     static documentation::Documentation Documentation();
 
 private:
+    ghoul::mm_unique_ptr<Translation> _translation = nullptr;
+    ghoul::mm_unique_ptr<properties::PropertyOwner> _transform = nullptr;
+    ghoul::mm_unique_ptr<Rotation> _rotation = nullptr;
+    ghoul::mm_unique_ptr<Scale> _scale = nullptr;
     ghoul::mm_unique_ptr<Renderable> _renderable = nullptr;
 
+    double _previousTime = 0.0;
+    properties::DoubleProperty _time;
     properties::Vec3Property _cameraPosition;
     properties::Vec3Property _cameraCenter;
     properties::Vec3Property _cameraUp;

--- a/src/properties/propertyowner.cpp
+++ b/src/properties/propertyowner.cpp
@@ -302,7 +302,8 @@ void PropertyOwner::addPropertySubOwner(openspace::properties::PropertyOwner* ow
         const bool hasProp = hasProperty(owner->identifier());
         if (hasProp) {
             LERROR(std::format(
-                "PropertyOwner '{}'s name already names a Property", owner->identifier()
+                "PropertyOwner '{}'s identifier is already in use for a Property",
+                owner->identifier()
             ));
             return;
         }

--- a/src/scene/scenegraphnode.cpp
+++ b/src/scene/scenegraphnode.cpp
@@ -924,7 +924,7 @@ void SceneGraphNode::renderDebugSphere(const Camera& camera, double size,
 void SceneGraphNode::setParent(SceneGraphNode& parent) {
     ghoul_assert(_parent != nullptr, "Node must be attached to a parent");
 
-    parent.attachChild(_parent->detachChild(*this));
+    _parent = &parent;
 }
 
 void SceneGraphNode::attachChild(ghoul::mm_unique_ptr<SceneGraphNode> child) {


### PR DESCRIPTION
New ScreenSpace type that takes a `Renderable` and renders it into a framebuffer displayed in a screenspace renderable window.

While I didn't like the name ScreenSpaceRenderableRenderable in the beginning, I grew on me over the weekend.  Still very much open for better names.

![image](https://github.com/user-attachments/assets/7a5f71fc-7ba5-4daa-a47e-e1f193234f69)

![image](https://github.com/user-attachments/assets/ce743b42-a481-4508-8e93-1ba73a662023)

Closes #1720
