### PR TITLE
Move profile name from top bar center to File menu 

### DIFF
--- a/data/assets/util/webgui.asset
+++ b/data/assets/util/webgui.asset
@@ -4,7 +4,7 @@ local guiCustomization = asset.require("customization/gui")
 
 
 -- Select which commit hashes to use for the UI frontend
-local frontendHash = "f899267b30691a10c8833c0afccc16976797d0fe"
+local frontendHash = "8c454895b301ba2d9d1b845b5ba506d3f4c887b9"
 
 -- The name of the file to download from the server
 local file = "frontend.zip"

--- a/data/profiles/asteroids.profile
+++ b/data/profiles/asteroids.profile
@@ -59,7 +59,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This profile shows approximately 936,000 asteroids from the JPL Horizons Small-Body Database (SBDB). Included in this profile (and defined on our wiki): Amor Asteroids, Apollo Asteroids, Aten Asteroids, Atira Asteroids, Centaur Asteroids, Chiron-Type Comets, Encke-Type Comets, Halley-Type Comets, Inner Main Asteroid Belt Asteroids, Jupiter Family Comets, Jupiter Trojan Asteroids, Main Asteroid Belt Asteroids, Mars-Crossing Asteroids, Outer Main Asteroid Belt Asteroids, Potentially Hazardous Asteroids (PHAs), and Trans-Neptunian Asteroids",
+    "description": "This profile shows approximately 936,000 asteroids from the JPL Horizons Small-Body Database (SBDB). Included in this profile (and defined on our wiki): Amor Asteroids, Apollo Asteroids, Aten Asteroids, Atira Asteroids, Centaur Asteroids, Chiron-Type Comets, Encke-Type Comets, Halley-Type Comets, Inner Main Asteroid Belt Asteroids, Jupiter Family Comets, Jupiter Trojan Asteroids, Main Asteroid Belt Asteroids, Mars-Crossing Asteroids, Outer Main Asteroid Belt Asteroids, Potentially Hazardous Asteroids (PHAs), and Trans-Neptunian Asteroids.",
     "license": "MIT License",
     "name": "Asteroids",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/default.profile
+++ b/data/profiles/default.profile
@@ -59,7 +59,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "Default OpenSpace Profile. Adds Earth satellites not contained in other profiles",
+    "description": "Default OpenSpace Profile. Adds Earth satellites not contained in other profiles.",
     "license": "MIT License",
     "name": "Default",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/eclipse.profile
+++ b/data/profiles/eclipse.profile
@@ -45,7 +45,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "OpenSpace profile to highlight solar eclipses on the Earth from 1900 to 2100",
+    "description": "OpenSpace profile to highlight solar eclipses on the Earth from 1900 to 2100.",
     "license": "MIT License",
     "name": "Default",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/apollo.profile
+++ b/data/profiles/missions/apollo.profile
@@ -82,7 +82,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This profile contains all the apollo assets in openspace. Apollo 8,11,17 and some associated materials. ",
+    "description": "This profile contains all the apollo assets in openspace. Apollo 8,11,17 and some associated materials.",
     "license": "MIT License",
     "name": "Apollo",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/artemis.profile
+++ b/data/profiles/missions/artemis.profile
@@ -56,7 +56,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "Artemis Profile. Adds the Orion capsule (Artemis-1) model with an estimated trajectery",
+    "description": "Artemis Profile. Adds the Orion capsule (Artemis-1) model with an estimated trajectery.",
     "license": "MIT License",
     "name": "Artemis",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/bepicolombo.profile
+++ b/data/profiles/missions/bepicolombo.profile
@@ -43,7 +43,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "Default OpenSpace Profile. Adds Earth satellites not contained in other profiles",
+    "description": "Default OpenSpace Profile. Adds Earth satellites not contained in other profiles.",
     "license": "MIT License",
     "name": "Default",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/dawn.profile
+++ b/data/profiles/missions/dawn.profile
@@ -49,7 +49,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "work in progress profile for the dawn mission",
+    "description": "A work in progress profile for the dawn mission.",
     "license": "MIT License",
     "name": "Dawn",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/gaia.profile
+++ b/data/profiles/missions/gaia.profile
@@ -34,7 +34,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This scene contains a new rendering method to show the massive ESA Gaia stars dataset. By default, it loads the few million stars of the Gaia DR2 that contain radial velocities",
+    "description": "This scene contains a new rendering method to show the massive ESA Gaia stars dataset. By default, it loads the few million stars of the Gaia DR2 that contain radial velocities.",
     "license": "MIT License",
     "name": "Gaia",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/juice.profile
