### PR TITLE
Add Notification window to the Launcher

### DIFF
--- a/apps/OpenSpace/ext/launcher/CMakeLists.txt
+++ b/apps/OpenSpace/ext/launcher/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HEADER_FILES
   include/backgroundimage.h
   include/filesystemaccess.h
   include/launcherwindow.h
+  include/notificationwindow.h
   include/settingsdialog.h
   include/splitcombobox.h
   include/windowcolors.h
@@ -59,6 +60,7 @@ set(SOURCE_FILES
   src/backgroundimage.cpp
   src/launcherwindow.cpp
   src/filesystemaccess.cpp
+  src/notificationwindow.cpp
   src/settingsdialog.cpp
   src/splitcombobox.cpp
   src/windowcolors.cpp

--- a/apps/OpenSpace/ext/launcher/include/notificationwindow.h
+++ b/apps/OpenSpace/ext/launcher/include/notificationwindow.h
@@ -1,0 +1,36 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_UI_LAUNCHER___NOTIFICATIONWINDOW___H__
+#define __OPENSPACE_UI_LAUNCHER___NOTIFICATIONWINDOW___H__
+
+#include <QTextEdit>
+
+class NotificationWindow final : public QTextEdit {
+Q_OBJECT
+public:
+    explicit NotificationWindow(QWidget* parent);
+};
+
+#endif // __OPENSPACE_UI_LAUNCHER___NOTIFICATIONWINDOW___H__

--- a/apps/OpenSpace/ext/launcher/include/notificationwindow.h
+++ b/apps/OpenSpace/ext/launcher/include/notificationwindow.h
@@ -27,10 +27,16 @@
 
 #include <QTextEdit>
 
+#include <openspace/util/httprequest.h>
+#include <memory>
+
 class NotificationWindow final : public QTextEdit {
 Q_OBJECT
 public:
     explicit NotificationWindow(QWidget* parent);
+
+private:
+    std::unique_ptr<openspace::HttpMemoryDownload> _request;
 };
 
 #endif // __OPENSPACE_UI_LAUNCHER___NOTIFICATIONWINDOW___H__

--- a/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
+++ b/apps/OpenSpace/ext/launcher/resources/qss/launcher.qss
@@ -119,6 +119,12 @@ LauncherWindow QComboBox#config:focus
 LauncherWindow QPushButton#settings:focus {
   outline: 2px solid rgb(61, 189, 238);
 }
+
+LauncherWindow QTextEdit#notifications {
+  background-color: #242424;
+  color: #d7d7d7;
+}
+
 /*
  * ProfileEdit
  */

