### PR TITLE
Launcher should indicate whether a profile is a standard profile or a user profile 

### DIFF
--- a/apps/OpenSpace/ext/launcher/CMakeLists.txt
+++ b/apps/OpenSpace/ext/launcher/CMakeLists.txt
@@ -31,6 +31,7 @@ set(HEADER_FILES
   include/notificationwindow.h
   include/settingsdialog.h
   include/splitcombobox.h
+  include/usericon.h
   include/windowcolors.h
   include/profile/actiondialog.h
   include/profile/additionalscriptsdialog.h
@@ -63,6 +64,7 @@ set(SOURCE_FILES
   src/notificationwindow.cpp
   src/settingsdialog.cpp
   src/splitcombobox.cpp
+  src/usericon.cpp
   src/windowcolors.cpp
   src/profile/actiondialog.cpp
   src/profile/additionalscriptsdialog.cpp

--- a/apps/OpenSpace/ext/launcher/include/usericon.h
+++ b/apps/OpenSpace/ext/launcher/include/usericon.h
@@ -1,0 +1,28 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <QIcon>
+
+// Creates an icon that is used to represent user-generated content
+QIcon userIcon();

--- a/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
+++ b/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
@@ -24,6 +24,7 @@
 
 #include "splitcombobox.h"
 
+#include "usericon.h"
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/misc/assert.h>
 #include <QPainter>
@@ -68,28 +69,14 @@ void SplitComboBox::populateList(const std::string& preset) {
     clear();
 
     // Create "icons" that we use to indicate whether an item is built-in or user content
-    QIcon userIcon = []() {
-        QPixmap px = QPixmap(40, 50);
-        px.fill(Qt::transparent);
-
-        QPainter painter = QPainter(&px);
-        painter.setBrush(QColor(183, 211, 149, 255));
-        painter.drawEllipse(0, 10, 38, 38);
-
-        QFont f = QFont("Arial");
-        f.setPixelSize(28);
-        f.setBold(true);
-        painter.setFont(f);
-        painter.drawText(0, 10, 40, 40, Qt::AlignCenter, "U");
-        return QIcon(px);
-    }();
+    QIcon icon = userIcon();
 
     //
     // Special item (if it was specified)
     if (!_specialFirst.empty()) {
         if (_specialFirst.starts_with(_userPath.string())) {
             addItem(
-                userIcon,
+                icon,
                 QString::fromStdString(_specialFirst),
                 QString::fromStdString(_specialFirst)
             );
@@ -120,7 +107,7 @@ void SplitComboBox::populateList(const std::string& preset) {
 
         // Display the relative path, but store the full path in the user data segment
         addItem(
-            userIcon,
+            icon,
             QString::fromStdString(relPath.string()),
             QString::fromStdString(p.string())
         );

--- a/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
+++ b/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
@@ -69,18 +69,18 @@ void SplitComboBox::populateList(const std::string& preset) {
 
     // Create "icons" that we use to indicate whether an item is built-in or user content
     QIcon userIcon = []() {
-        QPixmap px = QPixmap(20, 25);
+        QPixmap px = QPixmap(40, 50);
         px.fill(Qt::transparent);
 
         QPainter painter = QPainter(&px);
         painter.setBrush(QColor(183, 211, 149, 255));
-        painter.drawEllipse(0, 5, 19, 19);
+        painter.drawEllipse(0, 10, 38, 38);
 
         QFont f = QFont("Arial");
-        f.setPixelSize(14);
+        f.setPixelSize(28);
         f.setBold(true);
         painter.setFont(f);
-        painter.drawText(0, 5, 20, 20, Qt::AlignCenter, "U");
+        painter.drawText(0, 10, 40, 40, Qt::AlignCenter, "U");
         return QIcon(px);
     }();
 

--- a/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
+++ b/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
@@ -26,6 +26,7 @@
 
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/misc/assert.h>
+#include <QPainter>
 #include <QStandardItemModel>
 
 SplitComboBox::SplitComboBox(QWidget* parent, std::filesystem::path userPath,
@@ -66,14 +67,39 @@ void SplitComboBox::populateList(const std::string& preset) {
     // Clear the previously existing entries since we might call this function again
     clear();
 
+    // Create "icons" that we use to indicate whether an item is built-in or user content
+    QIcon userIcon = []() {
+        QPixmap px = QPixmap(20, 25);
+        px.fill(Qt::transparent);
+
+        QPainter painter = QPainter(&px);
+        painter.setBrush(QColor(183, 211, 149, 255));
+        painter.drawEllipse(0, 5, 19, 19);
+
+        QFont f = QFont("Arial");
+        f.setPixelSize(14);
+        f.setBold(true);
+        painter.setFont(f);
+        painter.drawText(0, 5, 20, 20, Qt::AlignCenter, "U");
+        return QIcon(px);
+    }();
 
     //
     // Special item (if it was specified)
     if (!_specialFirst.empty()) {
-        addItem(
-            QString::fromStdString(_specialFirst),
-            QString::fromStdString(_specialFirst)
-        );
+        if (_specialFirst.starts_with(_userPath.string())) {
+            addItem(
+                userIcon,
+                QString::fromStdString(_specialFirst),
+                QString::fromStdString(_specialFirst)
+            );
+        }
+        else {
+            addItem(
+                QString::fromStdString(_specialFirst),
+                QString::fromStdString(_specialFirst)
+            );
+        }
     }
 
 
@@ -94,6 +120,7 @@ void SplitComboBox::populateList(const std::string& preset) {
 
         // Display the relative path, but store the full path in the user data segment
         addItem(
+            userIcon,
             QString::fromStdString(relPath.string()),
             QString::fromStdString(p.string())
         );

--- a/apps/OpenSpace/ext/launcher/src/usericon.cpp
+++ b/apps/OpenSpace/ext/launcher/src/usericon.cpp
@@ -1,0 +1,43 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include "usericon.h"
+
+#include <QPainter>
+
+QIcon userIcon() {
+    QPixmap px = QPixmap(40, 50);
+    px.fill(Qt::transparent);
+
+    QPainter painter = QPainter(&px);
+    painter.setBrush(QColor(183, 211, 149, 255));
+    painter.drawEllipse(0, 10, 38, 38);
+
+    QFont f = QFont("Arial");
+    f.setPixelSize(28);
+    f.setBold(true);
+    painter.setFont(f);
+    painter.drawText(0, 10, 40, 40, Qt::AlignCenter, "U");
+    return QIcon(px);
+}


### PR DESCRIPTION
Add icon to all user-generated profile and configurations.  The icon is a U for "user generated content" within a circle of one of the logo's primary colors.

Open for comments on the look of the logo.  We can control the size, aspect ratio, and basically draw whatever we'd like, but the limitation is that it has to be on the left side of the text.

Another option would have been to use `setLabelDrawingMode` of the QComboBox, but that was only introduced in the latest Qt version 6.9 and still has some bugs with it.  It would be be possible to customize the rendering of the text with it, that that were to work.

![image](https://github.com/user-attachments/assets/57bc789b-371e-44e9-8d2e-db3face537e6)

Closes #3576 