### PR TITLE
Issue/1188 improve console

### DIFF
--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -67,6 +67,15 @@ private:
     void registerKeyHandlers();
     void registerKeyHandler(Key key, KeyModifier modifier, std::function<void()> callback);
 
+    // Helper functions for tab autocomplete
+    void autoCompleteCommand();
+    void resetAutoCompleteState();
+    size_t detectContext(std::string_view command);
+    bool gatherPathSuggestions(size_t contextStart);
+    void gatherFunctionSuggestions(size_t contextStart);
+    void filterSuggestions();
+    void cycleSuggestion();
+
     properties::BoolProperty _isVisible;
     properties::BoolProperty _shouldBeSynchronized;
     properties::BoolProperty _shouldSendToRemote;
@@ -85,19 +94,6 @@ private:
     // Map of registered keybinds and their corresponding callbacks
     std::map<KeyWithModifier, std::function<void()>> _keyHandlers;
 
-    struct {
-        int lastIndex;
-        bool hasInitialValue;
-        std::string initialValue;
-    } _autoCompleteInfo;
-
-    struct {
-        int index;
-        std::string suggestion;
-        bool isReverse;
-    } _suggestionInfo;
-
-
     enum class Context {
         None = 0,
         Function,
@@ -107,11 +103,11 @@ private:
     struct {
         Context context;
         bool isDataDirty;
-        std::string baseInput; // What the user typed
-        std::string typedFragment; // The partial word being completed (if any)
+        std::string input; // Part of the command that we're intrested in
         std::vector<std::string> suggestions;
         int currentIndex;
         std::string suggestion;
+        bool cycleReverse = false;
 
     } _autoCompleteState;
 

--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -34,6 +34,7 @@
 #include <openspace/util/keys.h>
 #include <ghoul/opengl/ghoul_gl.h>
 #include <ghoul/opengl/uniformcache.h>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -63,6 +64,8 @@ public:
 private:
     void parallelConnectionChanged(const ParallelConnection::Status& status);
     void addToCommand(const std::string& c);
+    void registerKeyHandlers();
+    void registerKeyHandler(Key key, KeyModifier modifier, std::function<void()> callback);
 
     properties::BoolProperty _isVisible;
     properties::BoolProperty _shouldBeSynchronized;
@@ -79,6 +82,8 @@ private:
     std::vector<std::string> _commandsHistory;
     size_t _activeCommand = 0;
     std::vector<std::string> _commands;
+    // Map of registered keybinds and their corresponding callbacks
+    std::map<KeyWithModifier, std::function<void()>> _keyHandlers;
 
     struct {
         int lastIndex;

--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -98,6 +98,24 @@ private:
     } _suggestionInfo;
 
 
+    enum class Context {
+        None = 0,
+        Function,
+        Path
+    };
+
+    struct {
+        Context context;
+        bool isDataDirty;
+        std::string baseInput; // What the user typed
+        std::string typedFragment; // The partial word being completed (if any)
+        std::vector<std::string> suggestions;
+        int currentIndex;
+        std::string suggestion;
+
+    } _autoCompleteState;
+
+
     float _currentHeight = 0.f;
     float _targetHeight = 0.f;
     float _fullHeight = 0.f;

--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -75,6 +75,7 @@ private:
     void gatherFunctionSuggestions(size_t contextStart);
     void filterSuggestions();
     void cycleSuggestion();
+    void applySuggestion();
 
     properties::BoolProperty _isVisible;
     properties::BoolProperty _shouldBeSynchronized;
@@ -101,13 +102,14 @@ private:
     };
 
     struct {
-        Context context;
-        bool isDataDirty;
-        std::string input; // Part of the command that we're intrested in
-        std::vector<std::string> suggestions;
-        int currentIndex;
-        std::string suggestion;
+        Context context = Context::None;
+        bool isDataDirty = true;
+        std::string input = ""; // Part of the command that we're intrested in
+        std::vector<std::string> suggestions = {};
+        int currentIndex = -1;
+        std::string suggestion = "";
         bool cycleReverse = false;
+        size_t insertPosition = 0;
 
     } _autoCompleteState;
 

--- a/include/openspace/rendering/luaconsole.h
+++ b/include/openspace/rendering/luaconsole.h
@@ -91,6 +91,13 @@ private:
         std::string initialValue;
     } _autoCompleteInfo;
 
+    struct {
+        int index;
+        std::string suggestion;
+        bool isReverse;
+    } _suggestionInfo;
+
+
     float _currentHeight = 0.f;
     float _targetHeight = 0.f;
     float _fullHeight = 0.f;

