### PR TITLE
feature/multithreaded-asteroids

### DIFF
--- a/modules/space/rendering/renderableorbitalkepler.h
+++ b/modules/space/rendering/renderableorbitalkepler.h
@@ -68,6 +68,8 @@ private:
         properties::FloatProperty maxSize;
         /// Max angular size between vector cameraToPoint and edge of the point
         properties::OptionProperty renderingModes;
+        /// Specifies rendering orientation when rendering points
+        properties::OptionProperty pointRenderOption;
         /// Specifies a multiplicative factor that fades out the trail line
         properties::FloatProperty trailFade;
         /// Specifies if the point outline should be enabled
@@ -76,47 +78,63 @@ private:
         properties::Vec3Property outlineColor;
         /// Specifies how much if the point should be covered by the outline
         properties::FloatProperty outlineWidth;
+
+        bool changedRenderType = false;
     };
 
     void updateBuffers();
-    void calculateSegmentsForPoints(const RenderData& data);
-    void calculateSegmentsForTrails(const RenderData& data);
+    void threadedSegmentCalculations(const int threadId, const UpdateData& data);
 
+    const int _nThreads = 0;
+    std::vector<int> _threadIds;
+    std::vector<int> _orbitsPerThread;
+    std::vector<int> _vertexBufferOffset;
+
+    bool _renderTrails = false;
+    bool _renderPoints = false;
+    bool _forceUpdate = false;
     bool _updateDataBuffersAtNextRender = false;
-    long long _numObjects = 0;
+
+    unsigned int _nOrbits = 0;
     GLsizei _lineDrawCount = 0;
-    properties::UIntProperty _segmentQuality;
-    properties::UIntProperty _startRenderIdx;
-    properties::UIntProperty _sizeRender;
-    std::vector<GLint> _segmentSizeRaw;
+    std::vector<GLint> _segmentsPerOrbit;
     std::vector<GLint> _startIndexPoints;
     std::vector<GLint> _segmentSizePoints;
     std::vector<GLint> _startIndexTrails;
     std::vector<GLint> _segmentSizeTrails;
     std::vector<kepler::Parameters> _parameters;
 
+    /// Extra data for more efficient updating of vectors
+    struct updateInfo {
+        double timestamp = std::numeric_limits<double>::min();
+        double timePerStep = 0.0;
+    };
+    std::vector<updateInfo> _updateHelper;
+
     /// The layout of the VBOs
     struct TrailVBOLayout {
         float x = 0.f;
         float y = 0.f;
         float z = 0.f;
-        float time = 0.f;
+        double time = 0.0;
         double epoch = 0.0;
         double period = 0.0;
     };
-
     /// The backend storage for the vertex buffer object containing all points
     std::vector<TrailVBOLayout> _vertexBufferData;
 
-    GLuint _vertexArray = 0;
-    GLuint _vertexBuffer = 0;
-
     ghoul::opengl::ProgramObject* _trailProgram = nullptr;
     ghoul::opengl::ProgramObject* _pointProgram = nullptr;
+    properties::UIntProperty _segmentQuality;
+    properties::UIntProperty _startRenderIdx;
+    properties::UIntProperty _sizeRender;
     properties::StringProperty _path;
     properties::BoolProperty _contiguousMode;
     kepler::Format _format;
     RenderableOrbitalKepler::Appearance _appearance;
+
+    GLuint _vertexArray = 0;
+    GLuint _vertexBuffer = 0;
 
     // Line cache
     UniformCache(modelViewTransform, projectionTransform, trailFadeExponent,
@@ -125,9 +143,9 @@ private:
 
     // Point cache
     UniformCache(modelTransform, viewTransform, projectionTransform,
-        cameraPositionWorld, cameraUpWorld,  inGameTime, color,
-        pointSizeExponent, enableMaxSize, maxSize, enableOutline,
-        outlineColor, outlineWeight, opacity)
+        renderOption, cameraViewDirectionUp, cameraViewDirectionRight,
+        cameraPositionWorld, cameraUpWorld, inGameTime, color, pointSizeExponent,
+        enableMaxSize, maxSize, enableOutline, outlineColor, outlineWeight, opacity)
         _uniformPointCache;
 };
 

--- a/modules/space/shaders/keplerpoints_gs.glsl
+++ b/modules/space/shaders/keplerpoints_gs.glsl
@@ -33,16 +33,26 @@ flat in float vertexRevolutionFraction[];
 uniform dmat4 modelTransform;
 uniform dmat4 viewTransform;
 uniform mat4 projectionTransform;
-uniform dvec3 cameraPositionWorld;
-uniform vec3 cameraUpWorld;
 uniform float pointSizeExponent;
 uniform bool enableMaxSize;
 uniform float maxSize;
+uniform int renderOption;
+
+// Camera View Direction
+uniform vec3 cameraViewDirectionUp;
+uniform vec3 cameraViewDirectionRight;
+
+// Camera Normal
+uniform dvec3 cameraPositionWorld;
+uniform vec3 cameraUpWorld;
 
 layout(triangle_strip, max_vertices = 4) out;
 out float projectionViewDepth;
 out vec4 viewSpace;
 out vec2 texCoord;
