### PR TITLE
Add submenu to the "New" buttons

### DIFF
--- a/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
@@ -35,6 +35,7 @@
 #include <QFile>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QStandardItemModel>
@@ -195,6 +196,20 @@ LauncherWindow::LauncherWindow(bool profileEnabled, const Configuration& globalC
             newProfileButton, &QPushButton::released,
             this, &LauncherWindow::newProfile
         );
+
+        QMenu* menu = new QMenu;
+        QAction* newClean = new QAction("New profile");
+        connect(
+            newClean, &QAction::triggered,
+            this, &LauncherWindow::newProfile
+        );
+        QAction* newFromCurrent = new QAction("Duplicate profile");
+        connect(
+            newFromCurrent, &QAction::triggered,
+            this, &LauncherWindow::editProfile
+        );
+        menu->addActions({ newClean, newFromCurrent });
+        newProfileButton->setMenu(menu);
     }
 
     // Creating the profile box _after_ the Edit and New buttons as the comboboxes
@@ -391,7 +406,19 @@ void LauncherWindow::selectProfile(std::optional<std::string> selection) {
     ghoul_assert(selection.has_value(), "No special item in the profiles");
     if (selection.has_value()) {
         // Having the `if` statement here to satisfy the MSVC code analysis
-        _editProfileButton->setEnabled(std::filesystem::exists(*selection));
+
+        // Enable the Edit button only for the user profiles
+        const bool isUser = selection->starts_with(_userProfilePath.string());
+        _editProfileButton->setEnabled(isUser);
+
+        if (isUser) {
+            _editProfileButton->setToolTip("");
+        }
+        else {
+            _editProfileButton->setToolTip(
+                "Cannot edit the selected profile as it is one of the built-in profiles"
+            );
+        }
     }
 }
 
@@ -407,8 +434,7 @@ void LauncherWindow::selectConfiguration(std::optional<std::string> selection) {
         // If the configuration is a default configuration, we don't allow editing
         _editWindowButton->setEnabled(false);
         _editWindowButton->setToolTip(
-            "Cannot edit since the selected configuration is one of the files "
-            "provided by OpenSpace"
+            "Cannot edit the selected configuration as it is one of the built-in profiles"
         );
     }
     else {


### PR DESCRIPTION
Add a new menu to the New button in the Launcher for the New profile to provide the option to either create an empty profile or duplicate an existing one.  Disable the "Edit" button when a built-in profile is selected


![image](https://github.com/user-attachments/assets/4c3bc378-0e9d-4eaa-91d4-f13f1956d5cf)


Closes #3578