--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -45,8 +45,9 @@
 
 namespace {
     constexpr std::string_view HistoryFile = "ConsoleHistory";
-    constexpr std::string_view JumpCharacters = ".,'/()";
-    constexpr std::string_view PathIdentifier = "\"'[";
+    constexpr std::string_view JumpCharacters = ".,'/()\\";
+    constexpr std::string_view PathStartIdentifier = "\"'[";
+    constexpr std::string_view PathEndIdentifier = "\"']";
 
     constexpr int NoAutoComplete = -1;
 
@@ -966,7 +967,7 @@ size_t LuaConsole::detectContext(std::string_view command) {
     // Find the path starting point which can start with either " ' or [ character
     size_t pathStartIndex = 0;
     for (size_t i = _inputPosition; i > 0; --i) {
-        if (PathIdentifier.find(command[i - 1]) != std::string::npos) {
+        if (PathStartIdentifier.find(command[i - 1]) != std::string::npos) {
             pathStartIndex = i;
             break;
         }
@@ -996,7 +997,7 @@ bool LuaConsole::gatherPathSuggestions(size_t contextStart) {
     const std::string possiblePath = currentCommand.substr(contextStart);
     // Find the last ' " ] if any exists, which marks the end of the path string.
     // Otherwise the rest of the string is assumed to be part of the path
-    const size_t pathEnd = possiblePath.find_last_of("\"']");
+    const size_t pathEnd = possiblePath.find_last_of(PathEndIdentifier);
     const std::string userTypedPath = currentCommand.substr(contextStart, pathEnd);
 
     const std::filesystem::path path = std::filesystem::path(userTypedPath);
@@ -1142,7 +1143,9 @@ void LuaConsole::cycleSuggestion() {
             (_autoCompleteState.currentIndex + dir + size) % size;
     }
 
-    const std::string& suggestion = _autoCompleteState.suggestions[_autoCompleteState.currentIndex];
+    const std::string& suggestion =
+        _autoCompleteState.suggestions[_autoCompleteState.currentIndex];
+    // Show only the characters not yet written 
     _autoCompleteState.suggestion = suggestion.substr(_autoCompleteState.input.size());
 }
 

--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -1116,7 +1116,7 @@ void LuaConsole::filterSuggestions() {
 
     for (const std::string& suggestion : _autoCompleteState.suggestions) {
         std::string candidate = normalize(suggestion);
-        std::string result = suggestion;
+        std::string result = sanitizeInput(suggestion);
 
         if (_autoCompleteState.context == Context::Function) {
             // We're only interested in autocomplete until the next separator "."

--- a/src/rendering/luaconsole.cpp
+++ b/src/rendering/luaconsole.cpp
@@ -1028,8 +1028,23 @@ bool LuaConsole::gatherPathSuggestions(size_t contextStart) {
             ghoul::filesystem::Sorted::Yes
         );
 
+    auto containsNonAscii = [](const std::filesystem::path& p) {
+        auto s = p.generic_u8string();
+        for (auto it = s.rbegin(); it != s.rend(); it++) {
+            if (static_cast<unsigned char>(*it) > 0x7F) {
+                return true;
+            }
+        }
+        return false;
+    };
+
     std::vector<std::string> entries;
     for (const auto& entry : suggestions) {
+        // Filter paths that contain non-ASCII characters
+        if (containsNonAscii(entry)) {
+            continue;
+        }
+        
         entries.push_back(entry.string());
     }
 


### PR DESCRIPTION
This PR includes some improvements to the console. It now supports nested tab completion for functions and also tab completion for paths. Also changed it so that we will have line breaks instead of horizontal scrolling if there are too many characters to fit on one line. Furthermore, added some new shortcuts: 

Shift + Left/Right arrow key moves to the nearest special character
Shift + Backspace removes whole words until the previous special character
Shift + Delete removes whole words until the next special character 
Enter applies the suggested path or function if any exists
Shift + Tab and Tab now correctly cycle between suggestions 

Tab completion for tabs will cycle through all the folders and files in a given path, or if a partial path is given, it will filter based on what you've written so far.

Path completion: 
`openspace.asset.remove("C:/Users/anden88/Desktop/projects/ab <tab>` -- list all folder & files starting with `ab`
`openspace.asset.remove("C:/Users/anden88/Desktop/projects <tab>` -- list all folders & files in `/../projects`
`openspace.asset.remove("C:/Users/anden88/Desktop/projects/ <tab>` -- same as above, no need to end with the `/`

It can also autocomplete within functions and strings, but it requires the last `" ] or '` character to match correctly. For example 
`openspace.printInfo(openspace.walkDirectory('C:/Users/anden88/Desktop/projects/<tab>'))` works but requires the `'` before the last closing paranthesis. 

Function completion: 
`openspace.a <tab>` -- existing behavior, list all functions starting with `a`
`openspace.printInfo(openspace.statemachine <tab>` -- list all functions that is part of the `statemachine` library

caveat: for nested function tab completion to work, it must at least contain `openspace.` The following will unfortunately not autocomplete `openspace.printInfo(ope <tab>`

I tried to squash any new bugs introduced and fix any unexpected behaviour. I'm sure I've missed something, so please try it out. Also, let me know if there are any other shortcut combinations that you feel are missing. 

Here is what it looks like 
https://github.com/user-attachments/assets/22d2e851-9b5a-490f-b6e4-2a4b20e242f7