+
+const int RenderOptionCameraViewDirection = 0;
+const int RenderOptionCameraPositionNormal = 1;
 
 void main() {
   // cFrac is how far along the trail orbit the head of the trail is.
@@ -65,12 +75,21 @@ void main() {
 
   // Calculate current vertex position to world space
   dvec4 vertPosWorldSpace = modelTransform * pos;
-
-  // Calculate new axis for plane
   vec3 camPosToVertPos = vec3(cameraPositionWorld - vertPosWorldSpace.xyz);
-  vec3 normal = normalize(camPosToVertPos);
-  vec3 right = normalize(cross(cameraUpWorld, normal));
-  vec3 up = normalize(cross(normal, right));
+
+  vec3 up;
+  vec3 right;
+  // Calculate new axis for plane
+  if (renderOption == RenderOptionCameraViewDirection) {
+    up = cameraViewDirectionUp;
+    right = cameraViewDirectionRight;
+  }
+  else {
+    // Camera Position Normal
+    vec3 normal = normalize(camPosToVertPos);
+    right = normalize(cross(cameraUpWorld, normal));
+    up = normalize(cross(normal, right));
+  }
 
   // Calculate size of points
   float initialSize = pow(10.0, pointSizeExponent);

--- a/modules/space/shaders/keplerpoints_vs.glsl
+++ b/modules/space/shaders/keplerpoints_vs.glsl
@@ -24,8 +24,8 @@
 
 #version __CONTEXT__
 
-layout (location = 0) in vec4 vertexData; // 1: x, 2: y, 3: z, 4: timeOffset,
-layout (location = 1) in dvec2 orbitData; // 1: epoch, 2: period
+layout (location = 0) in vec3 vertexData; // 1: x, 2: y, 3: z
+layout (location = 1) in dvec3 orbitData; // 1: timeOffset, 2: epoch, 3: period
 
 uniform double inGameTime;
 
@@ -33,8 +33,9 @@ flat out float currentRevolutionFraction;
 flat out float vertexRevolutionFraction;
 
 void main() {
-  double epoch = orbitData.x;
-  double period = orbitData.y;
+  double timeOffset = orbitData.x;
+  double epoch = orbitData.y;
+  double period = orbitData.z;
 
   // calculate nr of periods, get fractional part to know where the vertex closest to the
   // debris part is right now
@@ -45,7 +46,7 @@ void main() {
   }
 
   // Same procedure for the current vertex
-  vertexRevolutionFraction = float(vertexData.w / period);
+  vertexRevolutionFraction = float(timeOffset / period);
 
   gl_Position = vec4(vertexData.xyz, 1.0);
 }

--- a/modules/space/shaders/keplertrails_fs.glsl
+++ b/modules/space/shaders/keplertrails_fs.glsl
@@ -51,7 +51,7 @@ Fragment getFragment() {
     vertexDistance += 1.0;
   }
 
-  float invert = pow((1.0 - vertexDistance), trailFadeExponent);  
+  float invert = pow(1.0 - vertexDistance, trailFadeExponent);  
   float fade = clamp(invert, 0.0, 1.0);
 
   // Currently even fully transparent lines can occlude other lines, thus we discard these

--- a/modules/space/shaders/keplertrails_vs.glsl
+++ b/modules/space/shaders/keplertrails_vs.glsl
@@ -26,8 +26,8 @@
 
 #include "PowerScaling/powerScalingMath.hglsl"
 
-layout (location = 0) in vec4 vertexData; // 1: x, 2: y, 3: z, 4: timeOffset,
-layout (location = 1) in dvec2 orbitData; // 1: epoch, 2: period
+layout (location = 0) in vec3 vertexData; // 1: x, 2: y, 3: z
+layout (location = 1) in dvec3 orbitData; // 1: timeOffset, 2: epoch, 3: period
 
 out vec4 viewSpacePosition;
 out float viewSpaceDepth;
@@ -48,8 +48,9 @@ void main() {
   // offsetPeriods is calculated to know how much to fade that specific fragment.
 
   // If orbit_data is doubles, cast to float first
-  double epoch = orbitData.x;
-  double period = orbitData.y;
+  double timeOffset = orbitData.x;
+  double epoch = orbitData.y;
+  double period = orbitData.z;
 
   // Calculate nr of periods, get fractional part to know where the vertex closest to the
   // debris part is right now
@@ -61,7 +62,7 @@ void main() {
   }
 
   // Same procedure for the current vertex
-  offsetPeriods = vertexData.w / float(period);
+  offsetPeriods = float(timeOffset / period);
 
   viewSpacePosition = vec4(modelViewTransform * dvec4(vertexData.xyz, 1));
   vec4 vs_position = z_normalization(projectionTransform * viewSpacePosition);


### PR DESCRIPTION
## This PR adds the following
- Multithreading and a bettery system for updating which segments to render for each orbit
- Multithreading for loading of data
- Support for `Camera View Direction` in addition to existing `Camera Position Normal`

## Faster loading of data
Test with `.../scene/solarsystem/sssb/mpc.asset` (1.4 million objects). Loading times changed from `3 minutes` to `12 seconds`.

## Faster and smarter `update` function
Update function is now multithreaded and can also determine when new segments needs to be calculated, thus mostly doing minimal work for each frame (unless very high delta time).

### Compared to previous performance improvements in #3739:
**Datasets: Amor, Apollo, Outer main, Main, Inner main, Jupiter trojan, Transneptunian**
(ingame time paused)
- **Mode: Trails**
  - Before: 65 fps
  - After: 300 fps

- **Mode: Points**
  - Before: 65 fps
  - After: 350 fps

- **Mode: Trails + Points**
  - Before: 34 fps
  - After: 280 fps

### It also makes it possible to have better framerate at higher delta times:
**Datasets: Amor, Apollo, Outer main, Main, Inner main, Jupiter trojan, Transneptunian**
**Mode: Trails**
- **Before**
  - 14 days/sec: 32 fps
  - 30 days/sec: 25 fps

- **After**
  - 14 days/sec: 180 fps
  - 30 days/sec: 120 fps
