### PR TITLE
Issue/3681 missing attached node apollo

### DIFF
--- a/data/assets/scene/solarsystem/missions/apollo/11/apollo11.asset
+++ b/data/assets/scene/solarsystem/missions/apollo/11/apollo11.asset
@@ -93,7 +93,7 @@ local Apollo11MoonTrail = {
       Observer = coreKernels.ID.Moon,
       Frame = coreKernels.Frame.Moon
     },
-    Color = { 0.180000,0.510000,0.750000 },
+    Color = { 0.18, 0.51, 0.75 },
     StartTime = "1969 JUL 19 19:38:29.183",
     EndTime = "1969 JUL 22 04:55:35.183",
     SampleInterval = 60,
@@ -137,7 +137,7 @@ local Apollo11LemTrail = {
     Type = "RenderableTrailTrajectory",
     Enabled = false,
     Translation = lemTranslation,
-    Color = { 0.780000,0.940000,0.340000 },
+    Color = { 0.78, 0.94, 0.34 },
     StartTime = "1969 JUL 20 19:10:25.183",
     EndTime = "1969 JUL 20 20:17:46.183",
     SampleInterval = 2,

--- a/data/assets/scene/solarsystem/missions/apollo/11/lem_descent_rotation.asset
+++ b/data/assets/scene/solarsystem/missions/apollo/11/lem_descent_rotation.asset
@@ -1,4 +1,4 @@
-asset.export("keyframes", {
+local keyframes = {
   -- ["1969-7-20T20:9:53"] = {
   --   Type = "StaticRotation",
   --   Rotation = { -1.3815, -0.0048, -0.4891 }
@@ -1583,7 +1583,9 @@ asset.export("keyframes", {
     Type = "StaticRotation",
     Rotation = { -0.0794, -0.0088, -0.2447 }
   }
-})
+}
+
+asset.export("keyframes", keyframes)
 
 
 

--- a/include/openspace/scene/rotation.h
+++ b/include/openspace/scene/rotation.h
@@ -64,7 +64,7 @@ public:
     explicit Rotation(const ghoul::Dictionary& dictionary);
     virtual ~Rotation() override = default;
 
-    virtual bool initialize();
+    virtual void initialize();
 
     virtual void update(const UpdateData& data);
     const glm::dmat3& matrix() const;

--- a/include/openspace/scene/scale.h
+++ b/include/openspace/scene/scale.h
@@ -47,7 +47,7 @@ public:
     Scale(const ghoul::Dictionary& dictionary);
     virtual ~Scale() override = default;
 
-    virtual bool initialize();
+    virtual void initialize();
 
     virtual void update(const UpdateData& data);
     glm::dvec3 scaleValue() const;

--- a/include/openspace/scene/translation.h
+++ b/include/openspace/scene/translation.h
@@ -48,7 +48,7 @@ public:
     explicit Translation(const ghoul::Dictionary& dictionary);
     virtual ~Translation() override = default;
 
-    virtual bool initialize();
+    virtual void initialize();
 
     virtual void update(const UpdateData& data);
     glm::dvec3 position() const;

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -244,7 +244,6 @@ RenderableTrail::RenderableTrail(const ghoul::Dictionary& dictionary)
     }
 
     addPropertySubOwner(_appearance);
-
 }
 
 void RenderableTrail::initialize() {
@@ -299,7 +298,10 @@ glm::dvec3 RenderableTrail::translationPosition(Time time) const {
     // Use an empty modelTransform to get the position in local coordinates. Also, the
     // previous frame time does not matter so we just use time 0
     const UpdateData data = { {}, time, Time(0.0) };
-    _translation->update(data);
+    // @TODO (2025-06-09, emmbr) Do we need to also call the update for the translation?
+    // As of now, this borks up the performance of the trail completely, and I'm not sure
+    // the update is needed since we are not using the cached version of the position.
+    //_translation->update(data);
     return _translation->position(data);
 }
 

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -247,6 +247,7 @@ RenderableTrail::RenderableTrail(const ghoul::Dictionary& dictionary)
 }
 
 void RenderableTrail::initialize() {
+    Renderable::initialize();
     _translation->initialize();
 }
 

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -295,6 +295,14 @@ bool RenderableTrail::isReady() const {
     return _programObject != nullptr;
 }
 
+glm::dvec3 RenderableTrail::translationPosition(Time time) const {
+    // Use an empty modelTransform to get the position in local coordinates. Also, the
+    // previous frame time does not matter so we just use time 0
+    const UpdateData data = { {}, time, Time(0.0) };
+    _translation->update(data);
+    return _translation->position(data);
+}
+
 void RenderableTrail::internalRender(bool renderLines, bool renderPoints,
                                      const RenderData& data,
                                      const glm::dmat4& modelTransform,

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -247,6 +247,10 @@ RenderableTrail::RenderableTrail(const ghoul::Dictionary& dictionary)
 
 }
 
+void RenderableTrail::initialize() {
+    _translation->initialize();
+}
+
 void RenderableTrail::initializeGL() {
     ZoneScoped;
 
@@ -545,8 +549,6 @@ void RenderableTrail::render(const RenderData& data, RendererTasks&) {
             );
         }
     }