+++ b/data/profiles/missions/juice.profile
@@ -50,7 +50,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "Juice profile that visualizes the currently best known trajectory for the JUICE mission the Jupiter and its moons. See https://sci.esa.int/documents/33960/35865/1567260128466-JUICE_Red_Book_i1.0.pdf for more information about the JUICE mission. Currently, only the Janus and NavCam instruments are included in this profile, but the other instruments are available for a custom profile. Some of these are not behaving correctly, which will be addressed later",
+    "description": "Juice profile that visualizes the currently best known trajectory for the JUICE mission the Jupiter and its moons. See https://sci.esa.int/documents/33960/35865/1567260128466-JUICE_Red_Book_i1.0.pdf for more information about the JUICE mission. Currently, only the Janus and NavCam instruments are included in this profile, but the other instruments are available for a custom profile. Some of these are not behaving correctly, which will be addressed later.",
     "license": "MIT License",
     "name": "Juice",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/juno.profile
+++ b/data/profiles/missions/juno.profile
@@ -48,7 +48,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "A work in progress profile for juno.",
+    "description": "A work in progress profile for Juno.",
     "license": "MIT License",
     "name": "Juno",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/juno.profile
+++ b/data/profiles/missions/juno.profile
@@ -48,7 +48,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "work in progress scene for juno",
+    "description": "A work in progress profile for juno.",
     "license": "MIT License",
     "name": "Juno",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/jwst.profile
+++ b/data/profiles/missions/jwst.profile
@@ -122,7 +122,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "James Webb Space Telescope Profile. Adds the James Webb Space Telescope model with an estimated trajectery",
+    "description": "James Webb Space Telescope Profile. Adds the James Webb Space Telescope model with an estimated trajectory.",
     "license": "MIT License",
     "name": "James Webb Space Telescope",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/mars.profile
+++ b/data/profiles/missions/mars.profile
@@ -54,7 +54,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This profile shows the landing of the NASA InSight lander on Mars. The final minutes of the approach are shown with the lander finishing on the surface of Mars.  This profile also includes the landing trail and model for the Mars2020 rover Perseverence. ",
+    "description": "This profile shows the landing of the NASA InSight lander on Mars. The final minutes of the approach are shown with the lander finishing on the surface of Mars.  This profile also includes the landing trail and model for the Mars2020 rover Perseverence.",
     "license": "MIT License",
     "name": "Mars",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/messenger.profile
+++ b/data/profiles/missions/messenger.profile
@@ -42,7 +42,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This scene contains model and trajectory of the NASA MESSENGER spacecraft with craft pointing data from 2011-03 to 2011-06. In addition, a rendering of Mercury's magnetosphere based on data recorded by MESSENGER can be enabled and viewed around the planet. Along with the mission data, additional maps were added to Mercury showing mineral abundances on the surface and a multi-color mosaic from the MDIS instrument",
+    "description": "This scene contains model and trajectory of the NASA MESSENGER spacecraft with craft pointing data from 2011-03 to 2011-06. In addition, a rendering of Mercury's magnetosphere based on data recorded by MESSENGER can be enabled and viewed around the planet. Along with the mission data, additional maps were added to Mercury showing mineral abundances on the surface and a multi-color mosaic from the MDIS instrument.",
     "license": "MIT License",
     "name": "Messenger",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/messenger.profile
+++ b/data/profiles/missions/messenger.profile
@@ -42,7 +42,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This scene contains model and trajectory of the NASA MESSENGER spacecraft with craft pointing data from 2011-03 to 2011-06. In addition, a rendering of Mercury's magnetosphere based on data recorded by MESSENGER can be enabled and viewed around the planet. Along with the mission data, additional maps were added to Mercury showing mineral abundances on the surface and a multi-color mosaic from the MDIS instrument.",
+    "description": "This scene contains model and trajectory of the NASA MESSENGER spacecraft with pointing data from 2011-03 to 2011-06. In addition, a rendering of Mercury's magnetosphere based on data recorded by MESSENGER can be enabled and viewed around the planet. Along with the mission data, additional maps were added to Mercury showing mineral abundances on the surface and a multi-color mosaic from the MDIS instrument.",
     "license": "MIT License",
     "name": "Messenger",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/newhorizons.profile
