### PR TITLE
Issue/3596 saturn ring shadow

### DIFF
--- a/modules/globebrowsing/shaders/advanced_rings_fs.glsl
+++ b/modules/globebrowsing/shaders/advanced_rings_fs.glsl
@@ -31,6 +31,7 @@
 in vec2 vs_st;
 in float vs_screenSpaceDepth;
 in vec4 shadowCoords;
+in vec3 vs_normal;
 
 uniform sampler2DShadow shadowMapTexture;
 uniform sampler1D ringTextureFwrd;

--- a/modules/globebrowsing/shaders/advanced_rings_vs.glsl
+++ b/modules/globebrowsing/shaders/advanced_rings_vs.glsl
@@ -28,10 +28,12 @@
 
 layout(location = 0) in vec2 in_position;
 layout(location = 1) in vec2 in_st;
+layout(location = 2) in vec3 in_normal;
 
 out vec2 vs_st;
 out float vs_screenSpaceDepth;
 out vec4 shadowCoords;
+out vec3 vs_normal;
 
 uniform dmat4 modelViewProjectionMatrix;
 
@@ -43,6 +45,7 @@ uniform dmat4 shadowMatrix;
 
 void main() {
   vs_st = in_st;
+  vs_normal = mat3(modelViewProjectionMatrix) * in_normal;
 
   dvec4 positionClipSpace  = modelViewProjectionMatrix * dvec4(in_position, 0.0, 1.0);
   vec4 positionClipSpaceZNorm = z_normalization(vec4(positionClipSpace));

--- a/modules/globebrowsing/shaders/rings_fs.glsl
+++ b/modules/globebrowsing/shaders/rings_fs.glsl
@@ -31,6 +31,7 @@
 in vec2 vs_st;
 in float vs_screenSpaceDepth;
 in vec4 shadowCoords;
+in vec3 vs_normal;
 
 uniform sampler2DShadow shadowMapTexture;
 uniform sampler1D ringTexture;

--- a/modules/globebrowsing/shaders/rings_geom_fs.glsl
+++ b/modules/globebrowsing/shaders/rings_geom_fs.glsl
@@ -41,7 +41,7 @@ Fragment getFragment() {
   float radius = length(st);
 
   // Discard if normal is perpendicular to the camera direction
-  if (abs(dot(vs_normal, vec3(0.0, 0.0, 1.0))) <= 1.0e-3) {
+  if (abs(dot(normalize(vs_normal), vec3(0.0, 0.0, 1.0))) <= 1.0e-3) {
     discard;
   }
 

--- a/modules/globebrowsing/shaders/rings_geom_fs.glsl
+++ b/modules/globebrowsing/shaders/rings_geom_fs.glsl
@@ -27,6 +27,7 @@
 
 in vec2 vs_st;
 in float vs_screenSpaceDepth;
+in vec3 vs_normal;
 
 uniform sampler1D ringTexture;
 uniform vec2 textureOffset;
@@ -38,6 +39,11 @@ Fragment getFragment() {
 
   // The length of the texture coordinates vector is our distance from the center
   float radius = length(st);
+
+  // Discard if normal is perpendicular to the camera direction
+  if (abs(dot(vs_normal, vec3(0.0, 0.0, 1.0))) <= 1.0e-3) {
+    discard;
+  }
 
   // We only want to consider ring-like objects so we need to discard everything else
   if (radius > 1.0) {

--- a/modules/globebrowsing/shaders/rings_geom_fs.glsl
+++ b/modules/globebrowsing/shaders/rings_geom_fs.glsl
@@ -41,7 +41,7 @@ Fragment getFragment() {
   float radius = length(st);
 
   // Discard if normal is perpendicular to the camera direction
-  if (abs(dot(normalize(vs_normal), vec3(0.0, 0.0, 1.0))) <= 1.0e-3) {
+  if (abs(dot(normalize(vs_normal), vec3(0.0, 0.0, 1.0))) <= 0.01) {
     discard;
   }
 

--- a/modules/globebrowsing/shaders/rings_geom_vs.glsl
+++ b/modules/globebrowsing/shaders/rings_geom_vs.glsl
@@ -28,15 +28,18 @@
 
 layout(location = 0) in vec2 in_position;
 layout(location = 1) in vec2 in_st;
+layout(location = 2) in vec3 in_normal;
 
 out vec2 vs_st;
 out float vs_screenSpaceDepth;
+out vec3 vs_normal;
 
 uniform dmat4 modelViewProjectionMatrix;
 
 
 void main() {
   vs_st = in_st;
+  vs_normal = mat3(modelViewProjectionMatrix) * in_normal;
 
   dvec4 positionClipSpace  = modelViewProjectionMatrix * dvec4(in_position, 0.0, 1.0);
   vec4 positionClipSpaceZNorm = z_normalization(vec4(positionClipSpace));

--- a/modules/globebrowsing/shaders/rings_vs.glsl
+++ b/modules/globebrowsing/shaders/rings_vs.glsl
@@ -28,10 +28,12 @@
 
 layout(location = 0) in vec2 in_position;
 layout(location = 1) in vec2 in_st;
+layout(location = 2) in vec3 in_normal;
 
 out vec2 vs_st;
 out float vs_screenSpaceDepth;
 out vec4 shadowCoords;
+out vec3 vs_normal;
 
 uniform dmat4 modelViewProjectionMatrix;
 
@@ -43,6 +45,7 @@ uniform dmat4 shadowMatrix;
 
 void main() {
   vs_st = in_st;
+  vs_normal = mat3(modelViewProjectionMatrix) * in_normal;
 
   dvec4 positionClipSpace  = modelViewProjectionMatrix * dvec4(in_position, 0.0, 1.0);
   vec4 positionClipSpaceZNorm = z_normalization(vec4(positionClipSpace));

--- a/modules/globebrowsing/src/ringscomponent.cpp
+++ b/modules/globebrowsing/src/ringscomponent.cpp
@@ -769,15 +769,18 @@ void RingsComponent::createPlane() {
         GLfloat y;
         GLfloat s;
         GLfloat t;
+        GLfloat nx;
+        GLfloat ny;
+        GLfloat nz;
     };
 
     const std::array<VertexData, 6> vertices = {
-        VertexData{ -size, -size, 0.f, 0.f },
-        VertexData{  size,  size, 1.f, 1.f },
-        VertexData{ -size,  size, 0.f, 1.f },
-        VertexData{ -size, -size, 0.f, 0.f },
-        VertexData{  size, -size, 1.f, 0.f },
-        VertexData{  size,  size, 1.f, 1.f },
+        VertexData{ -size, -size, 0.f, 0.f, 0.f, 0.f, 1.f },
+        VertexData{  size,  size, 1.f, 1.f, 0.f, 0.f, 1.f },
+        VertexData{ -size,  size, 0.f, 1.f, 0.f, 0.f, 1.f },
+        VertexData{ -size, -size, 0.f, 0.f, 0.f, 0.f, 1.f },
+        VertexData{  size, -size, 1.f, 0.f, 0.f, 0.f, 1.f },
+        VertexData{  size,  size, 1.f, 1.f, 0.f, 0.f, 1.f },
     };
 
     glBindVertexArray(_quad);
@@ -800,6 +803,15 @@ void RingsComponent::createPlane() {
         GL_FALSE,
         sizeof(VertexData),
         reinterpret_cast<void*>(offsetof(VertexData, s))
+    );
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(
+        2,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        sizeof(VertexData),
+        reinterpret_cast<void*>(offsetof(VertexData, nx))
     );
 }
 


### PR DESCRIPTION
Fixes #3596 by discarding fragments in the ring shadow map shader when normals are perpendicular to the light source. This removes the artifacts while maintaining the shadow cast by the rings onto the surface of the Saturn globe geometry.