### PR TITLE
`errorlogtopic` send log messages as json object instead of a fixed string

### DIFF
--- a/modules/server/CMakeLists.txt
+++ b/modules/server/CMakeLists.txt
@@ -30,6 +30,7 @@ set(HEADER_FILES
   include/connection.h
   include/connectionpool.h
   include/jsonconverters.h
+  include/logging/notificationlog.h
   include/serverinterface.h
   include/topics/actionkeybindtopic.h
   include/topics/authorizationtopic.h
@@ -61,6 +62,7 @@ set(SOURCE_FILES
   src/connection.cpp
   src/connectionpool.cpp
   src/jsonconverters.cpp
+  src/logging/notificationlog.cpp
   src/serverinterface.cpp
   src/topics/actionkeybindtopic.cpp
   src/topics/authorizationtopic.cpp

--- a/modules/server/include/logging/notificationlog.h
+++ b/modules/server/include/logging/notificationlog.h
@@ -60,8 +60,7 @@ public:
      * Method that logs a message with a given level and category to the console.
      *
      * \param level The log level with which the message shall be logged
-     * \param category The category of this message. Can be used by each subclass
-     *        individually
+     * \param category The category of this message.
      * \param message The message body of the log message
      */
     void log(ghoul::logging::LogLevel level, std::string_view category,

--- a/modules/server/include/logging/notificationlog.h
+++ b/modules/server/include/logging/notificationlog.h
@@ -22,8 +22,8 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#ifndef __OPENSPACE_MODULE_SERVER___NOTIFICATION_LOG___H__
-#define __OPENSPACE_MODULE_SERVER___NOTIFICATION_LOG___H__
+#ifndef __OPENSPACE_MODULE_SERVER___NOTIFICATIONLOG___H__
+#define __OPENSPACE_MODULE_SERVER___NOTIFICATIONLOG___H__
 
 #include <ghoul/logging/log.h>
 
@@ -69,9 +69,8 @@ public:
 private:
     CallbackFunction _callbackFunction;
     TracyLockable(std::mutex, _mutex);
-
 };
 
 } // namespace ghoul::logging
 
-#endif // __OPENSPACE_MODULE_SERVER___NOTIFICATION_LOG___H__
+#endif // __OPENSPACE_MODULE_SERVER___NOTIFICATIONLOG___H__

--- a/modules/server/include/logging/notificationlog.h
+++ b/modules/server/include/logging/notificationlog.h
@@ -1,0 +1,77 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2025                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_MODULE_SERVER___NOTIFICATION_LOG___H__
+#define __OPENSPACE_MODULE_SERVER___NOTIFICATION_LOG___H__
+
+#include <ghoul/logging/log.h>
+
+#include <ghoul/misc/profiling.h>
+#include <functional>
+
+namespace openspace {
+
+/**
+ * A concrete subclass of Log that passes logs to the provided callback function. The
+ * callback is specified using `std::function`. Trying to log messages when the callback
+ * object has been deleted results in undefined behavior.
+ */
+class NotificationLog : public ghoul::logging::Log {
+public:
+    /// The type of function that is used as a callback in this log
+    using CallbackFunction = std::function<void(
+        std::string_view timeString,
+        std::string_view dateString,
+        std::string_view category,
+        ghoul::logging::LogLevel logLevel,
+        std::string_view message)>;
+
+    /**
+     * Constructor that calls Log constructor.
+     *
+     * \param minimumLogLevel The minimum log level that this logger will accept
+     */
+    NotificationLog(CallbackFunction callbackFunction,
+        ghoul::logging::LogLevel minimumLogLevel = ghoul::logging::LogLevel::Warning);
+
+    /**
+     * Method that logs a message with a given level and category to the console.
+     *
+     * \param level The log level with which the message shall be logged
+     * \param category The category of this message. Can be used by each subclass
+     *        individually
+     * \param message The message body of the log message
+     */
+    void log(ghoul::logging::LogLevel level, std::string_view category,
+        std::string_view message) override;
+
+private:
+    CallbackFunction _callbackFunction;
+    TracyLockable(std::mutex, _mutex);
+
+};
+
+} // namespace ghoul::logging
+
+#endif // __OPENSPACE_MODULE_SERVER___NOTIFICATION_LOG___H__

--- a/modules/server/include/logging/notificationlog.h
+++ b/modules/server/include/logging/notificationlog.h
@@ -50,6 +50,7 @@ public:
     /**
      * Constructor that calls Log constructor.
      *
+     * \param callbackFunction The callback function that is called for each log message
      * \param minimumLogLevel The minimum log level that this logger will accept
      */
     NotificationLog(CallbackFunction callbackFunction,

--- a/modules/server/include/topics/errorlogtopic.h
+++ b/modules/server/include/topics/errorlogtopic.h
@@ -39,6 +39,8 @@ public:
     bool isDone() const override;
 
 private:
+    void createLog(ghoul::logging::LogLevel logLevel);
+
     bool _isSubscribedTo = false;
     // Non owning but we remove the log from LogManager on destruction
     ghoul::logging::Log* _log = nullptr;

--- a/modules/server/include/topics/errorlogtopic.h
+++ b/modules/server/include/topics/errorlogtopic.h
@@ -39,6 +39,10 @@ public:
     bool isDone() const override;
 
 private:
+    /**
+     * Creates a log object and register it to the `LogManager`, does nothing if an active
+     * log already exists
+     */
     void createLog(ghoul::logging::LogLevel logLevel);
 
     bool _isSubscribedTo = false;

--- a/modules/server/src/logging/notificationlog.cpp
+++ b/modules/server/src/logging/notificationlog.cpp
@@ -28,24 +28,25 @@ namespace openspace {
 
 NotificationLog::NotificationLog(CallbackFunction callbackFunction,
                                  ghoul::logging::LogLevel minimumLogLevel)
-    : ghoul::logging::Log(TimeStamping::Yes
-        , DateStamping::Yes
-        , CategoryStamping::Yes
-        , LogLevelStamping::Yes
-        , minimumLogLevel)
+    : ghoul::logging::Log(
+        TimeStamping::Yes,
+        DateStamping::Yes,
+        CategoryStamping::Yes,
+        LogLevelStamping::Yes,
+        minimumLogLevel
+    )
     , _callbackFunction(std::move(callbackFunction))
 {}
 
 void NotificationLog::log(ghoul::logging::LogLevel level, std::string_view category,
-    std::string_view message) {
+                          std::string_view message)
+{
     ZoneScoped;
 
-    {
-        const std::lock_guard lock(_mutex);
-        const std::string timeStamp = timeString();
-        const std::string dateStamp = dateString();
-        _callbackFunction(timeStamp, dateStamp, category, level, message);
-    }
+    const std::lock_guard lock(_mutex);
+    const std::string timeStamp = timeString();
+    const std::string dateStamp = dateString();
+    _callbackFunction(timeStamp, dateStamp, category, level, message);
 }
 
 } // namespace openspace

--- a/modules/server/src/topics/errorlogtopic.cpp
+++ b/modules/server/src/topics/errorlogtopic.cpp
@@ -97,11 +97,11 @@ void ErrorLogTopic::createLog(ghoul::logging::LogLevel logLevel) {
         {
 
             nlohmann::json payload = {
-                { "level", level },
-                { "category", category },
-                { "message", message },
                 { "timeStamp", timeStamp },
-                { "dateStamp", dateStamp }
+                { "dateStamp", dateStamp },
+                { "category", category },
+                { "level", level },
+                { "message", message }
             };
             _connection->sendJson(wrappedPayload(std::move(payload)));
         };

--- a/modules/server/src/topics/errorlogtopic.cpp
+++ b/modules/server/src/topics/errorlogtopic.cpp
@@ -63,8 +63,9 @@ void ErrorLogTopic::handleJson(const nlohmann::json& json) {
         }
 
         auto onLogging = [this](std::string_view timeStamp, std::string_view dateStamp,
-            std::string_view category, ghoul::logging::LogLevel level,
-            std::string_view message) {
+                                std::string_view category, ghoul::logging::LogLevel level,
+                                std::string_view message)
+        {
 
             nlohmann::json payload = {
                 { "level", level },

--- a/modules/server/src/topics/errorlogtopic.cpp
+++ b/modules/server/src/topics/errorlogtopic.cpp
@@ -81,7 +81,6 @@ void ErrorLogTopic::handleJson(const nlohmann::json& json) {
 
         std::string level = json.at(LogLevelKey).get<std::string>();
         auto logLevel = ghoul::from_string<ghoul::logging::LogLevel>(level);
-
         createLog(logLevel);
     }
 }
@@ -92,19 +91,18 @@ void ErrorLogTopic::createLog(ghoul::logging::LogLevel logLevel) {
     }
 
     auto onLogging = [this](std::string_view timeStamp, std::string_view dateStamp,
-        std::string_view category, ghoul::logging::LogLevel level,
-        std::string_view message)
-        {
-
-            nlohmann::json payload = {
-                { "timeStamp", timeStamp },
-                { "dateStamp", dateStamp },
-                { "category", category },
-                { "level", level },
-                { "message", message }
-            };
-            _connection->sendJson(wrappedPayload(std::move(payload)));
+                            std::string_view category, ghoul::logging::LogLevel level,
+                            std::string_view message)
+    {
+        nlohmann::json payload = {
+            { "timeStamp", timeStamp },
+            { "dateStamp", dateStamp },
+            { "category", category },
+            { "level", level },
+            { "message", message }
         };
+        _connection->sendJson(wrappedPayload(std::move(payload)));
+    };
 
     auto log = std::make_unique<NotificationLog>(
         onLogging,

--- a/modules/server/src/topics/errorlogtopic.cpp
+++ b/modules/server/src/topics/errorlogtopic.cpp
@@ -78,7 +78,6 @@ void ErrorLogTopic::handleJson(const nlohmann::json& json) {
         ghoul::logging::LogManager::ref().removeLog(_log);
         _log = nullptr;
 
-
         std::string level = json.at(LogLevelKey).get<std::string>();
         auto logLevel = ghoul::from_string<ghoul::logging::LogLevel>(level);
         createLog(logLevel);


### PR DESCRIPTION
To make it easier on the frontend / receiving end of the topic to handle the log messages, this update changes the format to a JSON object instead of a fixed string that has to be parsed. 

Need an extra look at how the code is structured/indented. 7 months of frontend automation has ruined my feel for how we indent function params, etc