### PR TITLE
Lua console pasting improvements

### DIFF
--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -124,20 +124,36 @@ namespace {
     };
 
     std::string sanitizeInput(std::string str) {
-        // Remove carriage returns.
+        // Remove carriage returns
         str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
 
-        // Replace newlines with spaces.
         std::transform(
             str.begin(),
             str.end(),
             str.begin(),
-            [](char c) { return c == '\n' ? ' ' : c; }
+            [](char c) {
+                // Replace newlines with spaces
+                if (c == '\n') {
+                    return ' ';
+                }
+
+                // The documentation contains “ and ” which we convert to " to make them
+                // copy-and-pastable
+                if (c == -109 || c == -108) {
+                    return '"';
+                }
+
+                // Convert \ into / to make paths pastable
+                if (c == '\\') {
+                    return '/';
+                }
+
+                return c;
+            }
         );
 
         return str;
     }
-
 } // namespace
 
 namespace openspace {


### PR DESCRIPTION
Replace “ and ” with " to make copy-pasting from the documentation page possible.  The documentation contains text that uses, after Markdown, a "fancy" style of inverted commas.  For example: “CubicEaseIn”.  This makes it not possible to copy and paste this text as the fancy versions are not in our glyph table.

Replace \ with / to make copy-pasting paths less painful.  When pasting a path, you currently have to go in manually and replace \ with / or \\ to make it a valid path.  Can someone think of a scenario where this might be undesired?  I don't think we every paste escaped characters on purpose.