### PR TITLE
Add ability to configure horizontal field of view per window instead

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -924,24 +924,40 @@ void setSgctDelegateFunctions() {
 
         return Engine::instance().windows().front()->id();
     };
+    sgctDelegate.nameForWindow = [](int windowIdx) {
+        ZoneScoped;
+
+        ghoul_assert(
+            windowIdx >= 0 &&
+            windowIdx < Engine::instance().windows().size(),
+            "Invalid window index"
+        );
+        return Engine::instance().windows()[windowIdx]->name();
+    };
     sgctDelegate.openGLProcedureAddress = [](const char* func) {
         ZoneScoped;
 
         return glfwGetProcAddress(func);
     };
-    sgctDelegate.getHorizFieldOfView = []() {
+    sgctDelegate.horizFieldOfView = [](int windowIdx) {
         ZoneScoped;
 
-        return static_cast<double>(
-            Engine::instance().windows().front()->horizFieldOfViewDegrees()
+        ghoul_assert(
+            windowIdx >= 0 &&
+            windowIdx < Engine::instance().windows().size(),
+            "Invalid window index"
         );
+        return Engine::instance().windows()[windowIdx]->horizFieldOfViewDegrees();
     };
-    sgctDelegate.setHorizFieldOfView = [](float hFovDeg) {
+    sgctDelegate.setHorizFieldOfView = [](int windowIdx, float hFovDeg) {
         ZoneScoped;
 
-        for (std::unique_ptr<sgct::Window> const& w : Engine::instance().windows()) {
-            w->setHorizFieldOfView(hFovDeg);
-        }
+        ghoul_assert(
+            windowIdx >= 0 &&
+            windowIdx < Engine::instance().windows().size(),
+            "Invalid window index"
+        );
+        Engine::instance().windows()[windowIdx]->setHorizFieldOfView(hFovDeg);
     };
     #ifdef WIN32
     sgctDelegate.getNativeWindowHandle = [](size_t windowIndex) -> void* {

--- a/include/openspace/engine/windowdelegate.h
+++ b/include/openspace/engine/windowdelegate.h
@@ -99,9 +99,11 @@ struct WindowDelegate {
 
     int (*firstWindowId)() = []() { return 0; };
 
-    double (*getHorizFieldOfView)() = []() { return 0.0; };
+    std::string (*nameForWindow)(int windowIdx) = [](int) { return std::string(); };
 
-    void (*setHorizFieldOfView)(float hFovDeg) = [](float) { };
+    float (*horizFieldOfView)(int windowIdx) = [](int) { return 0.f; };
+
+    void (*setHorizFieldOfView)(int windowIdx, float hFovDeg) = [](int, float) {};
 
     void* (*getNativeWindowHandle)(size_t windowIndex) = [](size_t) -> void* {
         return nullptr;

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -204,7 +204,15 @@ private:
 
     properties::IntProperty _framerateLimit;
     std::chrono::high_resolution_clock::time_point _lastFrameTime;
-    properties::FloatProperty _horizFieldOfView;
+
+    struct Window : properties::PropertyOwner {
+        Window(PropertyOwnerInfo info, int id);
+
+        properties::FloatProperty horizFieldOfView;
+    };
+
+    properties::PropertyOwner _windowing;
+    std::vector<std::unique_ptr<Window>> _windows;
 
     properties::Vec3Property _globalRotation;
     properties::Vec3Property _screenSpaceRotation;

--- a/modules/skybrowser/src/utility.cpp
+++ b/modules/skybrowser/src/utility.cpp
@@ -196,7 +196,9 @@ glm::dvec2 fovWindow() {
     // OpenSpace FOV
     const glm::dvec2 windowDim = glm::dvec2(global::windowDelegate->currentWindowSize());
     const double ratio = windowDim.y / windowDim.x;
-    const double hFov = global::windowDelegate->getHorizFieldOfView();
+    const double hFov = global::windowDelegate->horizFieldOfView(
+        global::windowDelegate->currentWindowId()
+    );
     const glm::dvec2 OpenSpaceFOV = glm::dvec2(hFov, hFov * ratio);
     return OpenSpaceFOV;
 }


### PR DESCRIPTION
Breaking change as we only had a single property to control the field of view before, and it has been replaced by multiple properties. To keep them organized, a new propertowner has been added.

Example:

Before:
`openspace.setPropertyValue("RenderEngine.HorizFieldOfView", 30.0)`

Now:
`openspace.setPropertyValue("RenderEngine.Windowing.Window_0.HorizFieldOfView", 30.0)`
`openspace.setPropertyValue("RenderEngine.Windowing.Window_1.HorizFieldOfView", 60.0)`



Closes #3555 
Closes #2395
