### PR TITLE
Add rendering for mouse interaction

### DIFF
--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -99,6 +99,8 @@ public:
     void mousePositionCallback(double x, double y);
     void mouseScrollWheelCallback(double pos);
 
+    void renderOverlay() const;
+
     std::vector<std::string> listAllJoysticks() const;
     void setJoystickAxisMapping(std::string joystickName,
         int axis, JoystickCameraStates::AxisType mapping,
@@ -208,6 +210,14 @@ private:
     properties::BoolProperty _disableJoystickInputs;
     properties::BoolProperty _useKeyFrameInteraction;
     properties::FloatProperty _jumpToFadeDuration;
+
+    struct {
+        properties::BoolProperty enable;
+        bool isMouseFirstPress = false;
+        bool isMousePressed = false;
+        glm::vec2 clickPosition;
+        glm::vec2 currentPosition;
+    } _mouseVisualizer;
 };
 
 } // namespace openspace::interaction

--- a/include/openspace/navigation/navigationhandler.h
+++ b/include/openspace/navigation/navigationhandler.h
@@ -37,6 +37,7 @@
 #include <openspace/navigation/pathnavigator.h>
 #include <openspace/properties/scalar/boolproperty.h>
 #include <openspace/properties/scalar/floatproperty.h>
+#include <openspace/properties/vector/vec4property.h>
 #include <openspace/util/mouse.h>
 #include <openspace/util/keys.h>
 
@@ -212,7 +213,10 @@ private:
     properties::FloatProperty _jumpToFadeDuration;
 
     struct {
+        properties::PropertyOwner owner;
         properties::BoolProperty enable;
+        properties::Vec4Property color;
+
         bool isMouseFirstPress = false;
         bool isMousePressed = false;
         glm::vec2 clickPosition;

--- a/include/openspace/rendering/helper.h
+++ b/include/openspace/rendering/helper.h
@@ -63,6 +63,9 @@ void renderBox(const glm::vec2& position, const glm::vec2& size, const glm::vec4
 void renderBox(const glm::vec2& position, const glm::vec2& size, const glm::vec4& color,
     const ghoul::opengl::Texture& texture, Anchor anchor = Anchor::NW);
 
+void renderLine(const glm::vec2& startPosition, const glm::vec2& endPosition,
+    const glm::vec2& size, const glm::vec4& startColor, const glm::vec4& endColor);
+
 struct Shaders {
     struct {
         std::unique_ptr<ghoul::opengl::ProgramObject> program;
@@ -104,6 +107,11 @@ struct VertexObjects {
 
         int nElements = 64;
     } cone;
+
+    struct {
+        GLuint vao = 0;
+        GLuint vbo = 0;
+    } line;
 
     struct {
         GLuint vao = 0;

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -1299,6 +1299,7 @@ void OpenSpaceEngine::drawOverlays() {
     if (isGuiWindow) {
         global::renderEngine->renderOverlays(_shutdown);
         global::sessionRecordingHandler->render();
+        global::navigationHandler->renderOverlay();
     }
 
     for (const std::function<void()>& func : *global::callback::draw2D) {

--- a/src/rendering/helper.cpp
+++ b/src/rendering/helper.cpp
@@ -596,6 +596,7 @@ void renderLine(const glm::vec2& startPosition, const glm::vec2& endPosition,
         GL_STATIC_DRAW
     );
 
+    glEnable(GL_LINE_SMOOTH);
     glLineWidth(6.f);
     glDrawArrays(GL_LINES, 0, 2);
     glPointSize(6.f);


### PR DESCRIPTION
Adds a new BoolProperty to the NavigationHandler that, if enabled, shows the interaction of the mouse while pressing any button.


<img width="2562" height="1479" alt="image" src="https://github.com/user-attachments/assets/0e74da22-dae3-4a53-a97a-a4caaddd5129" />
(in the image, the OS mouse cursor is at the end of the white line, but is not captured in the screenshot)


Closes #1399