### PR TITLE
Fix out of bounds crash and remove duplicate notifyChangeListeners

### DIFF
--- a/src/properties/misc/optionproperty.cpp
+++ b/src/properties/misc/optionproperty.cpp
@@ -86,7 +86,6 @@ void OptionProperty::addOption(int value, std::string description) {
     if (success) {
         // Set default value to option added first
         NumericalProperty::setValue(_options[0].value);
-        notifyChangeListeners();
     }
 }
 
@@ -96,7 +95,6 @@ void OptionProperty::addOptions(std::vector<std::pair<int, std::string>> options
     }
     // Set default value to option added first
     NumericalProperty::setValue(_options[0].value);
-    notifyChangeListeners();
 }
 
 void OptionProperty::addOptions(std::vector<std::string> options) {
@@ -105,13 +103,11 @@ void OptionProperty::addOptions(std::vector<std::string> options) {
     }
     // Set default value to option added first
     NumericalProperty::setValue(_options[0].value);
-    notifyChangeListeners();
 }
 
 void OptionProperty::clearOptions() {
+    NumericalProperty::setValue(0);
     _options.clear();
-    notifyChangeListeners();
-    _value = 0;
 }
 
 void OptionProperty::setValue(int value) {


### PR DESCRIPTION
* Fixes hard crash when adding options dynamically with for example color mapping asset (out of bounds crash)
* Removes duplicate notifyChangeListeners (the NumericalProperty::SetValue function already calls notifyChangeListeners)