-
-
 
 
     if (renderPoints) {

--- a/modules/base/rendering/renderabletrail.cpp
+++ b/modules/base/rendering/renderabletrail.cpp
@@ -486,7 +486,7 @@ void RenderableTrail::render(const RenderData& data, RendererTasks&) {
             _primaryRenderInformation.count,
             _primaryRenderInformation.first,
             _useSplitRenderMode,
-            _numberOfUniqueVertices
+            _nUniqueVertices
         );
 
         const int floatingOffset = std::max(0, _primaryRenderInformation.count - 1);
@@ -499,7 +499,7 @@ void RenderableTrail::render(const RenderData& data, RendererTasks&) {
             _floatingRenderInformation.count,
             _floatingRenderInformation.first,
             _useSplitRenderMode,
-            _numberOfUniqueVertices,
+            _nUniqueVertices,
             floatingOffset
         );
 
@@ -513,7 +513,7 @@ void RenderableTrail::render(const RenderData& data, RendererTasks&) {
             _secondaryRenderInformation.count,
             _secondaryRenderInformation.first,
             _useSplitRenderMode,
-            _numberOfUniqueVertices,
+            _nUniqueVertices,
             offset
         );
 

--- a/modules/base/rendering/renderabletrail.h
+++ b/modules/base/rendering/renderabletrail.h
@@ -117,9 +117,8 @@ protected:
     explicit RenderableTrail(const ghoul::Dictionary& dictionary);
 
     /**
-     * Get the trail position for a given time from the translation object, and make
-     * sure the update function is called beforehand. The position will be in the local
-     * coordinate system of the renderable.
+     * Get the trail position for a given time from the translation object. The position
+     * will be in the local coordinate system of the renderable.
      *
      * \param time The time for which to get the position
      * \return The position of the trail at the given time, in the local coordinate system

--- a/modules/base/rendering/renderabletrail.h
+++ b/modules/base/rendering/renderabletrail.h
@@ -97,6 +97,7 @@ public:
 
     virtual ~RenderableTrail() override = default;
 
+    void initialize() override;
     void initializeGL() override;
     void deinitializeGL() override;
 

--- a/modules/base/rendering/renderabletrail.h
+++ b/modules/base/rendering/renderabletrail.h
@@ -116,6 +116,16 @@ public:
 protected:
     explicit RenderableTrail(const ghoul::Dictionary& dictionary);
 
+    /**
+     * Get the trail position for a given time from the translation object, and make
+     * sure the update function is called beforehand. The position will be in the local
+     * coordinate system of the renderable.
+     *
+     * \param time The time for which to get the position
+     * \return The position of the trail at the given time, in the local coordinate system
+     */
+    glm::dvec3 translationPosition(Time time) const;
+
     static documentation::Documentation Documentation();
 
     /// The layout of the VBOs (use float if sending as positions to shader)

--- a/modules/base/rendering/renderabletrail.h
+++ b/modules/base/rendering/renderabletrail.h
@@ -179,7 +179,7 @@ protected:
     /// Flag used to determine if we use a split trail or not during rendering
     bool _useSplitRenderMode = false;
     /// Number of unique vertices used when rendering segmented trails
-    int _numberOfUniqueVertices = 0;
+    int _nUniqueVertices = 0;
 
 private:
     void internalRender(bool renderLines, bool renderPoints,

--- a/modules/base/rendering/renderabletrailorbit.cpp
+++ b/modules/base/rendering/renderabletrailorbit.cpp
@@ -185,11 +185,9 @@ void RenderableTrailOrbit::update(const UpdateData& data) {
 
     // 2
     // Write the current location into the floating position
-    const glm::vec3 p = _translation->position({
-        {},
-        data.time,
-        Time(0.0)
-    });
+    const UpdateData updateData = { {}, data.time, Time(0.0) };
+    _translation->update(updateData);
+    const glm::vec3 p = _translation->position(updateData);
     _vertexArray[_primaryRenderInformation.first] = { p.x, p.y, p.z };
 
     glBindVertexArray(_primaryRenderInformation._vaoID);
@@ -405,11 +403,9 @@ RenderableTrailOrbit::UpdateReport RenderableTrailOrbit::updateTrails(
 
             // Get the new permanent point and write it into the (previously) floating
             // location
-            const glm::vec3 p = _translation->position({
-                {},
-                Time(_firstPointTime),
-                Time(0.0)
-            });
+            const UpdateData updateData = { {}, Time(_firstPointTime), Time(0.0) };
+            _translation->update(updateData);
+            const glm::vec3 p = _translation->position(updateData);
             _vertexArray[_primaryRenderInformation.first] = { p.x, p.y, p.z };
 
             // if we are on the upper bounds of the array, we start at 0
@@ -452,7 +448,9 @@ void RenderableTrailOrbit::fullSweep(double time) {
     const double secondsPerPoint = periodSeconds / (_resolution - 1);
     // starting at 1 because the first position is a floating current one
     for (int i = 1; i < _resolution; i++) {
-        const glm::vec3 p = _translation->position({ {}, Time(time), Time(0.0) });
+        const UpdateData updateData = { {}, Time(time), Time(0.0) };
+        _translation->update(updateData);
+        const glm::vec3 p = _translation->position(updateData);
         _vertexArray[i] = { p.x, p.y, p.z };
 
         time -= secondsPerPoint;

--- a/modules/base/rendering/renderabletrailorbit.cpp
+++ b/modules/base/rendering/renderabletrailorbit.cpp
@@ -185,9 +185,8 @@ void RenderableTrailOrbit::update(const UpdateData& data) {
 
     // 2
     // Write the current location into the floating position
-    const UpdateData updateData = { {}, data.time, Time(0.0) };
-    _translation->update(updateData);
-    const glm::vec3 p = _translation->position(updateData);
+    const glm::vec3 p = translationPosition(data.time);
+
     _vertexArray[_primaryRenderInformation.first] = { p.x, p.y, p.z };
 
     glBindVertexArray(_primaryRenderInformation._vaoID);
@@ -363,11 +362,7 @@ RenderableTrailOrbit::UpdateReport RenderableTrailOrbit::updateTrails(
 
             // Get the new permanent point and write it into the (previously) floating
             // location
-            const glm::vec3 p = _translation->position({
-                {},
-                Time(_lastPointTime),
-                Time(0.0)
-            });
+            const glm::vec3 p = translationPosition(Time(_lastPointTime));
             _vertexArray[_primaryRenderInformation.first] = { p.x, p.y, p.z };
 
             // Move the current pointer back one step to be used as the new floating
@@ -403,9 +398,7 @@ RenderableTrailOrbit::UpdateReport RenderableTrailOrbit::updateTrails(
 
             // Get the new permanent point and write it into the (previously) floating
             // location
-            const UpdateData updateData = { {}, Time(_firstPointTime), Time(0.0) };
-            _translation->update(updateData);
-            const glm::vec3 p = _translation->position(updateData);
+            const glm::vec3 p = translationPosition(Time(_firstPointTime));
             _vertexArray[_primaryRenderInformation.first] = { p.x, p.y, p.z };
 
             // if we are on the upper bounds of the array, we start at 0
@@ -448,9 +441,7 @@ void RenderableTrailOrbit::fullSweep(double time) {
     const double secondsPerPoint = periodSeconds / (_resolution - 1);
     // starting at 1 because the first position is a floating current one
     for (int i = 1; i < _resolution; i++) {
-        const UpdateData updateData = { {}, Time(time), Time(0.0) };
-        _translation->update(updateData);
-        const glm::vec3 p = _translation->position(updateData);
+        const glm::vec3 p = translationPosition(Time(time));
         _vertexArray[i] = { p.x, p.y, p.z };
 
         time -= secondsPerPoint;

--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -302,11 +302,13 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
 
         // Calculate all vertex positions
         for (unsigned int i = startIndex; i < stopIndex; i++) {
-            const glm::dvec3 dp = _translation->position({
+            const UpdateData updateData = {
                 {},
                 Time(_start + i * _totalSampleInterval),
                 Time(0.0)
-            });
+            };
+            _translation->update(updateData);
+            const glm::dvec3 dp = _translation->position(updateData);
             const glm::vec3 p(dp.x, dp.y, dp.z);
             _vertexArray[i] = { p.x, p.y, p.z };
             _timeVector[i] = Time(_start + i * _totalSampleInterval).j2000Seconds();
@@ -322,11 +324,9 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
         // Adds the last point in time to the _vertexArray so that we
         // ensure that points for _start and _end always exists
         if (stopIndex == _nVertices) {
-            const glm::dvec3 dp = _translation->position({
-                {},
-                Time(_end),
-                Time(0.0)
-            });
+            const UpdateData updateData = { {}, Time(_end), Time(0.0) };
+            _translation->update(updateData);
+            const glm::dvec3 dp = _translation->position(updateData);
             const glm::vec3 p(dp.x, dp.y, dp.z);
             _vertexArray[stopIndex] = { p.x, p.y, p.z };
             _timeVector[stopIndex] = Time(_end).j2000Seconds();
@@ -416,6 +416,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
         );
 
         // Get current position of the object
+        _translation->update(data);
         const glm::dvec3 p = _translation->position(data);
 
         // Calculates all replacement points before the object

--- a/modules/base/rendering/renderabletrailtrajectory.cpp
+++ b/modules/base/rendering/renderabletrailtrajectory.cpp
@@ -302,13 +302,9 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
 
         // Calculate all vertex positions
         for (unsigned int i = startIndex; i < stopIndex; i++) {
-            const UpdateData updateData = {
-                {},
-                Time(_start + i * _totalSampleInterval),
-                Time(0.0)
-            };
-            _translation->update(updateData);
-            const glm::dvec3 dp = _translation->position(updateData);
+            const glm::dvec3 dp = translationPosition(
+                Time(_start + i * _totalSampleInterval)
+            );
             const glm::vec3 p(dp.x, dp.y, dp.z);
             _vertexArray[i] = { p.x, p.y, p.z };
             _timeVector[i] = Time(_start + i * _totalSampleInterval).j2000Seconds();
@@ -324,9 +320,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
         // Adds the last point in time to the _vertexArray so that we
         // ensure that points for _start and _end always exists
         if (stopIndex == _nVertices) {
-            const UpdateData updateData = { {}, Time(_end), Time(0.0) };
-            _translation->update(updateData);
-            const glm::dvec3 dp = _translation->position(updateData);
+            const glm::dvec3 dp = translationPosition(Time(_end));
             const glm::vec3 p(dp.x, dp.y, dp.z);
             _vertexArray[stopIndex] = { p.x, p.y, p.z };
             _timeVector[stopIndex] = Time(_end).j2000Seconds();
@@ -416,8 +410,7 @@ void RenderableTrailTrajectory::update(const UpdateData& data) {
         );
 
         // Get current position of the object
-        _translation->update(data);
-        const glm::dvec3 p = _translation->position(data);
+        const glm::dvec3 p = translationPosition(data.time);
 
         // Calculates all replacement points before the object
         glm::dvec3 v = p;

--- a/modules/base/rendering/renderabletrailtrajectory.h
+++ b/modules/base/rendering/renderabletrailtrajectory.h
@@ -84,7 +84,7 @@ private:
     properties::BoolProperty _renderFullTrail;
     /// Determines how many vertices around the object that will be
     /// replaced during full trail rendering
-    properties::IntProperty _numberOfReplacementPoints;
+    properties::IntProperty _nReplacementPoints;
 
     /// Dirty flag that determines whether the full vertex buffer needs to be resampled
     bool _needsFullSweep = true;
@@ -102,7 +102,7 @@ private:
 
     /// How many points do we need to compute given the distance between the
     /// start and end date and the desired sample interval
-    unsigned int _numberOfVertices = 0;
+    unsigned int _nVertices = 0;
 
     double _totalSampleInterval = 0.0;
 

--- a/modules/base/rendering/screenspacerenderablerenderable.cpp
+++ b/modules/base/rendering/screenspacerenderablerenderable.cpp
@@ -187,7 +187,6 @@ ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
     addProperty(_cameraFov);
 
     _renderable = Renderable::createFromDictionary(p.renderable);
-    _renderable->initialize();
     addPropertySubOwner(_renderable.get());
 
     _transform = ghoul::mm_unique_ptr<properties::PropertyOwner>(
@@ -204,7 +203,6 @@ ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
         translation.setValue("Position", glm::dvec3(0.0));
         _translation = Translation::createFromDictionary(translation);
     }
-    _translation->initialize();
     _transform->addPropertySubOwner(_translation.get());
 
     if (p.transform.has_value() && p.transform->rotation.has_value()) {
@@ -216,7 +214,6 @@ ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
         rotation.setValue("Rotation", glm::dvec3(0.0));
         _rotation = Rotation::createFromDictionary(rotation);
     }
-    _rotation->initialize();
     _transform->addPropertySubOwner(_rotation.get());
 
     if (p.transform.has_value() && p.transform->scale.has_value()) {
@@ -228,11 +225,18 @@ ScreenSpaceRenderableRenderable::ScreenSpaceRenderableRenderable(
         scale.setValue("Scale", 1.0);
         _scale = Scale::createFromDictionary(scale);
     }
-    _scale->initialize();
     _transform->addPropertySubOwner(_scale.get());
 }
 
 ScreenSpaceRenderableRenderable::~ScreenSpaceRenderableRenderable() {}
+
+void ScreenSpaceRenderableRenderable::initialize() {
+    ScreenSpaceFramebuffer::initialize();
+    _translation->initialize();
+    _rotation->initialize();
+    _scale->initialize();
+    _renderable->initialize();
+}
 
 void ScreenSpaceRenderableRenderable::initializeGL() {
     ScreenSpaceFramebuffer::initializeGL();

--- a/modules/base/rendering/screenspacerenderablerenderable.h
+++ b/modules/base/rendering/screenspacerenderablerenderable.h
@@ -50,6 +50,7 @@ public:
     explicit ScreenSpaceRenderableRenderable(const ghoul::Dictionary& dictionary);
     virtual ~ScreenSpaceRenderableRenderable() override;
 
+    void initialize() override;
     void initializeGL() override;
     void deinitializeGL() override;
     void update() override;

--- a/modules/base/rotation/fixedrotation.cpp
+++ b/modules/base/rotation/fixedrotation.cpp
@@ -444,7 +444,7 @@ FixedRotation::FixedRotation(const ghoul::Dictionary& dictionary)
     setPropertyVisibility(_zAxis);
 }
 
-bool FixedRotation::initialize() {
+void FixedRotation::initialize() {
     ZoneScoped;
 
     // We have already checked this before, but still
@@ -454,7 +454,7 @@ bool FixedRotation::initialize() {
     // nodes referenced in the dictionary might not exist yet at construction time. At
     // initialization time, however, we know that they already have been created
 
-    const bool res = Rotation::initialize();
+    Rotation::initialize();
 
     _attachedObject = p.attached.value_or(_attachedObject);
 
@@ -525,7 +525,6 @@ bool FixedRotation::initialize() {
 
     // No need to hold on to the data
     _constructorDictionary = ghoul::Dictionary();
-    return res;
 }
 
 void FixedRotation::update(const UpdateData& data) {

--- a/modules/base/rotation/fixedrotation.h
+++ b/modules/base/rotation/fixedrotation.h
@@ -43,7 +43,7 @@ class FixedRotation : public Rotation {
 public:
     explicit FixedRotation(const ghoul::Dictionary& dictionary);
 
-    bool initialize() override;
+    void initialize() override;
 
     void update(const UpdateData& data) override;
     glm::dmat3 matrix(const UpdateData& data) const override;

--- a/modules/base/rotation/globerotation.cpp
+++ b/modules/base/rotation/globerotation.cpp
@@ -166,8 +166,8 @@ GlobeRotation::GlobeRotation(const ghoul::Dictionary& dictionary)
 
 void GlobeRotation::fillAttachedNode() {
     SceneGraphNode* n = sceneGraphNode(_sceneGraphNode);
-    if (!n || !n->renderable()) {
-        LERROR("Could not set attached node as it does not have a renderable");
+    if (!n) {
+        LERROR(std::format("Could not find attached node '{}'", _sceneGraphNode.value()));
         return;
     }
     _attachedNode = n;
@@ -179,7 +179,7 @@ void GlobeRotation::setUpdateVariables() {
 }
 
 glm::vec3 GlobeRotation::computeSurfacePosition(double latitude, double longitude) const {
-    ghoul_assert(_attachedNode, "Renderable cannot be nullptr");
+    ghoul_assert(_attachedNode, "Attached node cannot be nullptr");
 
     const Geodetic3 pos = {
         { .lat = glm::radians(latitude), .lon = glm::radians(longitude) },
@@ -211,11 +211,6 @@ void GlobeRotation::initialize() {
 }
 
 void GlobeRotation::update(const UpdateData& data) {
-    if (!_attachedNode) [[unlikely]] {
-        fillAttachedNode();
-        _matrixIsDirty = true;
-    }
-
     if (_useHeightmap || _useCamera) {
         // If we use the heightmap, we have to compute the height every frame
         setUpdateVariables();
@@ -229,8 +224,7 @@ glm::dmat3 GlobeRotation::matrix(const UpdateData&) const {
         return _matrix;
     }
 
-    if (!_attachedNode) {
-        LERROR(std::format("Could not find attached node '{}'", _sceneGraphNode.value()));
+    if (!_attachedNode) [[unlikely]] {
         return _matrix;
     }
 

--- a/modules/base/rotation/globerotation.cpp
+++ b/modules/base/rotation/globerotation.cpp
@@ -37,6 +37,8 @@
 #include <glm/gtx/quaternion.hpp>
 
 namespace {
+    constexpr std::string_view _loggerCat = "GlobeRotation";
+
     constexpr openspace::properties::Property::PropertyInfo GlobeInfo = {
         "Globe",
         "Attached Globe",
@@ -136,7 +138,7 @@ GlobeRotation::GlobeRotation(const ghoul::Dictionary& dictionary)
 
     _sceneGraphNode = p.globe;
     _sceneGraphNode.onChange([this]() {
-        findNode();
+        fillAttachedNode();
         setUpdateVariables();
     });
     addProperty(_sceneGraphNode);
@@ -162,13 +164,10 @@ GlobeRotation::GlobeRotation(const ghoul::Dictionary& dictionary)
     addProperty(_useCamera);
 }
 
-void GlobeRotation::findNode() {
+void GlobeRotation::fillAttachedNode() {
     SceneGraphNode* n = sceneGraphNode(_sceneGraphNode);
     if (!n || !n->renderable()) {
-        LERRORC(
-            "GlobeRotation",
-            "Could not set attached node as it does not have a Renderable"
-        );
+        LERROR("Could not set attached node as it does not have a renderable");
         return;
     }
     _attachedNode = n;
@@ -208,7 +207,7 @@ glm::vec3 GlobeRotation::computeSurfacePosition(double latitude, double longitud
 
 void GlobeRotation::update(const UpdateData& data) {
     if (!_attachedNode) [[unlikely]] {
-        findNode();
+        fillAttachedNode();
         _matrixIsDirty = true;
     }
 
@@ -226,10 +225,7 @@ glm::dmat3 GlobeRotation::matrix(const UpdateData&) const {
     }
 
     if (!_attachedNode) {
-        LERRORC(
-            "GlobeRotation",
-            std::format("Could not find globe '{}'", _sceneGraphNode.value())
-        );
+        LERROR(std::format("Could not find attached node '{}'", _sceneGraphNode.value()));
         return _matrix;
     }
 

--- a/modules/base/rotation/globerotation.cpp
+++ b/modules/base/rotation/globerotation.cpp
@@ -205,6 +205,11 @@ glm::vec3 GlobeRotation::computeSurfacePosition(double latitude, double longitud
     );
 }
 
+void GlobeRotation::initialize() {
+    Rotation::initialize();
+    fillAttachedNode();
+}
+
 void GlobeRotation::update(const UpdateData& data) {
     if (!_attachedNode) [[unlikely]] {
         fillAttachedNode();

--- a/modules/base/rotation/globerotation.h
+++ b/modules/base/rotation/globerotation.h
@@ -39,6 +39,8 @@ class GlobeRotation : public Rotation {
 public:
     explicit GlobeRotation(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dmat3 matrix(const UpdateData& data) const override;
 

--- a/modules/base/rotation/globerotation.h
+++ b/modules/base/rotation/globerotation.h
@@ -45,7 +45,7 @@ public:
     static documentation::Documentation Documentation();
 
 private:
-    void findNode();
+    void fillAttachedNode();
     void setUpdateVariables();
 
     /**

--- a/modules/base/rotation/multirotation.cpp
+++ b/modules/base/rotation/multirotation.cpp
@@ -64,6 +64,13 @@ MultiRotation::MultiRotation(const ghoul::Dictionary& dictionary)
     }
 }
 
+void MultiRotation::initialize() {
+    Rotation::initialize();
+    for (const ghoul::mm_unique_ptr<Rotation>& rot : _rotations) {
+        rot->initialize();
+    }
+}
+
 void MultiRotation::update(const UpdateData& data) {
     for (const ghoul::mm_unique_ptr<Rotation>& rot : _rotations) {
         rot->update(data);

--- a/modules/base/rotation/multirotation.h
+++ b/modules/base/rotation/multirotation.h
@@ -39,6 +39,8 @@ class MultiRotation : public Rotation {
 public:
     explicit MultiRotation(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dmat3 matrix(const UpdateData& data) const override;
 

--- a/modules/base/rotation/timelinerotation.cpp
+++ b/modules/base/rotation/timelinerotation.cpp
@@ -83,6 +83,13 @@ TimelineRotation::TimelineRotation(const ghoul::Dictionary& dictionary)
     addProperty(_shouldInterpolate);
 }
 
+void TimelineRotation::initialize() {
+    Rotation::initialize();
+    for (const Keyframe<ghoul::mm_unique_ptr<Rotation>>& kf : _timeline.keyframes()) {
+        kf.data->initialize();
+    }
+}
+
 void TimelineRotation::update(const UpdateData& data) {
     const double now = data.time.j2000Seconds();
     using KeyframePointer = const Keyframe<ghoul::mm_unique_ptr<Rotation>>*;

--- a/modules/base/rotation/timelinerotation.h
+++ b/modules/base/rotation/timelinerotation.h
@@ -40,6 +40,8 @@ class TimelineRotation : public Rotation {
 public:
     explicit TimelineRotation(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dmat3 matrix(const UpdateData& data) const override;
     static documentation::Documentation Documentation();

--- a/modules/base/scale/multiscale.cpp
+++ b/modules/base/scale/multiscale.cpp
@@ -63,6 +63,13 @@ MultiScale::MultiScale(const ghoul::Dictionary& dictionary)
     }
 }
 
+void MultiScale::initialize() {
+    Scale::initialize();
+    for (const ghoul::mm_unique_ptr<Scale>& scale : _scales) {
+        scale->initialize();
+    }
+}
+
 void MultiScale::update(const UpdateData& data) {
     for (const ghoul::mm_unique_ptr<Scale>& scale : _scales) {
         scale->update(data);

--- a/modules/base/scale/multiscale.h
+++ b/modules/base/scale/multiscale.h
@@ -35,6 +35,8 @@ class MultiScale : public Scale {
 public:
     explicit MultiScale(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dvec3 scaleValue(const UpdateData& data) const override;
 

--- a/modules/base/scale/timelinescale.cpp
+++ b/modules/base/scale/timelinescale.cpp
@@ -81,6 +81,13 @@ TimelineScale::TimelineScale(const ghoul::Dictionary& dictionary)
     addProperty(_shouldInterpolate);
 }
 
+void TimelineScale::initialize() {
+    Scale::initialize();
+    for (const Keyframe<ghoul::mm_unique_ptr<Scale>>& kf : _timeline.keyframes()) {
+        kf.data->initialize();
+    }
+}
+
 void TimelineScale::update(const UpdateData& data) {
     const double now = data.time.j2000Seconds();
     using KeyframePointer = const Keyframe<ghoul::mm_unique_ptr<Scale>>*;

--- a/modules/base/scale/timelinescale.h
+++ b/modules/base/scale/timelinescale.h
@@ -41,6 +41,8 @@ class TimelineScale : public Scale {
 public:
     explicit TimelineScale(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dvec3 scaleValue(const UpdateData& data) const override;
     static documentation::Documentation Documentation();

--- a/modules/base/translation/globetranslation.cpp
+++ b/modules/base/translation/globetranslation.cpp
@@ -190,8 +190,8 @@ GlobeTranslation::GlobeTranslation(const ghoul::Dictionary& dictionary)
 
 void GlobeTranslation::fillAttachedNode() {
     SceneGraphNode* n = sceneGraphNode(_sceneGraphNode);
-    if (!n || !n->renderable()) {
-        LERROR("Could not set attached node as it does not have a renderable");
+    if (!n) {
+        LERROR(std::format("Could not find attached node '{}'", _sceneGraphNode.value()));
         return;
     }
     _attachedNode = n;
@@ -208,11 +208,6 @@ void GlobeTranslation::initialize() {
 }
 
 void GlobeTranslation::update(const UpdateData& data) {
-    if (!_attachedNode) [[unlikely]] {
-        fillAttachedNode();
-        _positionIsDirty = true;
-    }
-
     if (_useHeightmap || _useCamera) {
         // If we use the heightmap, we have to compute the height every frame
         setUpdateVariables();
@@ -226,8 +221,7 @@ glm::dvec3 GlobeTranslation::position(const UpdateData&) const {
         return _position;
     }
 
-    if (!_attachedNode) {
-        LERROR(std::format("Could not find attached node '{}'", _sceneGraphNode.value()));
+    if (!_attachedNode) [[unlikely]] {
         return _position;
     }
 

--- a/modules/base/translation/globetranslation.cpp
+++ b/modules/base/translation/globetranslation.cpp
@@ -37,6 +37,8 @@
 #include <ghoul/logging/logmanager.h>
 
 namespace {
+    constexpr std::string_view _loggerCat = "GlobeTranslation";
+
     constexpr openspace::properties::Property::PropertyInfo GlobeInfo = {
         "Globe",
         "Attached Globe",
@@ -189,13 +191,9 @@ GlobeTranslation::GlobeTranslation(const ghoul::Dictionary& dictionary)
 void GlobeTranslation::fillAttachedNode() {
     SceneGraphNode* n = sceneGraphNode(_sceneGraphNode);
     if (!n || !n->renderable()) {
-        LERRORC(
-            "GlobeTranslation",
-            "Could not set attached node as it does not have a renderable"
-        );
+        LERROR("Could not set attached node as it does not have a renderable");
         return;
     }
-
     _attachedNode = n;
 }
 
@@ -224,10 +222,7 @@ glm::dvec3 GlobeTranslation::position(const UpdateData&) const {
     }
 
     if (!_attachedNode) {
-        LERRORC(
-            "GlobeRotation",
-            std::format("Could not find attached node '{}'", _sceneGraphNode.value())
-        );
+        LERROR(std::format("Could not find attached node '{}'", _sceneGraphNode.value()));
         return _position;
     }
 

--- a/modules/base/translation/globetranslation.cpp
+++ b/modules/base/translation/globetranslation.cpp
@@ -202,6 +202,11 @@ void GlobeTranslation::setUpdateVariables() {
     requireUpdate();
 }
 
+void GlobeTranslation::initialize() {
+    Translation::initialize();
+    fillAttachedNode();
+}
+
 void GlobeTranslation::update(const UpdateData& data) {
     if (!_attachedNode) [[unlikely]] {
         fillAttachedNode();

--- a/modules/base/translation/globetranslation.h
+++ b/modules/base/translation/globetranslation.h
@@ -39,6 +39,8 @@ class GlobeTranslation : public Translation {
 public:
     explicit GlobeTranslation(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dvec3 position(const UpdateData& data) const override;
 

--- a/modules/base/translation/multitranslation.cpp
+++ b/modules/base/translation/multitranslation.cpp
@@ -64,6 +64,13 @@ MultiTranslation::MultiTranslation(const ghoul::Dictionary& dictionary)
     }
 }
 
+void MultiTranslation::initialize() {
+    Translation::initialize();
+    for (const ghoul::mm_unique_ptr<Translation>& translation : _translations) {
+        translation->initialize();
+    }
+}
+
 void MultiTranslation::update(const UpdateData& data) {
     for (const ghoul::mm_unique_ptr<Translation>& translation : _translations) {
         translation->update(data);

--- a/modules/base/translation/multitranslation.h
+++ b/modules/base/translation/multitranslation.h
@@ -37,6 +37,8 @@ class MultiTranslation : public Translation {
 public:
     explicit MultiTranslation(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dvec3 position(const UpdateData& data) const override;
     static documentation::Documentation Documentation();

--- a/modules/base/translation/timelinetranslation.cpp
+++ b/modules/base/translation/timelinetranslation.cpp
@@ -83,6 +83,14 @@ TimelineTranslation::TimelineTranslation(const ghoul::Dictionary& dictionary)
     addProperty(_shouldInterpolate);
 }
 
+bool TimelineTranslation::initialize() {
+    Translation::initialize();
+
+    for (const Keyframe<ghoul::mm_unique_ptr<Translation>>& kf : _timeline.keyframes()) {
+        kf.data->initialize();
+    }
+}
+
 void TimelineTranslation::update(const UpdateData& data) {
     const double now = data.time.j2000Seconds();
     using KeyframePointer = const Keyframe<ghoul::mm_unique_ptr<Translation>>*;

--- a/modules/base/translation/timelinetranslation.cpp
+++ b/modules/base/translation/timelinetranslation.cpp
@@ -83,7 +83,7 @@ TimelineTranslation::TimelineTranslation(const ghoul::Dictionary& dictionary)
     addProperty(_shouldInterpolate);
 }
 
-bool TimelineTranslation::initialize() {
+void TimelineTranslation::initialize() {
     Translation::initialize();
 
     for (const Keyframe<ghoul::mm_unique_ptr<Translation>>& kf : _timeline.keyframes()) {

--- a/modules/base/translation/timelinetranslation.cpp
+++ b/modules/base/translation/timelinetranslation.cpp
@@ -85,7 +85,6 @@ TimelineTranslation::TimelineTranslation(const ghoul::Dictionary& dictionary)
 
 void TimelineTranslation::initialize() {
     Translation::initialize();
-
     for (const Keyframe<ghoul::mm_unique_ptr<Translation>>& kf : _timeline.keyframes()) {
         kf.data->initialize();
     }

--- a/modules/base/translation/timelinetranslation.h
+++ b/modules/base/translation/timelinetranslation.h
@@ -41,6 +41,8 @@ class TimelineTranslation : public Translation {
 public:
     explicit TimelineTranslation(const ghoul::Dictionary& dictionary);
 
+    void initialize() override;
+
     void update(const UpdateData& data) override;
     glm::dvec3 position(const UpdateData& data) const override;
     static documentation::Documentation Documentation();

--- a/src/scene/rotation.cpp
+++ b/src/scene/rotation.cpp
@@ -90,9 +90,7 @@ void Rotation::requireUpdate() {
     _needsUpdate = true;
 }
 
-bool Rotation::initialize() {
-    return true;
-}
+void Rotation::initialize() {}
 
 const glm::dmat3& Rotation::matrix() const {
     return _cachedMatrix;

--- a/src/scene/rotation.cpp
+++ b/src/scene/rotation.cpp
@@ -90,7 +90,11 @@ void Rotation::requireUpdate() {
     _needsUpdate = true;
 }
 
-void Rotation::initialize() {}
+void Rotation::initialize() {
+    if (_timeFrame) {
+        _timeFrame->initialize();
+    }
+}
 
 const glm::dmat3& Rotation::matrix() const {
     return _cachedMatrix;

--- a/src/scene/scale.cpp
+++ b/src/scene/scale.cpp
@@ -88,9 +88,7 @@ void Scale::requireUpdate() {
     _needsUpdate = true;
 }
 
-bool Scale::initialize() {
-    return true;
-}
+void Scale::initialize() {}
 
 glm::dvec3 Scale::scaleValue() const {
     return _cachedScale;

--- a/src/scene/scale.cpp
+++ b/src/scene/scale.cpp
@@ -88,7 +88,11 @@ void Scale::requireUpdate() {
     _needsUpdate = true;
 }
 
-void Scale::initialize() {}
+void Scale::initialize() {
+    if (_timeFrame) {
+        _timeFrame->initialize();
+    }
+}
 
 glm::dvec3 Scale::scaleValue() const {
     return _cachedScale;

--- a/src/scene/translation.cpp
+++ b/src/scene/translation.cpp
@@ -81,7 +81,11 @@ Translation::Translation(const ghoul::Dictionary& dictionary)
     }
 }
 
-void Translation::initialize() {}
+void Translation::initialize() {
+    if (_timeFrame) {
+        _timeFrame->initialize();
+    }
+}
 
 void Translation::update(const UpdateData& data) {
     ZoneScoped;

--- a/src/scene/translation.cpp
+++ b/src/scene/translation.cpp
@@ -81,9 +81,7 @@ Translation::Translation(const ghoul::Dictionary& dictionary)
     }
 }
 
-bool Translation::initialize() {
-    return true;
-}
+void Translation::initialize() {}
 
 void Translation::update(const UpdateData& data) {
     ZoneScoped;


### PR DESCRIPTION
Fixes #3681 and prevents similar issues from happening in the future by refactoring initialization code for transforms. All transforms should now have their `update` and `initialize` functions called correctly, even in timeline- and multi-transforms

The changes include: 
- Fix misnamed error message category for `GlobeTranslation`
- The attached node for the `GlobeTranslation` (and `GlobeRotation`) is now set in the initialize instead of update, and the timeline and multi-transforms correctly initialize all their member transforms. A benefit of this is that we only get the error message once if the attached node is not found
- Correctly call the `update` and `initialize` functions for renderables and transforms that have other transforms as members
- Make `initialize` function for transforms return void instead of bool
- `ScreenSpaceRenderableRenderable` not calls the intilize functions of its transforms and renderable in `initialize` instead of constructor
- Make code style for `GlobeTranslation` and `GlobeRotation` more consistent
- Some other minor code cleanup