### PR TITLE
CMake 4.x requires consistency - once you use plain signature, all ca…

### DIFF
--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -201,7 +201,7 @@ if (OS_MACOSX)
     set_executable_target_properties(${target})
     # add_cef_logical_target("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
     add_dependencies(${target} libcef_dll_wrapper)
-    target_link_libraries(${target} libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+    target_link_libraries(${target} PRIVATE libcef_dll_wrapper ${CEF_STANDARD_LIBS})
     set_target_properties(${target} PROPERTIES
       MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/mac/helper-Info.plist
       OUTPUT_NAME "${target}_OUTPUT_NAME"
@@ -212,7 +212,7 @@ if (OS_MACOSX)
 
     if (USE_SANDBOX)
       # Logical target used to link the cef_sandbox library.
-      target_link_libraries(${target} cef_sandbox_lib)
+      target_link_libraries(${target} PRIVATE cef_sandbox_lib)
     endif ()
   endforeach()
 


### PR DESCRIPTION
…lls must be plain, or once you use keywords, all must use keywords.

keyword is used at support/cmake/common-compile-settings/common-compile-settings.cmake:67


Closes #3859