+++ b/data/profiles/missions/newhorizons.profile
@@ -125,7 +125,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This profile shows the acquisition of NASA New Horizons' images of the Plutonian system in July 2015. The profile starts at around 10:00 on July 14th, around 10 minutes before a new image campaign starts. By selecting Pluto as the Origin and moving time faster, you can see the imprint of the instrument's field-of-view on the planetary surface and see the images being projected. A timer on the top left of the screen shows when the next image is being taken",
+    "description": "This profile shows the acquisition of NASA New Horizons' images of the Plutonian system in July 2015. The profile starts at around 10:00 on July 14th, around 10 minutes before a new image campaign starts. By selecting Pluto as the Origin and moving time faster, you can see the imprint of the instrument's field-of-view on the planetary surface and see the images being projected. A timer on the top left of the screen shows when the next image is being taken.",
     "license": "MIT License",
     "name": "New Horizons",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/osirisrex.profile
+++ b/data/profiles/missions/osirisrex.profile
@@ -77,7 +77,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This profile demonstrates the entire lifetime of the NASA OSIRIS-REx spacecraft on its way to the asteroid Bennu and its subsequent journey back to Earth. The profile starts at Earth around the time of the spacecraft's launch and has information throughout the entire mission until its landing back on Earth in Utah. The models of OSIRIS-REx and Bennu are available, as well as a preliminary instrument timing, which uses the same image projection technique as employed in New Horizons and Rosetta",
+    "description": "This profile demonstrates the entire lifetime of the NASA OSIRIS-REx spacecraft on its way to the asteroid Bennu and its subsequent journey back to Earth. The profile starts at Earth around the time of the spacecraft's launch and has information throughout the entire mission until its landing back on Earth in Utah. The models of OSIRIS-REx and Bennu are available, as well as a preliminary instrument timing, which uses the same image projection technique as employed in New Horizons and Rosetta.",
     "license": "MIT License",
     "name": "Osiris-Rex",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/rosetta.profile
+++ b/data/profiles/missions/rosetta.profile
@@ -90,7 +90,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "The Rosetta scene shows the entire mission of ESA's Rosetta spacecraft around comet 67P, also known as Churyumov-Gerasimenko. The spacecraft's images are projected onto the comet and the separation of the Philae lander is visible as well",
+    "description": "The Rosetta scene shows the entire mission of ESA's Rosetta spacecraft around comet 67P, also known as Churyumov-Gerasimenko. The spacecraft's images are projected onto the comet and the separation of the Philae lander is visible as well.",
     "license": "MIT License",
     "name": "Rosetta",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/missions/voyager.profile
