### PR TITLE
Change frontend endpoint to gui

### DIFF
--- a/data/assets/util/webgui.asset
+++ b/data/assets/util/webgui.asset
@@ -50,7 +50,7 @@ asset.onInitialize(function()
   openspace.setPropertyValueSingle("Modules.WebGui.ServerProcessEnabled", false)
 
   local directories = openspace.propertyValue("Modules.WebGui.Directories")
-  directories[#directories + 1] = "frontend"
+  directories[#directories + 1] = "gui"
   directories[#directories + 1] = frontend .. "frontend"
   -- Add user directory for webpanels
   directories[#directories + 1] = "webpanels"
@@ -67,7 +67,7 @@ asset.onInitialize(function()
   directories[#directories + 1] = openspace.absPath("${USER_SHOWCOMPOSER_PROJECTS}")
 
   openspace.setPropertyValueSingle("Modules.WebGui.Directories", directories)
-  openspace.setPropertyValueSingle("Modules.WebGui.DefaultEndpoint", "frontend")
+  openspace.setPropertyValueSingle("Modules.WebGui.DefaultEndpoint", "gui")
   openspace.setPropertyValueSingle("Modules.WebGui.ServerProcessEnabled", enabled)
 
   -- The GUI contains date and simulation increment,
@@ -90,7 +90,7 @@ asset.onInitialize(function()
   end
   openspace.setPropertyValueSingle(
     "Modules.CefWebGui.GuiUrl",
-    "http://127.0.0.1:" .. port .. "/frontend/"
+    "http://127.0.0.1:" .. port .. "/gui"
   )
 end)
 

--- a/modules/cefwebgui/cefwebguimodule.cpp
+++ b/modules/cefwebgui/cefwebguimodule.cpp
@@ -212,7 +212,7 @@ void CefWebGuiModule::internalInitialize(const ghoul::Dictionary& configuration)
     _endpointCallback = webGuiModule->addEndpointChangeCallback(
         [this](const std::string& endpoint, bool exists) {
             ZoneScopedN("CefWebGuiModule::endpointCallback");
-            if (exists && endpoint == "frontend" && _instance) {
+            if (exists && endpoint == "gui" && _instance) {
                 _instance->reloadBrowser();
             }
         }


### PR DESCRIPTION
To be used with https://github.com/OpenSpace/OpenSpace-WebGuiBackend/pull/23 and https://github.com/OpenSpace/OpenSpace-WebGui/pull/171.

Detailed descriptions are in https://github.com/OpenSpace/OpenSpace-WebGuiBackend/pull/23

Changed the endpoint of the gui to "gui" from "endpoint".

The motivation for this is mainly to separate the endpoint from the folder name, which currently can get a bit confusing.