### PR TITLE
Remove offset for max chunk level

### DIFF
--- a/modules/globebrowsing/src/rawtiledatareader.cpp
+++ b/modules/globebrowsing/src/rawtiledatareader.cpp
@@ -118,27 +118,6 @@ GDALDataType toGDALDataType(GLenum glType) {
     }
 }
 
-/**
- * Use as a helper function when determining the maximum tile level. This function
- * returns the negated number of overviews requred to downscale the highest overview
- * dataset so that it fits within minimumPixelSize pixels in the x-dimension.
- */
-int calculateTileLevelDifference(GDALDataset* dataset, int minimumPixelSize) {
-    GDALRasterBand* firstBand = dataset->GetRasterBand(1);
-    GDALRasterBand* maxOverview = nullptr;
-    const int numOverviews = firstBand->GetOverviewCount();
-    if (numOverviews <= 0) { // No overviews. Use first band.
-        maxOverview = firstBand;
-    }
-    else { // Pick the highest overview.
-        maxOverview = firstBand->GetOverview(numOverviews - 1);
-    }
-    const int sizeLevel0 = maxOverview->GetXSize();
-    const double diff = log2(minimumPixelSize) - log2(sizeLevel0);
-    const double intdiff = diff >= 0 ? ceil(diff) : floor(diff);
-    return static_cast<int>(intdiff);
-}
-
 bool isInside(const PixelRegion& lhs, const PixelRegion& rhs) {
     const glm::ivec2 e = lhs.start + lhs.numPixels;
     const glm::ivec2 re = rhs.start + rhs.numPixels;
@@ -434,17 +413,7 @@ void RawTileDataReader::initialize() {
         _padfTransform = geoTransform(_rasterXSize, _rasterYSize);
     }
 
-    const double tileLevelDifference = calculateTileLevelDifference(
-        _dataset,
-        _initData.dimensions.x
-    );
-
-    const int numOverviews = _dataset->GetRasterBand(1)->GetOverviewCount();
-    _maxChunkLevel = static_cast<int>(-tileLevelDifference);
-    if (numOverviews > 0) {
-        _maxChunkLevel += numOverviews;
-    }
-    _maxChunkLevel = std::max(_maxChunkLevel, 2);
+    _maxChunkLevel = _dataset->GetRasterBand(1)->GetOverviewCount();
 }
 
 void RawTileDataReader::reset() {


### PR DESCRIPTION
Addresses the disappearing height level when close to the surface.   The reason seems to be that extra piece of code (now removed) that did some magic and added 3 to the max level of the heightlayer max level, causing invalid tiles to be loaded that were nulled out due to the next NoDataValue.

I couldn't see any other side effects and the color layers max level seems unaffected as well.


Closes #3771