### PR TITLE
Show full trail for renderableTrailOrbit

### DIFF
--- a/data/assets/scene/solarsystem/telescopes/gaia/trail.asset
+++ b/data/assets/scene/solarsystem/telescopes/gaia/trail.asset
@@ -30,8 +30,10 @@ local GaiaTrail = {
     },
     Color = { 0.0, 0.8, 0.7 },
     PointSize = 5,
+    StartTime = "2013 Dec 19 09:55:27",
+    EndTime = "2026 Sep 14 00:00:00",
     Period = 365, -- 1 year orbit time
-    Resolution = 24244 -- Sameple rate of 40 minutes
+    Resolution = 13140 -- Sameple rate of 40 minutes
   },
   GUI = {
     Name = "Gaia Trail",
@@ -57,6 +59,8 @@ local GaiaTrailEclip = {
     },
     Color = { 1.0, 0.0, 0.0 },
     PointSize = 5,
+    StartTime = "2013 Dec 20 00:00:00",
+    EndTime = "2026 Sep 14 00:00:00",
     Period = 365, -- 1 year orbit time
     Resolution = 365 -- Sameple rate of 1 day
   },

--- a/modules/base/rendering/renderabletrailorbit.cpp
+++ b/modules/base/rendering/renderabletrailorbit.cpp
@@ -101,16 +101,14 @@ namespace {
     constexpr openspace::properties::Property::PropertyInfo StartTimeInfo = {
         "StartTime",
         "Start Time",
-        "The start time for the range of this trajectory. The date must be in ISO 8601 "
-        "format: YYYY MM DD HH:mm:ss.xxx.",
+        "The start time for the range of this trajectory. The date must be in ISO 8601.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 
     constexpr openspace::properties::Property::PropertyInfo EndTimeInfo = {
         "EndTime",
         "End Time",
-        "The end time for the range of this trajectory. The date must be in ISO 8601 "
-        "format: YYYY MM DD HH:mm:ss.xxx.",
+        "The end time for the range of this trajectory. The date must be in ISO 8601.",
         openspace::properties::Property::Visibility::AdvancedUser
     };
 

--- a/modules/base/rendering/renderabletrailorbit.h
+++ b/modules/base/rendering/renderabletrailorbit.h
@@ -56,6 +56,12 @@ public:
     static documentation::Documentation Documentation();
 
 private:
+    enum Phase {
+        Beginning = 0,
+        Normal,
+        End
+    };
+
     /**
      * Performs a full sweep of the orbit and fills the entire vertex buffer object.
      *
@@ -92,6 +98,21 @@ private:
      */
     UpdateReport updateTrails(const UpdateData& data);
 
+    /**
+    * Determines which type of render phase the trail is in. Result depends is
+    * calculated based on ingame time, start time and end time.
+    *
+    * \param time The current ingame time in j2000 epoch.
+    * \return Integer 0 to 2 representing phase (Enum: Beginning, Normal, End)
+    */
+    Phase trailPhase(double time);
+
+    /// Determines if trail length should be forced to be one orbital period in length
+    properties::BoolProperty _forceFullOrbitTrail;
+    /// The start time of the trail
+    properties::StringProperty _startTime;
+    /// The end time of the trail
+    properties::StringProperty _endTime;
     /// The orbital period of the RenderableTrail in days
     properties::DoubleProperty _period;
     /// The number of points that should be sampled between _period and now
@@ -103,6 +124,9 @@ private:
     /// A dirty flag to determine whether the index buffer needs to be regenerated and
     /// then reuploaded
     bool _indexBufferDirty = true;
+    /// Flag to help determine if we should apply full sweep or not when
+    /// _forceFullOrbitTrail is enabled
+    bool _forceFlag;
 
     /// The time stamp of the oldest point in the array
     double _firstPointTime = 0.0;


### PR DESCRIPTION
## Information
Adds toggle `Force Full Orbit Trail`, `Start Time` and `End Time` for renderableTrailOrbit. When start and end times are provided, the new toggle can be used to force a trail of one period of length. When enabled, the behavior is as follows:
- Before `start`: Trail is between start and one period forward in time
- Between `start` and `start + period`: Trail is between start and one period forward in time
- Between `start + period` and `end`: Trail is between ingame time and one period backwards in time
- After `end`: Trail is between end and one period backwards in time
If `Start Time` or `End Time` is not provided, the toggle does nothing

## Changes
- **[New]** - Added new toggle `Force Full Orbit Trail` which enables new feature
- **[New]** - Added new optional `StartTime` and `EndTime` for asset type `renderableTrailOrbit`
- **[Breaking]** - Corrected Gaia trail number of samples from 24244 to 13140 as comment indicated sample interval of 40 minutes but previous number of samples did not reflect that

Closes #1791 