### PR TITLE
Fixed incorrect rendering of planet-onto-ring shadows in fisheye projection mode

### DIFF
--- a/data/assets/scene/solarsystem/planets/saturn/saturn.asset
+++ b/data/assets/scene/solarsystem/planets/saturn/saturn.asset
@@ -62,7 +62,7 @@ local Saturn = {
       }
     },
     Shadows = {
-      Enabled = true,
+      Enabled = false,
       DistanceFraction = 40.0
     }
   },

--- a/modules/globebrowsing/shaders/advanced_rings_fs.glsl
+++ b/modules/globebrowsing/shaders/advanced_rings_fs.glsl
@@ -24,6 +24,7 @@
 
 #include "PowerScaling/powerScaling_fs.hglsl"
 #include "fragment.glsl"
+#include "ellipsoid.glsl"
 
 #define NSSamplesMinusOne #{nShadowSamples}
 #define NSSamples (NSSamplesMinusOne + 1)
@@ -32,8 +33,9 @@ in vec2 vs_st;
 in float vs_screenSpaceDepth;
 in vec4 shadowCoords;
 in vec3 vs_normal;
+// Fragment position in object space
+in vec3 posObj;
 
-uniform sampler2DShadow shadowMapTexture;
 uniform sampler1D textureForwards;
 uniform sampler1D textureBackwards;
 uniform sampler1D textureUnlit;
@@ -47,6 +49,7 @@ uniform vec3 camPositionObj;
 uniform float nightFactor;
 uniform float zFightingPercentage;
 uniform float opacity;
