### PR TITLE
Harmonizing `OrientationRenderOption` and `Billboard` settings.  Make RenderablePlanes use the new setting

### DIFF
--- a/data/assets/examples/renderable/renderablepointcloud/pointcloud_textured_facecameraposition.asset
+++ b/data/assets/examples/renderable/renderablepointcloud/pointcloud_textured_facecameraposition.asset
@@ -15,7 +15,7 @@ local Node = {
     File = asset.resource("data/dummydata.csv"),
     -- Change the orientation render option to face the camera position instead
     -- of its view direction
-    OrientationRenderOption = "Camera Position Normal",
+    Billboard = "Camera Position Normal",
     -- Add a texture so we can more easily see how the orientation is changed
     Texture = {
       File = openspace.absPath("${DATA}/test3.jpg")

--- a/data/assets/scene/digitaluniverse/deepsky.asset
+++ b/data/assets/scene/digitaluniverse/deepsky.asset
@@ -66,7 +66,7 @@ local DeepSkyObjectsImages = {
     },
     -- Use fixed orientation, and rotate planes based on orientation information in
     -- the dataset
-    OrientationRenderOption = "Fixed Rotation",
+    Billboard = "Fixed Rotation",
     UseOrientationData = true,
     Unit = "pc",
     SizeSettings = {

--- a/data/assets/scene/digitaluniverse/milkyway.asset
+++ b/data/assets/scene/digitaluniverse/milkyway.asset
@@ -24,7 +24,7 @@ local Object = {
     },
     -- Use fixed orientation, and rotate planes based on orientation information in
     -- the dataset
-    OrientationRenderOption = "Fixed Rotation",
+    Billboard = "Fixed Rotation",
     UseOrientationData = true,
     Unit = "pc",
     Fading = {

--- a/data/assets/scene/digitaluniverse/milkyway_arm_labels.asset
+++ b/data/assets/scene/digitaluniverse/milkyway_arm_labels.asset
@@ -25,7 +25,7 @@ local Object = {
     },
     -- Use fixed orientation, and rotate planes based on orientation information in
     -- the dataset
-    OrientationRenderOption = "Fixed Rotation",
+    Billboard = "Fixed Rotation",
     UseOrientationData = true,
     Unit = "pc",
     Fading = {

--- a/data/assets/scene/digitaluniverse/tully.asset
+++ b/data/assets/scene/digitaluniverse/tully.asset
@@ -86,7 +86,7 @@ local TullyGalaxiesImages = {
     TransformationMatrix = transforms.Supergalactic,
     -- Use fixed orientation, and rotate planes based on orientation information in
     -- the dataset
-    OrientationRenderOption = "Fixed Rotation",
+    Billboard = "Fixed Rotation",
     UseOrientationData = true,
     Unit = "Mpc",
     Fading = {

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -383,18 +383,20 @@ namespace {
             PositionNormal [[codegen::key("Camera Position Normal")]],
             FixedRotation [[codegen::key("Fixed Rotation")]]
         };
-        // Controls whether the plane will be orientated as a billboard. Setting this
-        // value to `true` is the same as setting it to \"Camera View Direction\", setting
-        // it to `false` is the same as setting it to \"Fixed Rotation\". If the value is
-        // not specified, the default value of `true` is used instead.
-        // Controls how the planes for the points will be oriented. \"Camera View
-        // Direction\" rotates the points so that the plane is orthogonal to the viewing
-        // direction of the camera (useful for planar displays), and \"Camera Position
-        // Normal\" rotates the points towards the position of the camera (useful for
-        // spherical displays, like dome theaters). In both these cases the points will be
-        // billboarded towards the camera. In contrast, \"Fixed Rotation\" does not rotate
-        // the points at all based on the camera and should be used when the dataset
-        // contains orientation information for the points.
+
+        // Controls whether the planes for the points will be billboarded, that is
+        // oriented to face the camera. Setting this value to `true` is the same as
+        // setting it to \"Camera View Direction\", setting it to `false` is the same as
+        // setting it to \"Fixed Rotation\". If the value is not specified, the default
+        // value of `true` is used instead.
+        //
+        // \"Camera View Direction\" rotates the points so that the plane is orthogonal to
+        // the viewing direction of the camera (useful for planar displays), and \"Camera
+        // Position Normal\" rotates the points towards the position of the camera (useful
+        // for spherical displays, like dome theaters). In both these cases the points
+        // will be billboarded towards the camera. In contrast, \"Fixed Rotation\" does
+        // not rotate the points at all based on the camera and should be used when the
+        // dataset contains orientation information for the points.
         std::optional<std::variant<bool, RenderOption>> billboard;
 
         // [[codegen::verbatim(UseOrientationDataInfo.description)]]
@@ -1231,6 +1233,8 @@ void RenderablePointCloud::renderPoints(const RenderData& data,
     _program->setUniform(_uniformCache.up, glm::vec3(orthoUp));
     _program->setUniform(_uniformCache.right, glm::vec3(orthoRight));
     _program->setUniform(_uniformCache.fadeInValue, fadeInVariable);
+
+    _program->setUniform(_uniformCache.renderOption, _renderOption.value());
 
     _program->setUniform(_uniformCache.opacity, opacity());
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -383,8 +383,19 @@ namespace {
             PositionNormal [[codegen::key("Camera Position Normal")]],
             FixedRotation [[codegen::key("Fixed Rotation")]]
         };
-        // [[codegen::verbatim(OrientationRenderOptionInfo.description)]]
-        std::optional<RenderOption> orientationRenderOption;
+        // Controls whether the plane will be orientated as a billboard. Setting this
+        // value to `true` is the same as setting it to \"Camera View Direction\", setting
+        // it to `false` is the same as setting it to \"Fixed Rotation\". If the value is
+        // not specified, the default value of `true` is used instead.
+        // Controls how the planes for the points will be oriented. \"Camera View
+        // Direction\" rotates the points so that the plane is orthogonal to the viewing
+        // direction of the camera (useful for planar displays), and \"Camera Position
+        // Normal\" rotates the points towards the position of the camera (useful for
+        // spherical displays, like dome theaters). In both these cases the points will be
+        // billboarded towards the camera. In contrast, \"Fixed Rotation\" does not rotate
+        // the points at all based on the camera and should be used when the dataset
+        // contains orientation information for the points.
+        std::optional<std::variant<bool, RenderOption>> billboard;
 
         // [[codegen::verbatim(UseOrientationDataInfo.description)]]
         std::optional<bool> useOrientationData;
@@ -663,8 +674,23 @@ RenderablePointCloud::RenderablePointCloud(const ghoul::Dictionary& dictionary)
     _renderOption.addOption(RenderOption::PositionNormal, "Camera Position Normal");
     _renderOption.addOption(RenderOption::FixedRotation, "Fixed Rotation");
 
-    if (p.orientationRenderOption.has_value()) {
-        _renderOption = codegen::map<RenderOption>(*p.orientationRenderOption);
+    if (p.billboard.has_value()) {
+        ghoul_assert(
+            std::holds_alternative<bool>(*p.billboard) ||
+            std::holds_alternative<Parameters::RenderOption>(*p.billboard),
+            "Wrong type"
+        );
+
+        if (std::holds_alternative<bool>(*p.billboard)) {
+            _renderOption = std::get<bool>(*p.billboard) ?
+                RenderOption::ViewDirection :
+                RenderOption::FixedRotation;
+        }
+        else {
+            _renderOption = codegen::map<RenderOption>(
+                std::get<Parameters::RenderOption>(*p.billboard)
+            );
+        }
     }
     else {
         _renderOption = RenderOption::ViewDirection;
@@ -1206,7 +1232,6 @@ void RenderablePointCloud::renderPoints(const RenderData& data,
     _program->setUniform(_uniformCache.right, glm::vec3(orthoRight));
     _program->setUniform(_uniformCache.fadeInValue, fadeInVariable);
 
-    _program->setUniform(_uniformCache.renderOption, _renderOption.value());
     _program->setUniform(_uniformCache.opacity, opacity());
 
     _program->setUniform(_uniformCache.scaleExponent, _sizeSettings.scaleExponent);

--- a/modules/base/rendering/renderableplane.cpp
+++ b/modules/base/rendering/renderableplane.cpp
@@ -41,17 +41,29 @@
 #include <variant>
 
 namespace {
+    enum RenderOption {
+        ViewDirection = 0,
+        PositionNormal,
+        FixedRotation
+    };
+
     enum BlendMode {
         Normal = 0,
         Additive
     };
 
-    constexpr openspace::properties::Property::PropertyInfo BillboardInfo = {
-        "Billboard",
-        "Billboard Mode",
-        "Specifies whether the plane should be a billboard, which means that it is "
-        "always facing the camera. If it is not, it can be oriented using other "
-        "transformations.",
+    constexpr openspace::properties::Property::PropertyInfo OrientationRenderOptionInfo =
+    {
+        "OrientationRenderOption",
+        "Orientation Render Option",
+        "Controls how the plane will be oriented. \"Camera View Direction\" rotates the "
+        "plane so that it is orthogonal to the viewing direction of the camera (useful "
+        "for planar displays), and \"Camera Position Normal\" rotates the plane towards "
+        "the position of the camera (useful for spherical displays, like dome theaters). "
+        "In both these cases the plane will be billboarded towards the camera but in a "
+        "slightly different way. In contrast, \"Fixed Rotation\" does not rotate the "
+        "plane at all based on the camera and should be used the plane should be "
+        "oriented in a fixed way.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
@@ -96,10 +108,26 @@ namespace {
     // A `RenderablePlane` is a renderable that will shows some form of contents projected
     // on a two-dimensional plane, which in turn is placed in three-dimensional space as
     // any other `Renderable`. It is possible to specify the `Size` of the plane, whether
-    // it should always face the camera (`Billboard`), and other parameters shown below.
+    // it should always face the camera (`Orientation`), and other parameters shown below.
     struct [[codegen::Dictionary(RenderablePlane)]] Parameters {
-        // [[codegen::verbatim(BillboardInfo.description)]]
-        std::optional<bool> billboard;
+        enum class [[codegen::map(RenderOption)]] RenderOption {
+            ViewDirection [[codegen::key("Camera View Direction")]],
+            PositionNormal [[codegen::key("Camera Position Normal")]],
+            FixedRotation [[codegen::key("Fixed Rotation")]]
+        };
+
+        // Controls whether the plane will be orientated as a billboard. Setting this
+        // value to `true` is the same as setting it to \"Camera Position Normal\",
+        // setting it to `false` is the same as setting it to \"Fixed Rotation\". If the
+        // value is not specified, the default value of `false` is used instead.
+        // \"Camera View Direction\" rotates the plane so that it is orthogonal to the
+        // viewing direction of the camera (useful for planar displays), and \"Camera
+        // Position Normal\" rotates the plane towards the position of the camera (useful
+        // for spherical displays, like dome theaters). In both these cases the plane will
+        // be billboarded towards the camera but in a slightly different way. In contrast,
+        // \"Fixed Rotation\" does not rotate the plane at all based on the camera and
+        // should be used the plane should be oriented in a fixed way.
+        std::optional<std::variant<bool, RenderOption>> billboard;
 
         // [[codegen::verbatim(MirrorBacksideInfo.description)]]
         std::optional<bool> mirrorBackside;
@@ -132,13 +160,13 @@ documentation::Documentation RenderablePlane::Documentation() {
 RenderablePlane::RenderablePlane(const ghoul::Dictionary& dictionary)
     : Renderable(dictionary, { .automaticallyUpdateRenderBin = false })
     , _blendMode(BlendModeInfo)
-    , _billboard(BillboardInfo, false)
+    , _renderOption(OrientationRenderOptionInfo)
     , _mirrorBackside(MirrorBacksideInfo, false)
     , _size(SizeInfo, glm::vec2(10.f), glm::vec2(0.f), glm::vec2(1e25f))
     , _autoScale(AutoScaleInfo, false)
     , _multiplyColor(MultiplyColorInfo, glm::vec3(1.f), glm::vec3(0.f), glm::vec3(1.f))
 {
-    Parameters p = codegen::bake<Parameters>(dictionary);
+    const Parameters p = codegen::bake<Parameters>(dictionary);
 
     _opacity.onChange([this]() {
         if (_blendMode == static_cast<int>(BlendMode::Normal)) {
@@ -178,8 +206,32 @@ RenderablePlane::RenderablePlane(const ghoul::Dictionary& dictionary)
     }
     addProperty(_blendMode);
 
-    _billboard = p.billboard.value_or(_billboard);
-    addProperty(_billboard);
+    _renderOption.addOption(RenderOption::ViewDirection, "Camera View Direction");
+    _renderOption.addOption(RenderOption::PositionNormal, "Camera Position Normal");
+    _renderOption.addOption(RenderOption::FixedRotation, "Fixed Rotation");
+
+    if (p.billboard.has_value()) {
+        ghoul_assert(
+            std::holds_alternative<bool>(*p.billboard) ||
+            std::holds_alternative<Parameters::RenderOption>(*p.billboard),
+            "Wrong type"
+        );
+
+        if (std::holds_alternative<bool>(*p.billboard)) {
+            _renderOption = std::get<bool>(*p.billboard) ?
+                RenderOption::ViewDirection :
+                RenderOption::FixedRotation;
+        }
+        else {
+            _renderOption = codegen::map<RenderOption>(
+                std::get<Parameters::RenderOption>(*p.billboard)
+            );
+        }
+    }
+    else {
+        _renderOption = RenderOption::FixedRotation;
+    }
+    addProperty(_renderOption);
 
     _mirrorBackside = p.mirrorBackside.value_or(_mirrorBackside);
     addProperty(_mirrorBackside);
@@ -245,29 +297,11 @@ void RenderablePlane::render(const RenderData& data, RendererTasks&) {
 
     _shader->setUniform(_uniformCache.mirrorBackside, _mirrorBackside);
 
-    const glm::dvec3 objPosWorld = glm::dvec3(
-        glm::translate(
-            glm::dmat4(1.0),
-            data.modelTransform.translation) * glm::dvec4(0.0, 0.0, 0.0, 1.0)
-    );
 
-    const glm::dvec3 normal = glm::normalize(data.camera.positionVec3() - objPosWorld);
-    const glm::dvec3 newRight = glm::normalize(
-        glm::cross(data.camera.lookUpVectorWorldSpace(), normal)
-    );
-    const glm::dvec3 newUp = glm::cross(normal, newRight);
 
-    glm::dmat4 cameraOrientedRotation = glm::dmat4(1.0);
-    cameraOrientedRotation[0] = glm::dvec4(newRight, 0.0);
-    cameraOrientedRotation[1] = glm::dvec4(newUp, 0.0);
-    cameraOrientedRotation[2] = glm::dvec4(normal, 0.0);
-
-    const glm::dmat4 rotationTransform = _billboard ?
-        cameraOrientedRotation :
-        glm::dmat4(data.modelTransform.rotation);
-
+    glm::dmat4 rotationTransform = rotationMatrix(data);
     auto [modelTransform, modelViewTransform, modelViewProjectionTransform] =
-        calcAllTransforms(data, { .rotation = rotationTransform });
+        calcAllTransforms(data, { .rotation = std::move(rotationTransform) });
 
     _shader->setUniform(
         _uniformCache.modelViewProjection,
@@ -349,6 +383,65 @@ void RenderablePlane::createPlane() {
         reinterpret_cast<void*>(sizeof(GLfloat) * 4)
     );
     glBindVertexArray(0);
+}
+
+glm::dmat4 RenderablePlane::rotationMatrix(const RenderData& data) const {
+    switch (_renderOption.value()) {
+        case RenderOption::ViewDirection:
+        {
+            glm::dvec3 cameraViewDirectionWorld = -data.camera.viewDirectionWorldSpace();
+            glm::dvec3 cameraUpDirectionWorld = data.camera.lookUpVectorWorldSpace();
+            glm::dvec3 orthoRight = glm::normalize(
+                glm::cross(cameraUpDirectionWorld, cameraViewDirectionWorld)
+            );
+            if (orthoRight == glm::dvec3(0.0)) {
+                glm::dvec3 otherVector = glm::vec3(
+                    cameraUpDirectionWorld.y,
+                    cameraUpDirectionWorld.x,
+                    cameraUpDirectionWorld.z
+                );
+                orthoRight = glm::normalize(
+                    glm::cross(otherVector, cameraViewDirectionWorld)
+                );
+            }
+            glm::dvec3 orthoUp = glm::normalize(
+                glm::cross(cameraViewDirectionWorld, orthoRight)
+            );
+
+            glm::dmat4 cameraOrientedRotation = glm::dmat4(1.0);
+            cameraOrientedRotation[0] = glm::dvec4(orthoRight, 0.0);
+            cameraOrientedRotation[1] = glm::dvec4(orthoUp, 0.0);
+            cameraOrientedRotation[2] = glm::dvec4(cameraViewDirectionWorld, 0.0);
+            return cameraOrientedRotation;
+        }
+        case RenderOption::PositionNormal:
+        {
+            const glm::dvec3 objPosWorld = glm::dvec3(
+                glm::translate(
+                    glm::dmat4(1.0),
+                    data.modelTransform.translation
+                ) * glm::dvec4(0.0, 0.0, 0.0, 1.0)
+            );
+
+            const glm::dvec3 normal = glm::normalize(
+                data.camera.positionVec3() - objPosWorld
+            );
+            const glm::dvec3 newRight = glm::normalize(
+                glm::cross(data.camera.lookUpVectorWorldSpace(), normal)
+            );
+            const glm::dvec3 newUp = glm::cross(normal, newRight);
+
+            glm::dmat4 cameraOrientedRotation = glm::dmat4(1.0);
+            cameraOrientedRotation[0] = glm::dvec4(newRight, 0.0);
+            cameraOrientedRotation[1] = glm::dvec4(newUp, 0.0);
+            cameraOrientedRotation[2] = glm::dvec4(normal, 0.0);
+            return cameraOrientedRotation;
+        }
+        case RenderOption::FixedRotation:
+            return glm::dmat4(data.modelTransform.rotation);
+    }
+
+    throw std::logic_error("Missing case exception");
 }
 
 } // namespace openspace

--- a/modules/base/rendering/renderableplane.cpp
+++ b/modules/base/rendering/renderableplane.cpp
@@ -108,7 +108,7 @@ namespace {
     // A `RenderablePlane` is a renderable that will shows some form of contents projected
     // on a two-dimensional plane, which in turn is placed in three-dimensional space as
     // any other `Renderable`. It is possible to specify the `Size` of the plane, whether
-    // it should always face the camera (`Orientation`), and other parameters shown below.
+    // it should always face the camera (`Billboard`), and other parameters shown below.
     struct [[codegen::Dictionary(RenderablePlane)]] Parameters {
         enum class [[codegen::map(RenderOption)]] RenderOption {
             ViewDirection [[codegen::key("Camera View Direction")]],
@@ -116,10 +116,11 @@ namespace {
             FixedRotation [[codegen::key("Fixed Rotation")]]
         };
 
-        // Controls whether the plane will be orientated as a billboard. Setting this
-        // value to `true` is the same as setting it to \"Camera Position Normal\",
-        // setting it to `false` is the same as setting it to \"Fixed Rotation\". If the
-        // value is not specified, the default value of `false` is used instead.
+        // Controls whether the plane will be oriented as a billboard. Setting this value
+        // to `true` is the same as setting it to \"Camera Position Normal\", setting it
+        // to `false` is the same as setting it to \"Fixed Rotation\". If the value is not
+        // specified, the default value of `false` is used instead.
+        //
         // \"Camera View Direction\" rotates the plane so that it is orthogonal to the
         // viewing direction of the camera (useful for planar displays), and \"Camera
         // Position Normal\" rotates the plane towards the position of the camera (useful

--- a/modules/base/rendering/renderableplane.h
+++ b/modules/base/rendering/renderableplane.h
@@ -64,12 +64,19 @@ public:
     static documentation::Documentation Documentation();
 
 protected:
+    enum OrientationOption {
+        ViewDirection = 0,
+        PositionNormal,
+        FixedRotation
+    };
+
     virtual void bindTexture();
     virtual void unbindTexture();
     void createPlane();
+    glm::dmat4 rotationMatrix(const RenderData& data) const;
 
     properties::OptionProperty _blendMode;
-    properties::BoolProperty _billboard;
+    properties::OptionProperty _renderOption;
     properties::BoolProperty _mirrorBackside;
     properties::Vec2Property _size;
     properties::BoolProperty _autoScale;

--- a/modules/skybrowser/src/renderableskytarget.cpp
+++ b/modules/skybrowser/src/renderableskytarget.cpp
@@ -236,7 +236,8 @@ void RenderableSkyTarget::render(const RenderData& data, RendererTasks&) {
     cameraOrientedRotation[1] = glm::dvec4(_upVector, 0.0);
     cameraOrientedRotation[2] = glm::dvec4(normal, 0.0);
 
-    const glm::dmat4 rotationTransform = _billboard ?
+    const glm::dmat4 rotationTransform =
+        _renderOption.value() != OrientationOption::FixedRotation ?
         cameraOrientedRotation :
         glm::dmat4(data.modelTransform.rotation);
 


### PR DESCRIPTION
A bit of an experimental solution for closing #3554.

# Before
Setting the billboarding setting for RenderablePointClouds and RenderablePlane were different:

RenderablePointClouds:
`OrientationRenderOption = "Camera View Direction"`, `OrientationRenderOption = "Camera Position Normal"`, or `OrientationRenderOption = "Fixed Orientation"`
with a default value of "Fixed Orientation" if nothing is specified

RenderablePlane:
`Billboard = true`, or `Billboard = false`.  If `true`, it behaves the same as `"Camera Position Normal"` from the RenderablePointClouds.  The default value is `true` is nothing is specified


# After
RenderablePointClouds and RenderablePlane behave more similar
`Billboard = "Camera View Direction"`, `Billboard = "Camera Position Normal"`, `Billboard = "Fixed Orientation"`, `Billboard = true`, or `Billboard = false`

Specifying the named variable is exactly the same for both cases.   For RenderablePlane, `true` is the same as "Camera Position Normal" and for RenderablePointClouds `true` is the same as "Camera View Direction".  The default values are unchanged.
The reason for the keeping the different behavior is to maintain backwards compatibility as each Renderable type can better decide what it means for billboarding to be `true`



Closes #3554