### PR TITLE
Bring back the space stations at startup

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/earth.asset
+++ b/data/assets/scene/solarsystem/planets/earth/earth.asset
@@ -92,12 +92,48 @@ local ToggleSatelliteTrails = {
   Identifier = "os.solarsystem.ToggleSatelliteTrails",
   Name = "Toggle satellite trails",
   Command = [[
-    local list = openspace.property("{earth_satellites}.Renderable.Enabled")
+    local list = openspace.property(
+      "{earth_satellites~space_stations}.Renderable.Enabled"
+    )
     for _,v in pairs(list) do
       openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
     end
   ]],
-  Documentation = "Toggle trails on or off for satellites around Earth",
+  Documentation = [[
+    Toggle trails on or off for the satellites around Earth (excluding space stations)
+  ]],
+  GuiPath = "/Solar System/Earth",
+  IsLocal = false
+}
+
+local ToggleSpaceStations = {
+  Identifier = "os.solarsystem.ToggleSpaceStations",
+  Name = "Toggle space stations",
+  Command = [[
+    local list = openspace.property("{space_stations}.Renderable.Enabled")
+    for _,v in pairs(list) do
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
+    end
+  ]],
+  Documentation = [[
+    Toggle visiblity of the space stations around Earth (including their trail).
+  ]],
+  GuiPath = "/Solar System/Earth",
+  IsLocal = false
+}
+
+local ToggleSpaceStationTrails = {
+  Identifier = "os.solarsystem.ToggleSpaceStationTrails",
+  Name = "Toggle space station trails",
+  Command = [[
+    local list = openspace.property("{space_stations&trails}.Renderable.Enabled")
+    for _,v in pairs(list) do
+      openspace.setPropertyValueSingle(v, not openspace.propertyValue(v))
+    end
+  ]],
+  Documentation = [[
+    Toggle visiblity of the trails for the space stations around Earth.
+  ]],
   GuiPath = "/Solar System/Earth",
   IsLocal = false
 }
@@ -109,9 +145,13 @@ asset.onInitialize(function()
 
   openspace.action.registerAction(FocusEarth)
   openspace.action.registerAction(ToggleSatelliteTrails)
+  openspace.action.registerAction(ToggleSpaceStations)
+  openspace.action.registerAction(ToggleSpaceStationTrails)
 end)
 
 asset.onDeinitialize(function()
+  openspace.action.removeAction(ToggleSpaceStationTrails)
+  openspace.action.removeAction(ToggleSpaceStations)
   openspace.action.removeAction(ToggleSatelliteTrails)
   openspace.action.removeAction(FocusEarth)
 

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -49,7 +49,7 @@ local IssPosition = {
       Format = "OMM"
     }
   },
-  Tag = { "earth_satellites", "ISS" },
+  Tag = { "earth_satellites", "ISS", "space_stations" },
   GUI = {
     Name = "ISS Position",
     Path = "/Solar System/Planets/Earth/Satellites/ISS",
@@ -76,7 +76,7 @@ local IssModel = {
     },
     PerformShading = true
   },