+uniform vec3 ellipsoidRadii;
 
 
 Fragment getFragment() {
@@ -86,28 +89,12 @@ Fragment getFragment() {
     discard;
   }
 
-  // shadow == 1.0 means it is not in shadow
-  float shadow = 1.0;
-  if (shadowCoords.z >= 0) {
-    vec4 normalizedShadowCoords = shadowCoords;
-    normalizedShadowCoords.z = normalizeFloat(zFightingPercentage * normalizedShadowCoords.w);
-    normalizedShadowCoords.xy = normalizedShadowCoords.xy / normalizedShadowCoords.w;
-    normalizedShadowCoords.w = 1.0;
+  // Check if ray from fragment to sun intersects the ellipsoid (globe)
+  // This creates more accurate shadowing for rings
+  bool intersectsGlobe = rayIntersectsEllipsoid(posObj, sunPositionObj, vec3(0.0), ellipsoidRadii);
 
-    float sum = 0;
-    #for i in 0..#{nShadowSamples}
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(-NSSamples + #{i}, -NSSamples + #{i}));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(-NSSamples + #{i},  0));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(-NSSamples + #{i},  NSSamples - #{i}));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(                0, -NSSamples + #{i}));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(                0,  NSSamples - #{i}));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2( NSSamples - #{i}, -NSSamples + #{i}));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2( NSSamples - #{i},  0));
-      sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(NSSamples - #{i},  NSSamples - #{i}));
-    #endfor
-    sum += textureProjOffset(shadowMapTexture, normalizedShadowCoords, ivec2(0, 0));
-    shadow = clamp(sum / (8.0 * NSSamples + 1.f), 0.05, 1.0);
-  }
+  // shadow == 1.0 means it is not in shadow
+  float shadow = intersectsGlobe ? 0.05 : 1.0;
 
   // The normal for the one plane depends on whether we are dealing
   // with a front facing or back facing fragment

--- a/modules/globebrowsing/shaders/advanced_rings_vs.glsl
+++ b/modules/globebrowsing/shaders/advanced_rings_vs.glsl
@@ -34,6 +34,7 @@ out vec2 vs_st;
 out float vs_screenSpaceDepth;
 out vec4 shadowCoords;
 out vec3 vs_normal;
+out vec3 posObj;
 
 uniform dmat4 modelViewProjectionMatrix;
 
@@ -46,6 +47,7 @@ uniform dmat4 shadowMatrix;
 void main() {
   vs_st = in_st;
   vs_normal = mat3(modelViewProjectionMatrix) * in_normal;
+  posObj = vec3(in_position, 0.0);
 
   dvec4 positionClipSpace  = modelViewProjectionMatrix * dvec4(in_position, 0.0, 1.0);
   vec4 positionClipSpaceZNorm = z_normalization(vec4(positionClipSpace));

--- a/modules/globebrowsing/shaders/ellipsoid.glsl
+++ b/modules/globebrowsing/shaders/ellipsoid.glsl
@@ -1,0 +1,35 @@
+bool rayIntersectsEllipsoid(vec3 rayOrigin, vec3 rayDir, vec3 ellipsoidCenter, vec3 ellipsoidRadii) {
+    // Translate ray to ellipsoid's local coordinate system
+    vec3 oc = rayOrigin - ellipsoidCenter;
+    
+    // Normalize by ellipsoid radii to convert to unit sphere problem
+    vec3 ocNorm = oc / ellipsoidRadii;
+    vec3 dirNorm = rayDir / ellipsoidRadii;
+    
+    // Quadratic equation coefficients: At² + Bt + C = 0
+    float a = dot(dirNorm, dirNorm);
+    float b = dot(ocNorm, dirNorm); // Note: factor of 2 moved to discriminant calc
+    float c = dot(ocNorm, ocNorm) - 1.0;
+    
+    // Calculate discriminant (optimized: b² - ac since we factored out the 2)
+    float discriminant = b * b - a * c;
+    
+    // Early exit if no intersection
+    if (discriminant < 0.0) {
+        return false;
+    }
+    
+    // Check if at least one intersection is in front of ray origin
+    // For quadratic At² + 2Bt + C = 0, if we want to check if any t >= 0:
+    // If C <= 0, ray origin is inside ellipsoid, so definitely intersects
+    if (c <= 0.0) {
+        return true;
+    }
+    
+    // If both intersections exist and C > 0, check if the smaller root t1 >= 0
+    // t1 = (-b - sqrt(discriminant)) / a
+    // Since we need t1 >= 0: -b - sqrt(discriminant) >= 0
+    // This means: -b >= sqrt(discriminant), so b <= -sqrt(discriminant)
+    // Since sqrt(discriminant) >= 0, this means b <= 0
+    return b <= 0.0;
+}

--- a/modules/globebrowsing/shaders/rings_vs.glsl
+++ b/modules/globebrowsing/shaders/rings_vs.glsl
@@ -34,6 +34,7 @@ out vec2 vs_st;
 out float vs_screenSpaceDepth;
 out vec4 shadowCoords;
 out vec3 vs_normal;
+out vec3 posObj;
 
 uniform dmat4 modelViewProjectionMatrix;
 
@@ -46,6 +47,7 @@ uniform dmat4 shadowMatrix;
 void main() {
   vs_st = in_st;
   vs_normal = mat3(modelViewProjectionMatrix) * in_normal;
+  posObj = vec3(in_position, 0.0);
 
   dvec4 positionClipSpace  = modelViewProjectionMatrix * dvec4(in_position, 0.0, 1.0);
   vec4 positionClipSpaceZNorm = z_normalization(vec4(positionClipSpace));

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -889,6 +889,7 @@ void RenderableGlobe::render(const RenderData& data, RendererTasks&) {
                 if (_ringsComponent && _ringsComponent->isEnabled() &&
                     _ringsComponent->isVisible())
                 {
+                    _ringsComponent->setEllipsoidRadii(glm::vec3(_ellipsoid.radii()));
                     _ringsComponent->draw(data, _shadowComponent->shadowMapData());
                 }
             }
@@ -897,6 +898,7 @@ void RenderableGlobe::render(const RenderData& data, RendererTasks&) {
                 if (_ringsComponent && _ringsComponent->isEnabled() &&
                     _ringsComponent->isVisible())
                 {
+                    _ringsComponent->setEllipsoidRadii(glm::vec3(_ellipsoid.radii()));
                     _ringsComponent->draw(data);
                 }
             }

--- a/modules/globebrowsing/src/ringscomponent.h
+++ b/modules/globebrowsing/src/ringscomponent.h
@@ -84,6 +84,8 @@ public:
     glm::vec3 sunPositionObj() const;
     glm::vec3 camPositionObj() const;
 
+    void setEllipsoidRadii(const glm::vec3& radii);
+
 private:
     void loadTexture();
     void createPlane();
@@ -107,13 +109,13 @@ private:
     std::unique_ptr<ghoul::opengl::ProgramObject> _shader;
     std::unique_ptr<ghoul::opengl::ProgramObject> _geometryOnlyShader;
     UniformCache(modelViewProjectionMatrix, textureOffset, colorFilterValue, nightFactor,
-        sunPosition, ringTexture, shadowMatrix, shadowMapTexture, zFightingPercentage,
-        opacity
+        sunPosition, sunPositionObj, ringTexture, shadowMatrix, zFightingPercentage,
+        opacity, ellipsoidRadii
     ) _uniformCache;
     UniformCache(modelViewProjectionMatrix, textureOffset, colorFilterValue, nightFactor,
         sunPosition, sunPositionObj, camPositionObj, textureForwards, textureBackwards,
         textureUnlit, textureColor, textureTransparency, shadowMatrix,
-        shadowMapTexture, zFightingPercentage, opacity
+        zFightingPercentage, opacity, ellipsoidRadii
     ) _uniformCacheAdvancedRings;
     UniformCache(modelViewProjectionMatrix, textureOffset, ringTexture) _geomUniformCache;
 
@@ -139,6 +141,7 @@ private:
 
     glm::vec3 _sunPosition = glm::vec3(0.f);
     glm::vec3 _camPositionObjectSpace = glm::vec3(0.f);
+    glm::vec3 _ellipsoidRadii = glm::vec3(1.f);
 
     // Callback for readiness state changes
     ReadinessChangeCallback _readinessChangeCallback;


### PR DESCRIPTION
The shadows cast by Saturn onto its rings in fisheye projection mode are rendered incorrectly because the depth map used for shadow rendering is rendered during the normal render pass, so it is rendered 5 times and in different directions. This causes parts of the shadow to be missing. (See #3776 for more details)

<img width="1098" height="925" alt="Screenshot 2025-08-25 120237" src="https://github.com/user-attachments/assets/0aa93cfa-dac1-4a7f-b4e9-891e678a385e" />

I've simply replaced shadow-mapping with a ray/ellipsoid intersection test. However, there are other use cases for shadow-mapping, like in [project/moon-shot](https://github.com/OpenSpace/OpenSpace/tree/project/moon-shot), so I've left most of the shadow-map rendering logic intact so that the project can be eventually updated and merged.

fixes #3776