--- a/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
@@ -46,8 +46,10 @@
 using namespace openspace;
 
 namespace {
-    constexpr int ScreenWidth = 480;
-    constexpr int ScreenHeight = 640;
+    constexpr int MainScreenWidth = 480;
+    constexpr int MainScreenHeight = 640;
+    constexpr int FullScreenWidth = MainScreenWidth;
+    constexpr int FullScreenHeight = 706;
 
     constexpr int LeftRuler = 40;
     constexpr int TopRuler = 80;
@@ -56,10 +58,12 @@ namespace {
     constexpr int SmallItemWidth = 100;
     constexpr int SmallItemHeight = SmallItemWidth / 4;
 
+    constexpr int NotificationShelfHeight = FullScreenHeight - MainScreenHeight;
+
     constexpr int SettingsIconSize = 35;
 
     namespace geometry {
-        constexpr QRect BackgroundImage(0, 0, ScreenWidth, ScreenHeight);
+        constexpr QRect BackgroundImage(0, 0, MainScreenWidth, MainScreenHeight);
         constexpr QRect LogoImage(LeftRuler, TopRuler, ItemWidth, ItemHeight);
         constexpr QRect ChooseLabel(LeftRuler + 10, TopRuler + 80, 151, 24);
         constexpr QRect ProfileBox(LeftRuler, TopRuler + 110, ItemWidth, ItemHeight);
@@ -81,14 +85,19 @@ namespace {
             LeftRuler, TopRuler + 400, ItemWidth, ItemHeight
         );
         constexpr QRect VersionString(
-            5, ScreenHeight - SmallItemHeight, ItemWidth, SmallItemHeight
+            5, MainScreenHeight - SmallItemHeight, ItemWidth, SmallItemHeight
         );
         constexpr QRect SettingsButton(
-            ScreenWidth - SettingsIconSize - 5,
-            ScreenHeight - SettingsIconSize - 5,
+            MainScreenWidth - SettingsIconSize - 5,
+            MainScreenHeight - SettingsIconSize - 5,
             SettingsIconSize,
             SettingsIconSize
         );
+        constexpr QRect NotificationShelf(
+            0,
+            MainScreenHeight,
+            MainScreenWidth,
+            NotificationShelfHeight);
     } // namespace geometry
 
 
@@ -133,7 +142,7 @@ LauncherWindow::LauncherWindow(bool profileEnabled, const Configuration& globalC
     );
 
     setWindowTitle("OpenSpace Launcher");
-    setFixedSize(ScreenWidth, ScreenHeight);
+    setFixedSize(FullScreenWidth, FullScreenHeight);
     setAutoFillBackground(false);
 
     {
@@ -164,7 +173,11 @@ LauncherWindow::LauncherWindow(bool profileEnabled, const Configuration& globalC
         logoImage->setPixmap(QPixmap(":/images/openspace-horiz-logo-small.png"));
     }
 
-    new NotificationWindow(this);
+    {
+        NotificationWindow* notificationWindow = new NotificationWindow(centralWidget);
+        notificationWindow->setGeometry(geometry::NotificationShelf);
+        notificationWindow->show();
+    }
 
     //
     // Profile chooser

--- a/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
@@ -26,6 +26,7 @@
 
 #include "profile/profileedit.h"
 #include "backgroundimage.h"
+#include "notificationwindow.h"
 #include "settingsdialog.h"
 #include "splitcombobox.h"
 #include <openspace/openspace.h>
@@ -162,6 +163,8 @@ LauncherWindow::LauncherWindow(bool profileEnabled, const Configuration& globalC
         logoImage->setGeometry(geometry::LogoImage);
         logoImage->setPixmap(QPixmap(":/images/openspace-horiz-logo-small.png"));
     }
+
+    new NotificationWindow(this);
 
     //
     // Profile chooser

--- a/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
@@ -223,7 +223,7 @@ NotificationWindow::NotificationWindow(QWidget* parent)
         );
 
         // Add the HTML-like table attributes
-        text = std::format("<table border=\"0\">{}</table>", std::move(text));
+        text = std::format("<table border='0'>{}</table>", std::move(text));
 
         // 5. Set the text
         QString t = QString::fromStdString(text);

--- a/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
@@ -1,0 +1,102 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include "notificationwindow.h"
+
+#include <openspace/util/httprequest.h>
+#include <ghoul/misc/assert.h>
+#include <ghoul/misc/stringhelper.h>
+#include <string_view>
+#include <vector>
+
+using namespace openspace;
+
+namespace {
+    constexpr std::string_view URL = "https://raw.githubusercontent.com/OpenSpace/Notifications/refs/heads/master/test.txt";
+
+    struct Entry {
+        std::string date;
+        std::string text;
+    };
+
+    // Parses a single notification entry out of the list of lines
+    Entry parseEntry(std::vector<std::string>::const_iterator& curr) {
+        ghoul_assert(!curr->empty(), "First line must not be empty");
+
+        std::string date = *curr;
+        std::string text;
+        do {
+            curr++;
+
+            text += *curr;
+        } while (!curr->empty());
+
+        return { std::move(date), std::move(text) };
+    }
+
+    std::vector<Entry> parseEntries(const std::string& data) {
+        std::vector<Entry> entries;
+
+        std::vector<std::string> lines = ghoul::tokenizeString(data, '\n');
+        std::vector<std::string>::const_iterator curr = lines.cbegin();
+        while (curr != lines.end()) {
+            Entry e = parseEntry(curr);
+            entries.push_back(std::move(e));
+        }
+
+        return entries;
+    }
+} // namespace
+
+NotificationWindow::NotificationWindow(QWidget* parent)
+    : QTextEdit(parent)
+{
+    setAcceptRichText(true);
+    setReadOnly(true);
+
+    HttpMemoryDownload req = HttpMemoryDownload(std::string(URL));
+    req.start(std::chrono::seconds(1));
+
+    std::thread t = std::thread([this, &req]() {
+        if (!req.hasSucceeded()) {
+            // The download has failed for some reason
+            return;
+        }
+        const std::vector<char> data = req.downloadedData();
+        std::string notificationText = std::string(data.begin(), data.end());
+
+        std::vector<Entry> entries = parseEntries(notificationText);
+
+        std::string text = std::accumulate(
+            entries.begin(),
+            entries.end(),
+            std::string(),
+            [](std::string t, const Entry& e) {
+                return std::format("{}\n# {}\n{}", std::move(t), e.date, e.text);
+            }
+        );
+        setText(QString::fromStdString(text));
+    });
+    t.detach();
+}

--- a/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
@@ -85,6 +85,7 @@ namespace {
             date::day(day)
         );
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
         Qt::ColorScheme scheme = QGuiApplication::styleHints()->colorScheme();
         QColor text = QGuiApplication::palette().text().color();
         if (scheme == Qt::ColorScheme::Dark) {
@@ -93,6 +94,10 @@ namespace {
         else {
             text = text.lighter();
         }
+#else
+        QColor text = QGuiApplication::palette().text().color();
+        text = text.darker();
+#endif
 
         if (date::sys_days(ymd) < date::sys_days(lastStartedDate)) {
             return std::format(

--- a/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
@@ -102,11 +102,11 @@ namespace {
         if (date::sys_days(ymd) < date::sys_days(lastStartedDate)) {
             return std::format(
                 "<tr>"
-                    "<td width=\"15%\">"
-                        "<font color=\"#{2:x}{3:x}{4:x}\">{0}</font>"
+                    "<td width='15%'>"
+                        "<font color='#{2:x}{3:x}{4:x}'>{0}</font>"
                     "</td>"
-                    "<td width=\"85%\" align=\"left\">"
-                        "<font color=\"#{2:x}{3:x}{4:x}\">{1}</font>"
+                    "<td width='85%' align='left'>"
+                        "<font color='#{2:x}{3:x}{4:x}'>{1}</font>"
                     "</td>"
                 "</tr>",
                 e.date, e.text, text.red(), text.green(), text.blue()
@@ -115,10 +115,10 @@ namespace {
         else {
             return std::format(
                 "<tr>"
-                    "<td width=\"15%\">"
+                    "<td width='15%'>"
                         "{0}"
                     "</td>"
-                    "<td width=\"85%\" align=\"left\">"
+                    "<td width='85%' align='left'>"
                         "{1}"
                     "</td>"
                 "</tr>",

--- a/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/notificationwindow.cpp
@@ -85,21 +85,11 @@ namespace {
             date::day(day)
         );
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
-        Qt::ColorScheme scheme = QGuiApplication::styleHints()->colorScheme();
-        QColor text = QGuiApplication::palette().text().color();
-        if (scheme == Qt::ColorScheme::Dark) {
-            text = text.darker();
-        }
-        else {
-            text = text.lighter();
-        }
-#else
         QColor text = QGuiApplication::palette().text().color();
         text = text.darker();
-#endif
 
         if (date::sys_days(ymd) < date::sys_days(lastStartedDate)) {
+            QColor text = QColor(120, 120, 120);
             return std::format(
                 "<tr>"
                     "<td width='15%'>"
@@ -134,6 +124,7 @@ NotificationWindow::NotificationWindow(QWidget* parent)
     setAcceptRichText(true);
     setReadOnly(true);
     setFocusPolicy(Qt::NoFocus);
+    setObjectName("notifications");
 
     std::string URL = std::format(
         "https://raw.githubusercontent.com/OpenSpace/Notifications/refs/heads/master/"

--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -53,6 +53,7 @@
 #include <sgct/projection/nonlinearprojection.h>
 #include <sgct/user.h>
 #include <sgct/window.h>
+#include <date/date.h>
 #include <stb_image.h>
 #include <tracy/Tracy.hpp>
 #include <iostream>
@@ -1451,6 +1452,15 @@ int main(int argc, char* argv[]) {
 
         settings.configuration =
             isGeneratedWindowConfig ? "" : global::configuration->windowConfiguration;
+        const date::year_month_day now = date::year_month_day(
+            floor<date::days>(std::chrono::system_clock::now())
+        );
+        settings.lastStartedDate = std::format(
+            "{}-{:0>2}-{:0>2}",
+            static_cast<int>(now.year()),
+            static_cast<unsigned>(now.month()),
+            static_cast<unsigned>(now.day())
+        );
 
         saveSettings(settings, findSettings());
     }

--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -1071,6 +1071,12 @@ void setSgctDelegateFunctions() {
 int main(int argc, char* argv[]) {
     ZoneScoped;
 
+    // For debugging purposes: Enforce Light Mode in Qt
+    // qputenv("QT_QPA_PLATFORM", "windows:darkmode=0");
+
+    // For debugging purposes: Enforce Dark Mode in Qt
+    // qputenv("QT_QPA_PLATFORM", "windows:darkmode=1");
+
 #ifdef OPENSPACE_BREAK_ON_FLOATING_POINT_EXCEPTION
     _clearfp();
     _controlfp(_controlfp(0, 0) & ~(_EM_ZERODIVIDE | _EM_OVERFLOW), _MCW_EM);

--- a/include/openspace/engine/settings.h
+++ b/include/openspace/engine/settings.h
@@ -35,8 +35,12 @@ namespace openspace {
 struct Settings {
     auto operator<=>(const Settings&) const = default;
 
+    // Settings that are not configurable by the user and that represent a persistent
+    // state for the system
     std::optional<bool> hasStartedBefore;
+    std::optional<std::string> lastStartedDate;
 
+    // Configurable settings
     std::optional<std::string> configuration;
     std::optional<bool> rememberLastConfiguration;
     std::optional<std::string> profile;

--- a/src/engine/settings.cpp
+++ b/src/engine/settings.cpp
@@ -49,6 +49,7 @@ namespace version1 {
 
         Settings settings;
         settings.hasStartedBefore = get_to<bool>(json, "started-before");
+        settings.lastStartedDate = get_to<std::string>(json, "last-started-date");
         settings.configuration = get_to<std::string>(json, "config");
         settings.rememberLastConfiguration = get_to<bool>(json, "config-remember");
         settings.profile = get_to<std::string>(json, "profile");
@@ -139,6 +140,9 @@ void saveSettings(const Settings& settings, const std::filesystem::path& filenam
 
     if (settings.hasStartedBefore.has_value()) {
         json["started-before"] = *settings.hasStartedBefore;
+    }
+    if (settings.lastStartedDate.has_value()) {
+        json["last-started-date"] = *settings.lastStartedDate;
     }
     if (settings.configuration.has_value()) {
         json["config"] = *settings.configuration;


### PR DESCRIPTION
This PR adds a new window to the bottom of the Launcher that shows notifications.  The contents of the notifications are sources from this GitHub Repository: https://github.com/OpenSpace/Notifications. The README in the there also explains how to write notifications. It is possible to provide different notifications based on specific OpenSpace versions.

The notification window only shows notifications that are younger than 6 months and any notification that has already been there before the last time OpenSpace started are deemphasized.

![image](https://github.com/user-attachments/assets/78587a55-5560-49d8-bcf3-a45bc136e853)

For now, notifications are shown even for the `master` branch. Question: Should it?

Closes #773 