### PR TITLE
Some X11 cursors in GLFW are optional and result in a crash (GLFW)

### DIFF
--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -42,6 +42,7 @@
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/logging/visualstudiooutputlog.h>
+#include <ghoul/misc/defer.h>
 #include <ghoul/misc/stacktrace.h>
 #ifdef WIN32
 #define GLFW_EXPOSE_NATIVE_WIN32
@@ -1083,60 +1084,62 @@ void setSgctDelegateFunctions() {
         sgct::Engine::instance().setStatsGraphScale(scale);
     };
     sgctDelegate.setMouseCursor = [](WindowDelegate::Cursor mouse) {
-        auto glfwCreateStandardCursorChecked = [](int shape) {
-            auto prev_error_callback = glfwSetErrorCallback(NULL);
-            auto cursor = glfwCreateStandardCursor(shape);
-            glfwSetErrorCallback(prev_error_callback);
-            if (cursor == NULL) {
+        auto createGLFWCursor = [](int shape) {
+            GLFWerrorfun prevErrorCallback = glfwSetErrorCallback(nullptr);
+            defer { glfwSetErrorCallback(prevErrorCallback); };
+
+            GLFWcursor* cursor = glfwCreateStandardCursor(shape);
+            if (!cursor) {
                 LINFO(std::format(
-                    "Replacing unavailable cursor shape {} with {}",
+                    "Replacing unavailable cursor shape {} with arrow cursor ({})",
                     shape, GLFW_ARROW_CURSOR
                 ));
                 return glfwCreateStandardCursor(GLFW_ARROW_CURSOR);
-            } else {
-                return cursor;
             }
+
+            return cursor;
         };
+
         static std::unordered_map<WindowDelegate::Cursor, GLFWcursor*> Cursors = {
             {
                 WindowDelegate::Cursor::Arrow,
-                glfwCreateStandardCursorChecked(GLFW_ARROW_CURSOR)
+                createGLFWCursor(GLFW_ARROW_CURSOR)
             },
             {
                 WindowDelegate::Cursor::IBeam,
-                glfwCreateStandardCursorChecked(GLFW_IBEAM_CURSOR)
+                createGLFWCursor(GLFW_IBEAM_CURSOR)
             },
             {
                 WindowDelegate::Cursor::CrossHair,
-                glfwCreateStandardCursorChecked(GLFW_CROSSHAIR_CURSOR)
+                createGLFWCursor(GLFW_CROSSHAIR_CURSOR)
             },
             {
                 WindowDelegate::Cursor::PointingHand,
-                glfwCreateStandardCursorChecked(GLFW_POINTING_HAND_CURSOR)
+                createGLFWCursor(GLFW_POINTING_HAND_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeEW,
-                glfwCreateStandardCursorChecked(GLFW_RESIZE_EW_CURSOR)
+                createGLFWCursor(GLFW_RESIZE_EW_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeNS,
-                glfwCreateStandardCursorChecked(GLFW_RESIZE_NS_CURSOR)
+                createGLFWCursor(GLFW_RESIZE_NS_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeNWSE,
-                glfwCreateStandardCursorChecked(GLFW_RESIZE_NWSE_CURSOR)
+                createGLFWCursor(GLFW_RESIZE_NWSE_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeNESW,
-                glfwCreateStandardCursorChecked(GLFW_RESIZE_NESW_CURSOR)
+                createGLFWCursor(GLFW_RESIZE_NESW_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeAll,
-                glfwCreateStandardCursorChecked(GLFW_RESIZE_ALL_CURSOR)
+                createGLFWCursor(GLFW_RESIZE_ALL_CURSOR)
             },
             {
                 WindowDelegate::Cursor::NotAllowed,
-                glfwCreateStandardCursorChecked(GLFW_NOT_ALLOWED_CURSOR)
+                createGLFWCursor(GLFW_NOT_ALLOWED_CURSOR)
             },
         };
         ghoul_assert(

--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -1083,46 +1083,60 @@ void setSgctDelegateFunctions() {
         sgct::Engine::instance().setStatsGraphScale(scale);
     };
     sgctDelegate.setMouseCursor = [](WindowDelegate::Cursor mouse) {
+        auto glfwCreateStandardCursorChecked = [](int shape) {
+            auto prev_error_callback = glfwSetErrorCallback(NULL);
+            auto cursor = glfwCreateStandardCursor(shape);
+            glfwSetErrorCallback(prev_error_callback);
+            if (cursor == NULL) {
+                LINFO(std::format(
+                    "Replacing unavailable cursor shape {} with {}",
+                    shape, GLFW_ARROW_CURSOR
+                ));
+                return glfwCreateStandardCursor(GLFW_ARROW_CURSOR);
+            } else {
+                return cursor;
+            }
+        };
         static std::unordered_map<WindowDelegate::Cursor, GLFWcursor*> Cursors = {
             {
                 WindowDelegate::Cursor::Arrow,
-                glfwCreateStandardCursor(GLFW_ARROW_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_ARROW_CURSOR)
             },
             {
                 WindowDelegate::Cursor::IBeam,
-                glfwCreateStandardCursor(GLFW_IBEAM_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_IBEAM_CURSOR)
             },
             {
                 WindowDelegate::Cursor::CrossHair,
-                glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_CROSSHAIR_CURSOR)
             },
             {
                 WindowDelegate::Cursor::PointingHand,
-                glfwCreateStandardCursor(GLFW_POINTING_HAND_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_POINTING_HAND_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeEW,
-                glfwCreateStandardCursor(GLFW_RESIZE_EW_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_RESIZE_EW_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeNS,
-                glfwCreateStandardCursor(GLFW_RESIZE_NS_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_RESIZE_NS_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeNWSE,
-                glfwCreateStandardCursor(GLFW_RESIZE_NWSE_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_RESIZE_NWSE_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeNESW,
-                glfwCreateStandardCursor(GLFW_RESIZE_NESW_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_RESIZE_NESW_CURSOR)
             },
             {
                 WindowDelegate::Cursor::ResizeAll,
-                glfwCreateStandardCursor(GLFW_RESIZE_ALL_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_RESIZE_ALL_CURSOR)
             },
             {
                 WindowDelegate::Cursor::NotAllowed,
-                glfwCreateStandardCursor(GLFW_NOT_ALLOWED_CURSOR)
+                glfwCreateStandardCursorChecked(GLFW_NOT_ALLOWED_CURSOR)
             },
         };
         ghoul_assert(


### PR DESCRIPTION
Some of the mouse cursors referenced in main.cpp ( sgctDelegate.setMouseCursor ) are optional and might not be available. This produces error message "X11: Standard cursor shape unavailable" and subsequently crashes the application. 
See [https://github.com/glfw/glfw/blob/aa5e31356178de43d42f43f48914a62c25033f4b/docs/compat.dox#L88](https://github.com/glfw/glfw/blob/aa5e31356178de43d42f43f48914a62c25033f4b/docs/compat.dox#L88)

Output:

```bash
(D) PathNavigator        The scene graph node 'Root' has no, or a very small, bounding sphere. Using minimal value of 10. This might lead to unexpected results
(D) PathNavigator        The scene graph node 'Root' has no, or a very small, bounding sphere. Using minimal value of 10. This might lead to unexpected results
(D) PathNavigator        Successfully generated camera path
(D) OpenSpaceEngine      Mode: CameraPath
(I) PathNavigator        Pausing time simulation during path traversal
(I) PathNavigator        Starting path
terminate called after throwing an instance of 'sgct::Error'
  what():  [Engine] (3010): GLFW error (65547): X11: Standard cursor shape unavailable
```

The crash can be traced back to **glfwCreateStandardCursor**:

```bash
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fffe6e4527e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fffe6e288ff in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007fffe72a5ff5 in ??? () at /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007fffe72bb0da in ??? () at /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007fffe72a5a55 in std::terminate() () at /lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007fffe72bb391 in __cxa_throw () at /lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x000055555584a818 in operator() (__closure=0x0, desc=0x7fffffffb880 "X11: Standard cursor shape unavailable", error=<optimized out>) at /usr/include/c++/13/bits/allocator.h:184
#10 _FUN () at /home/attila/Sviluppo/OpenSpace/apps/OpenSpace/ext/sgct/src/engine.cpp:282
#11 0x00005555578eee73 in _glfwInputError ()
#12 0x0000555557901a23 in _glfwCreateStandardCursorX11 ()
#13 0x00005555578f1133 in glfwCreateStandardCursor ()
#14 0x0000555555bd2d6c in operator() (mouse=openspace::WindowDelegate::Cursor::Arrow, __closure=0x0) at /home/attila/Sviluppo/OpenSpace/apps/OpenSpace/main.cpp:1113
#15 0x0000555556bc0e5a in openspace::BrowserClient::DisplayHandler::OnCursorChange (this=<optimized out>, type=<optimized out>) at /home/attila/Sviluppo/OpenSpace/modules/webbrowser/src/browserclient.cpp:172
#16 0x0000555556e8f36c in (anonymous namespace)::display_handler_on_cursor_change (custom_cursor_info=<optimized out>, type=CT_POINTER, cursor=0, browser=<optimized out>, self=<optimized out>)
    at /home/attila/Sviluppo/OpenSpace/build/modules/webbrowser/ext/cef/cef_binary_127.3.5+g114ea2a+chromium-127.0.6533.120_linux64/libcef_dll/cpptoc/display_handler_cpptoc.cc:307
#17 (anonymous namespace)::display_handler_on_cursor_change (self=<optimized out>, browser=<optimized out>, cursor=0, type=CT_POINTER, custom_cursor_info=<optimized out>)
    at /home/attila/Sviluppo/OpenSpace/build/modules/webbrowser/ext/cef/cef_binary_127.3.5+g114ea2a+chromium-127.0.6533.120_linux64/libcef_dll/cpptoc/display_handler_cpptoc.cc:278
```

The added patch checks if the cursor is available, otherwise it defaults to GLFW_ARROW_CURSOR 

Tested on Linux Mint 22.1 Cinnamon (compiled from source 38b4aeaebc81f5fdafbf53b31453831ad7ec2596 )
 