### PR TITLE
webbrowser: Fix CEF deprecation notice and crash

### DIFF
--- a/modules/webbrowser/src/cefhost.cpp
+++ b/modules/webbrowser/src/cefhost.cpp
@@ -57,6 +57,9 @@ CefHost::CefHost([[maybe_unused]] const std::string& helperLocation) {
     settings.windowless_rendering_enabled = true;
     attachDebugSettings(settings);
 
+    // cf. https://github.com/chromiumembedded/cef/issues/3685
+    setings.chrome_runtime = true;
+
 #ifdef __APPLE__
     // Load the CEF framework library at runtime instead of linking directly as required
     // by the macOS sandbox implementation


### PR DESCRIPTION
According to https://github.com/chromiumembedded/cef/issues/3685, using the so-called "Alloy bootstrap" (which seems to be the default) is deprecated. This causes a warning when starting OpenSpace.

In some setups (e.g. an AppImage build on Ubuntu 22.04), the warning is followed by a fatal error and a crash:

   [0505/213642.653624:FATAL:path_service.cc(265)] Failed to get the path for 1001

Following the migration instructions from the aforementioned ticket solve both the warning and the crash.