-  Tag = { "earth_satellites", "ISS" },
+  Tag = { "earth_satellites", "ISS", "space_stations" },
   GUI = {
     Name = "ISS",
     Path = "/Solar System/Planets/Earth/Satellites/ISS"
@@ -99,7 +99,7 @@ local IssTrail = {
     Fade = 1.5,
     Resolution = 320
   },
-  Tag = { "earth_satellites", "ISS" },
+  Tag = { "earth_satellites", "ISS", "space_stations", "trails" },
   GUI = {
     Name = "ISS Trail",
     Path = "/Solar System/Planets/Earth/Satellites/ISS",
@@ -124,7 +124,7 @@ local IssLabel = {
     FadeDistances = { 0.15, 15.0 },
     FadeWidths = { 1.0, 25.0 }
   },
-  Tag = { "solarsystem_labels" },
+  Tag = { "solarsystem_labels", "earth_satellites", "ISS", "space_stations", "labels" },
   GUI = {
     Name = "ISS Label",
     Path = "/Solar System/Planets/Earth/Satellites",

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/tiangong.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/tiangong.asset
@@ -37,7 +37,7 @@ local TiangongPosition = {
       DestinationFrame = coreKernels.Frame.J2000
     }
   },
-  Tag = { "earth_satellites" },
+  Tag = { "earth_satellites", "Tiangong", "space_stations" },
   GUI = {
     Name = "Tiangong Position",
     Path = "/Solar System/Planets/Earth/Satellites/Tiangong",
@@ -66,7 +66,7 @@ local TiangongModel = {
     },
     PerformShading = true
   },
-  Tag = { "earth_satellites" },
+  Tag = { "earth_satellites", "Tiangong", "space_stations" },
   GUI = {
     Name = "Tiangong",
     Path = "/Solar System/Planets/Earth/Satellites/Tiangong"
@@ -89,7 +89,7 @@ local TiangongTrail = {
     Fade = 1.5,
     Resolution = 320
   },
-  Tag = { "earth_satellites" },
+  Tag = { "earth_satellites", "Tiangong", "space_stations", "trails" },
   GUI = {
     Name = "Tiangong Trail",
     Path = "/Solar System/Planets/Earth/Satellites/Tiangong",
@@ -114,7 +114,13 @@ local TiangongLabel = {
     FadeDistances = { 0.15, 15.0 },
     FadeWidths = { 1.0, 25.0 }
   },
-  Tag = { "solarsystem_labels" },
+  Tag = {
+    "solarsystem_labels",
+    "earth_satellites",
+    "Tiangong",
+    "space_stations",
+    "labels"
+  },
   GUI = {
     Name = "Tiangong Label",
     Path = "/Solar System/Planets/Earth/Satellites",

--- a/data/profiles/default.profile
+++ b/data/profiles/default.profile
@@ -67,7 +67,7 @@
   },
   "properties": [
     {
-      "name": "{earth_satellites}.Renderable.Enabled",
+      "name": "{earth_satellites~space_stations}.Renderable.Enabled",
       "type": "setPropertyValue",
       "value": "false"
     }

--- a/data/profiles/missions/artemis.profile
+++ b/data/profiles/missions/artemis.profile
@@ -67,7 +67,7 @@
   },
   "properties": [
     {
-      "name": "{earth_satellites}.Renderable.Enabled",
+      "name": "{earth_satellites~space_stations}.Renderable.Enabled",
       "type": "setPropertyValue",
       "value": "false"
     },

--- a/data/profiles/missions/jwst.profile
+++ b/data/profiles/missions/jwst.profile
@@ -133,7 +133,7 @@
   },
   "properties": [
     {
-      "name": "{earth_satellites}.Renderable.Enabled",
+      "name": "{earth_satellites~space_stations}.Renderable.Enabled",
       "type": "setPropertyValue",
       "value": "false"
     },

--- a/data/profiles/nightsky.profile
+++ b/data/profiles/nightsky.profile
@@ -70,7 +70,7 @@
   },
   "properties": [
     {
-      "name": "{earth_satellites}.Renderable.Enabled",
+      "name": "{earth_satellites~space_stations}.Renderable.Enabled",
       "type": "setPropertyValue",
       "value": "false"
     },

--- a/data/profiles/spaceweather/bastilleday2000.profile
+++ b/data/profiles/spaceweather/bastilleday2000.profile
@@ -117,7 +117,7 @@
   },
   "properties": [
     {
-      "name": "{earth_satellites}.Renderable.Enabled",
+      "name": "{earth_satellites~space_stations}.Renderable.Enabled",
       "type": "setPropertyValue",
       "value": "false"
     },

--- a/scripts/core_scripts.lua
+++ b/scripts/core_scripts.lua
@@ -333,8 +333,10 @@ openspace.toggleFade = function(renderable, fadeTime, endScript)
   if (fadeTime == nil) then
     fadeTime = openspace.propertyValue("OpenSpaceEngine.FadeDuration")
   end
+
   local enabled = openspace.propertyValue(renderable .. ".Enabled")
   local fadeState = openspace.propertyValue(renderable .. ".Fade")
+
   if (enabled) then
     if (fadeState < 0.5) then
       openspace.fadeIn(renderable, fadeTime-(fadeTime*fadeState), endScript)


### PR DESCRIPTION
Utilize the new feature to combine tags to not hide the space station together with the other Earth satellites at startup. 

And add actions for toggling the space stations as well. 

Do not toggle these as part of the regular satellites, for backward compatibility with 0.20.0


I'm working on improving the toggling to do fading instead of instant toggling, but that will be another PR. Ended up being a bit of a rabbit hole :) 