### PR TITLE
Make the profile editor (launcher GUI) and thus the Qt6 dependency optional

### DIFF
--- a/apps/OpenSpace/CMakeLists.txt
+++ b/apps/OpenSpace/CMakeLists.txt
@@ -143,14 +143,13 @@ add_custom_command(TARGET OpenSpace POST_BUILD
 
 end_header("Dependency: SGCT")
 
-# Profile Editor / Launcher GUI 
-option(OPENSPACE_PROFILE_EDITOR "Build profile editor (launcher GUI)" ON)
-if (OPENSPACE_PROFILE_EDITOR)
-
+# Profile Editor / Launcher GUI
+option(OPENSPACE_APPLICATION_OPENSPACE-LAUNCHER "Build Launcher GUI" ON)
+if (OPENSPACE_APPLICATION_OPENSPACE-LAUNCHER)
   begin_header("Dependency: Profile Editor")
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ext/launcher)
   target_link_libraries(OpenSpace PRIVATE openspace-ui-launcher)
-  add_compile_definitions(OPENSPACE_PROFILE_EDITOR)
+  target_compile_definitions(OpenSpace PRIVATE OPENSPACE_HAS_LAUNCHER)
   end_header("Dependency: Profile Editor")
 
   if (WIN32)

--- a/apps/OpenSpace/main.cpp
+++ b/apps/OpenSpace/main.cpp
@@ -79,11 +79,11 @@
 #include <float.h>
 #endif // OPENSPACE_BREAK_ON_FLOATING_POINT_EXCEPTION
 
-#ifdef OPENSPACE_PROFILE_EDITOR
+#ifdef OPENSPACE_HAS_LAUNCHER
 #include <launcherwindow.h>
 #include <QApplication>
 #include <QMessageBox>
-#endif // OPENSPACE_PROFILE_EDITOR
+#endif // OPENSPACE_HAS_LAUNCHER
 
 #ifdef WIN32
 extern "C" {
@@ -1452,8 +1452,7 @@ int main(int argc, char* argv[]) {
 #endif // __APPLE__
 
     if (!global::configuration->bypassLauncher) {
-#ifdef OPENSPACE_PROFILE_EDITOR
-
+#ifdef OPENSPACE_HAS_LAUNCHER
 #ifndef __APPLE__
         int qac = 0;
         QApplication app(qac, nullptr);
@@ -1546,11 +1545,9 @@ int main(int argc, char* argv[]) {
             }
             global::configuration->windowConfiguration = config;
         }
-#else
-        LDEBUG("Forcing the use of the bypassLauncher path, as the profile editor is not available.");
+#else // ^^^^ OPENSPACE_HAS_LAUNCHER // !OPENSPACE_HAS_LAUNCHER
         glfwInit();
-
-#endif // OPENSPACE_PROFILE_EDITOR
+#endif // OPENSPACE_HAS_LAUNCHER
     }
     else {
         glfwInit();


### PR DESCRIPTION
The reason for the requested change is that the dependency on newer versions of Qt6 (>=6.8.0) prevents OpenSpace from running on the Windows Server 2016 operating system [1] [2].

Running the binary file on Windows Server 2016 causes OpenSpace to crash immediately with the following error message: 
"The procedure entry point SetThreadDescription could not be loaded in the dynamic link library Qt6Core.dll". 
Since the Qt libraries are included in the main.cpp file, no crash or log files are created, and using the --bypassLauncher command line option does not cause the Qt6 DLLs to be skipped.

The solution proposed here is to add an additional option in CMAKE to make the profile editor (launcher GUI), which is the only project that uses Qt, optional. However, if the profile launcher is skipped, you must either change the desired profile and window options in openspace.cfg or set it using the command line parameters.

[1] https://qt-project.atlassian.net/browse/QTBUG-134075
[2] https://lists.qt-project.org/pipermail/development/2025-March/046207.html