### PR TITLE
Launcher: display paths with forward slash

### DIFF
--- a/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
+++ b/apps/OpenSpace/ext/launcher/src/launcherwindow.cpp
@@ -166,7 +166,7 @@ LauncherWindow::LauncherWindow(bool profileEnabled, const Configuration& globalC
             centralWidget
         );
     }
-    
+
     {
         QLabel* logoImage = new QLabel(centralWidget);
         logoImage->setObjectName("clear");
@@ -323,7 +323,7 @@ LauncherWindow::LauncherWindow(bool profileEnabled, const Configuration& globalC
     connect(
         _windowConfigBox, &SplitComboBox::selectionChanged,
         this, &LauncherWindow::selectConfiguration
-    ); 
+    );
     connect(
         _windowConfigBox, &SplitComboBox::selectionChanged,
         this, &LauncherWindow::updateStartButton

--- a/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
+++ b/apps/OpenSpace/ext/launcher/src/splitcombobox.cpp
@@ -110,7 +110,7 @@ void SplitComboBox::populateList(const std::string& preset) {
         // Display the relative path, but store the full path in the user data segment
         addItem(
             icon,
-            QString::fromStdString(relPath.string()),
+            QString::fromStdString(relPath.generic_string()),
             QString::fromStdString(p.string())
         );
 
@@ -139,7 +139,7 @@ void SplitComboBox::populateList(const std::string& preset) {
 
         // Display the relative path, but store the full path in the user data segment
         addItem(
-            QString::fromStdString(relPath.string()),
+            QString::fromStdString(relPath.generic_string()),
             QString::fromStdString(p.string())
         );
 


### PR DESCRIPTION
I used [std::filesystem::path::generic_string](https://en.cppreference.com/w/cpp/filesystem/path/generic_string.html) to display profile and config names in a platform-independent way. (with `/` separators)

Additionally this helps with the `Profile` field in `openspace.cfg`, which required backslashes on Windows and forward slashes on Unix, for deeply nested profile files.

<img width="482" height="738" alt="image" src="https://github.com/user-attachments/assets/ea91ef4d-5cda-479c-b71e-e47eff7f59f4" />