+++ b/data/profiles/missions/voyager.profile
@@ -83,7 +83,7 @@
   ],
   "meta": {
     "author": "OpenSpace Team",
-    "description": "This scene contains the NASA Voyager 1 and Voyager 2 missions as they were launched from Earth in the 1970s and observed the gas giants in the Solar System. The spacecraft models are included and are pointed accurately throughout the mission. Position and orientation information are available until the second half of the 21st century",
+    "description": "This scene contains the NASA Voyager 1 and Voyager 2 missions as they were launched from Earth in the 1970s and observed the gas giants in the Solar System. The spacecraft models are included and are pointed accurately throughout the mission. Position and orientation information are available until the second half of the 21st century.",
     "license": "MIT License",
     "name": "Voyager",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/spaceweather/bastilleday2000.profile
+++ b/data/profiles/spaceweather/bastilleday2000.profile
@@ -110,7 +110,7 @@
   ],
   "meta": {
     "author": "CCMC",
-    "description": "This profile is showing the Coronal mass ejection of the bastille day 2000-07-14. The profile is data intensive and will require a powerful GPU",
+    "description": "This profile is showing the Coronal mass ejection of the bastille day 2000-07-14. The profile is data intensive and will require a powerful GPU.",
     "license": "MIT License",
     "name": "Bastille day 2000",
     "url": "https://www.openspaceproject.com",

--- a/data/profiles/spaceweather/solarstorm2012.profile
+++ b/data/profiles/spaceweather/solarstorm2012.profile
@@ -63,7 +63,7 @@
   ],
   "meta": {
     "author": "Community Coordinated Modeling Center, NASA Goddard",
-    "description": "This profile is showing several coronal mass ejection (CMEs) during July 2012, where the last one was incredible intense. Its strength was comparable to the most intense CME in recorded history, the Carrington Event of 1859, which caused damage to electric equipment world wide. Luckily this 2012 event missed earth. The event is modeled with ENLIL which spands across the solarsystem, from the Sun to Earth, Batsrus which is showing the interaction of the flow of the solar wind and Earths magnetosphere. There is also one time step of the PFSS model showing the Suns local magnetic structure",
+    "description": "This profile is showing several coronal mass ejection (CMEs) during July 2012, where the last one was incredible intense. Its strength was comparable to the most intense CME in recorded history, the Carrington Event of 1859, which caused damage to electric equipment world wide. Luckily this 2012 event missed earth. The event is modeled with ENLIL which spands across the solarsystem, from the Sun to Earth, Batsrus which is showing the interaction of the flow of the solar wind and Earths magnetosphere. There is also one time step of the PFSS model showing the Suns local magnetic structure.",
     "license": "MIT License",
     "name": "Solar storm 2012",
     "url": "https://www.openspaceproject.com",

--- a/modules/server/src/topics/profiletopic.cpp
+++ b/modules/server/src/topics/profiletopic.cpp
@@ -26,6 +26,7 @@
 
 #include <modules/server/include/connection.h>
 #include <modules/server/include/jsonconverters.h>
+#include <openspace/engine/configuration.h>
 #include <openspace/engine/globals.h>
 #include <openspace/scene/profile.h>
 
@@ -36,13 +37,24 @@ bool ProfileTopic::isDone() const {
 }
 
 void ProfileTopic::handleJson(const nlohmann::json&) {
-    const std::string name = global::profile->meta->name.value_or("");
-
-    const nlohmann::json data = {
+    // @TODO (2025-04-30, emmbr) If we expose the json converters from profile.cpp, we
+    // could use those her einstead and minimize the risk of getting the dat aout of sync
+    nlohmann::json data = {
         { "uiPanelVisibility", global::profile->uiPanelVisibility },
         { "markNodes", global::profile->markNodes },
-        { "name", name }
+        { "filePath", global::configuration->profile},
     };
+
+    if (global::profile->meta.has_value()) {
+        data["name"] = global::profile->meta->name.value_or("");
+
+        data["author"] = global::profile->meta->author.value_or("");
+        data["description"] = global::profile->meta->description.value_or("");
+        data["license"] = global::profile->meta->license.value_or("");
+        data["url"] = global::profile->meta->url.value_or("");
+        data["version"] = global::profile->meta->version.value_or("");
+    }
+
     _connection->sendJson(wrappedPayload(data));
 }
 

--- a/modules/server/src/topics/profiletopic.cpp
+++ b/modules/server/src/topics/profiletopic.cpp
@@ -38,11 +38,12 @@ bool ProfileTopic::isDone() const {
 
 void ProfileTopic::handleJson(const nlohmann::json&) {
     // @TODO (2025-04-30, emmbr) If we expose the json converters from profile.cpp, we
-    // could use those her einstead and minimize the risk of getting the dat aout of sync
+    // could use those here instead and minimize the risk of getting the serialization of
+    // the data out of sync
     nlohmann::json data = {
         { "uiPanelVisibility", global::profile->uiPanelVisibility },
         { "markNodes", global::profile->markNodes },
-        { "filePath", global::configuration->profile},
+        { "filePath", global::configuration->profile}
     };
 
     if (global::profile->meta.has_value()) {

--- a/modules/server/src/topics/profiletopic.cpp
+++ b/modules/server/src/topics/profiletopic.cpp
@@ -43,7 +43,7 @@ void ProfileTopic::handleJson(const nlohmann::json&) {
     nlohmann::json data = {
         { "uiPanelVisibility", global::profile->uiPanelVisibility },
         { "markNodes", global::profile->markNodes },
-        { "filePath", global::configuration->profile}
+        { "filePath", global::configuration->profile }
     };
 
     if (global::profile->meta.has_value()) {


### PR DESCRIPTION
Move the profile name away from the top bar, to be less visually intrusive, and add some more information about the profile, such as the description, file path, author, and license. 

I skipped showing the version in the UI as of now, thinking that this might be more confusing than useful. I also updated the profile description so they all end with punctuation, as it looked weird when they didn't. 

Uses this UI PR: OpenSpace/OpenSpace-WebGui#133

This is what it looks like: 
![image](https://github.com/user-attachments/assets/19ccec9a-d457-42c7-ba02-7d0873a01736)

