### PR TITLE
Add handling for apostrophe code

### DIFF
--- a/modules/webbrowser/src/eventhandler.cpp
+++ b/modules/webbrowser/src/eventhandler.cpp
@@ -455,6 +455,16 @@ bool EventHandler::specialKeyEvent(Key key, KeyModifier mod, KeyAction action) {
             _browserInstance->sendKeyEvent(keyEvent);
             return true;
         }
+        case Key::Apostrophe: {
+            CefKeyEvent keyEvent;
+            keyEvent.windows_key_code = mapFromGlfwToWindows(Key(222));
+            keyEvent.character = mapFromGlfwToCharacter(Key(222));
+            keyEvent.native_key_code = mapFromGlfwToNative(Key(222));
+            keyEvent.modifiers = static_cast<uint32_t>(mod);
+            keyEvent.type = keyEventType(action);
+            _browserInstance->sendKeyEvent(keyEvent);
+            return true;
+        }
         default:
             return false;
     }


### PR DESCRIPTION
Fixes the issue of not being able to use English keyboard and writing " in CEF. 

To test:
* Write in Swedish and English keyboard to see nothing else broke
* Switch to english keyboard and write ' and " and see that it works now

Closes #2761