### PR TITLE
Add support for different blackout colors and images. Invert BlackoutFactor value

### DIFF
--- a/include/openspace/rendering/framebufferrenderer.h
+++ b/include/openspace/rendering/framebufferrenderer.h
@@ -160,7 +160,8 @@ public:
         const glm::ivec4& viewport);
     void performDeferredTasks(const std::vector<DeferredcasterTask>& tasks,
         const glm::ivec4& viewport);
-    void render(Scene* scene, Camera* camera, float blackoutFactor);
+    void render(Scene* scene, Camera* camera, const glm::vec4& blackoutColor,
+        ghoul::opengl::Texture* blackoutTexture);
 
     /**
      * Update render data. Responsible for calling RenderEngine::setRenderData.
@@ -189,7 +190,8 @@ private:
         std::unique_ptr<ghoul::opengl::ProgramObject>
     >;
 
-    void applyTMO(float blackoutFactor, const glm::ivec4& viewport);
+    void applyTMO(const glm::vec4& blackoutColor, ghoul::opengl::Texture* blackoutTexture,
+        const glm::ivec4& viewport);
     void applyFXAA(const glm::ivec4& viewport);
     void updateDownscaleTextures() const;
     void writeDownscaledVolume(const glm::ivec4& viewport);
@@ -208,8 +210,9 @@ private:
     std::unique_ptr<ghoul::opengl::ProgramObject> _fxaaProgram;
     std::unique_ptr<ghoul::opengl::ProgramObject> _downscaledVolumeProgram;
 
-    UniformCache(hdrFeedingTexture, blackoutFactor, hdrExposure, gamma,
-        hue, saturation, value, viewport, resolution) _hdrUniformCache;
+    UniformCache(hdrFeedingTexture, blackoutColor, hasBlackoutTexture, blackoutTexture,
+        hdrExposure, gamma, hue, saturation, value, viewport,
+        resolution) _hdrUniformCache;
     UniformCache(renderedTexture, inverseScreenSize, viewport,
         resolution) _fxaaUniformCache;
     UniformCache(downscaledRenderedVolume, downscaledRenderedVolumeDepth, viewport,

--- a/include/openspace/rendering/framebufferrenderer.h
+++ b/include/openspace/rendering/framebufferrenderer.h
@@ -160,7 +160,8 @@ public:
         const glm::ivec4& viewport);
     void performDeferredTasks(const std::vector<DeferredcasterTask>& tasks,
         const glm::ivec4& viewport);
-    void render(Scene* scene, Camera* camera, const glm::vec4& blackoutColor,
+    void render(Scene* scene, Camera* camera, float blackoutFactor,
+        const glm::vec4& blackoutColor, float blackoutTextureFactor,
         ghoul::opengl::Texture* blackoutTexture);
 
     /**
@@ -190,7 +191,8 @@ private:
         std::unique_ptr<ghoul::opengl::ProgramObject>
     >;
 
-    void applyTMO(const glm::vec4& blackoutColor, ghoul::opengl::Texture* blackoutTexture,
+    void applyTMO(float blackoutFactor, const glm::vec4& blackoutColor,
+        float blackoutTextureFactor, ghoul::opengl::Texture* blackoutTexture,
         const glm::ivec4& viewport);
     void applyFXAA(const glm::ivec4& viewport);
     void updateDownscaleTextures() const;
@@ -210,9 +212,9 @@ private:
     std::unique_ptr<ghoul::opengl::ProgramObject> _fxaaProgram;
     std::unique_ptr<ghoul::opengl::ProgramObject> _downscaledVolumeProgram;
 
-    UniformCache(hdrFeedingTexture, blackoutColor, hasBlackoutTexture, blackoutTexture,
-        hdrExposure, gamma, hue, saturation, value, viewport,
-        resolution) _hdrUniformCache;
+    UniformCache(hdrFeedingTexture, blackoutFactor, blackoutColor, hasBlackoutTexture,
+        blackoutTexture, blackoutTextureFactor, hdrExposure, gamma, hue, saturation,
+        value, viewport, resolution) _hdrUniformCache;
     UniformCache(renderedTexture, inverseScreenSize, viewport,
         resolution) _fxaaUniformCache;
     UniformCache(downscaledRenderedVolume, downscaledRenderedVolumeDepth, viewport,

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -197,11 +197,18 @@ private:
     BoolProperty _screenshotUseDateTime;
     BoolProperty _disableMasterRendering;
 
-    Vec4Property _globalBlackoutColor;
-    StringProperty _globalBlackoutImage;
-    bool _globalBlackoutImageIsDirty = false;
-    std::unique_ptr<ghoul::opengl::Texture> _globalBlackoutImageTexture;
-    BoolProperty _applyBlackoutToMaster;
+    struct Blackout {
+        PropertyOwner owner;
+        FloatProperty factor;
+        Vec4Property color;
+        FloatProperty imageFactor;
+        StringProperty imagePath;
+        BoolProperty applyToMaster;
+        bool imageIsDirty = false;
+        std::unique_ptr<ghoul::opengl::Texture> imageTexture;
+    };
+    Blackout _globalBlackout;
+
 
     BoolProperty _enableFXAA;
 

--- a/include/openspace/rendering/renderengine.h
+++ b/include/openspace/rendering/renderengine.h
@@ -28,6 +28,7 @@
 #include <openspace/properties/propertyowner.h>
 
 #include <openspace/properties/list/intlistproperty.h>
+#include <openspace/properties/misc/stringproperty.h>
 #include <openspace/properties/misc/triggerproperty.h>
 #include <openspace/properties/scalar/boolproperty.h>
 #include <openspace/properties/scalar/intproperty.h>
@@ -173,7 +174,6 @@ private:
     void renderCameraInformation();
     void renderShutdownInformation(float timer, float fullTime);
     void renderDashboard() const;
-    float combinedBlackoutFactor() const;
 
     Camera* _camera = nullptr;
     Scene* _scene = nullptr;
@@ -197,7 +197,10 @@ private:
     BoolProperty _screenshotUseDateTime;
     BoolProperty _disableMasterRendering;
 
-    FloatProperty _globalBlackOutFactor;
+    Vec4Property _globalBlackoutColor;
+    StringProperty _globalBlackoutImage;
+    bool _globalBlackoutImageIsDirty = false;
+    std::unique_ptr<ghoul::opengl::Texture> _globalBlackoutImageTexture;
     BoolProperty _applyBlackoutToMaster;
 
     BoolProperty _enableFXAA;

--- a/shaders/framebuffer/hdr_and_filtering_fs.glsl
+++ b/shaders/framebuffer/hdr_and_filtering_fs.glsl
@@ -68,10 +68,11 @@ void main() {
   vec4 blkoutColor = blackoutColor;
   if (blackoutFactor < 1.0 && hasBlackoutTexture) {
     vec2 texSize = vec2(textureSize(blackoutTexture, 0));
-
     float texAspect = texSize.x / texSize.y;
     float windowAspect = resolution.x / resolution.y;
 
+    // Calculate the converted texture coordinates based on the aspect ratios of the
+    // rendering window and the image
     vec2 imageTexCoords;
     if (texAspect > windowAspect) {
       float fittedHeight = windowAspect / texAspect;

--- a/shaders/framebuffer/hdr_and_filtering_fs.glsl
+++ b/shaders/framebuffer/hdr_and_filtering_fs.glsl
@@ -33,9 +33,11 @@ in Data {
 layout (location = 0) out vec4 out_color;
 
 uniform float hdrExposure;
+uniform float blackoutFactor;
 uniform vec4 blackoutColor;
 uniform bool hasBlackoutTexture;
 uniform sampler2D blackoutTexture;
+uniform float blackoutTextureFactor;
 uniform float gamma;
 uniform float hue;
 uniform float saturation;
@@ -64,7 +66,7 @@ void main() {
   vec3 tColor = toneMappingOperator(color.rgb, hdrExposure);
 
   vec4 blkoutColor = blackoutColor;
-  if (blkoutColor.a > 0.0 && hasBlackoutTexture) {
+  if (blackoutFactor < 1.0 && hasBlackoutTexture) {
     vec2 texSize = vec2(textureSize(blackoutTexture, 0));
 
     float texAspect = texSize.x / texSize.y;
@@ -87,11 +89,11 @@ void main() {
     bool inRange = imageTexCoords.s >= 0.0 && imageTexCoords.s <= 1.0 &&
         imageTexCoords.t >= 0.0 && imageTexCoords.t <= 1.0;
 
-    vec4 texColor = inRange ? texture(blackoutTexture, imageTexCoords) : vec4(0.0);
-    blkoutColor.rgb = mix(blkoutColor.rgb, texColor.rgb, texColor.a);
+    vec4 t = texture(blackoutTexture, imageTexCoords);
+    blkoutColor = inRange ? mix(blkoutColor, t, blackoutTextureFactor) : blkoutColor;
   }
 
-  tColor.rgb = mix(tColor.rgb, blkoutColor.rgb, blkoutColor.a);
+  tColor.rgb = mix(tColor.rgb, blkoutColor.rgb, blkoutColor.a * (1.0 - blackoutFactor));
 
   // Color control
   vec3 hsvColor = rgb2hsv(tColor);

--- a/shaders/framebuffer/hdr_and_filtering_fs.glsl
+++ b/shaders/framebuffer/hdr_and_filtering_fs.glsl
@@ -65,7 +65,29 @@ void main() {
 
   vec4 blkoutColor = blackoutColor;
   if (blkoutColor.a > 0.0 && hasBlackoutTexture) {
-    vec4 texColor = texture(blackoutTexture, st);
+    vec2 texSize = vec2(textureSize(blackoutTexture, 0));
+
+    float texAspect = texSize.x / texSize.y;
+    float windowAspect = resolution.x / resolution.y;
+
+    vec2 imageTexCoords;
+    if (texAspect > windowAspect) {
+      float fittedHeight = windowAspect / texAspect;
+
+      imageTexCoords.s = st.s;
+      imageTexCoords.t = (st.t - 0.5) / fittedHeight + 0.5;
+    }
+    else {
+      float fittedWidth = texAspect / windowAspect;
+
+      imageTexCoords.s = (st.s - 0.5) / fittedWidth + 0.5;
+      imageTexCoords.t = st.y;
+    }
+
+    bool inRange = imageTexCoords.s >= 0.0 && imageTexCoords.s <= 1.0 &&
+        imageTexCoords.t >= 0.0 && imageTexCoords.t <= 1.0;
+
+    vec4 texColor = inRange ? texture(blackoutTexture, imageTexCoords) : vec4(0.0);
     blkoutColor.rgb = mix(blkoutColor.rgb, texColor.rgb, texColor.a);
   }
 

--- a/shaders/framebuffer/hdr_and_filtering_fs.glsl
+++ b/shaders/framebuffer/hdr_and_filtering_fs.glsl
@@ -33,7 +33,9 @@ in Data {
 layout (location = 0) out vec4 out_color;
 
 uniform float hdrExposure;
-uniform float blackoutFactor;
+uniform vec4 blackoutColor;
+uniform bool hasBlackoutTexture;
+uniform sampler2D blackoutTexture;
 uniform float gamma;
 uniform float hue;
 uniform float saturation;
@@ -57,10 +59,17 @@ void main() {
   st.y = st.y / (resolution.y / viewport[3]) + (viewport[1] / resolution.y);
 
   vec4 color = texture(hdrFeedingTexture, st);
-  color.rgb *= blackoutFactor;
 
   // Applies TMO
   vec3 tColor = toneMappingOperator(color.rgb, hdrExposure);
+
+  vec4 blkoutColor = blackoutColor;
+  if (blkoutColor.a > 0.0 && hasBlackoutTexture) {
+    vec4 texColor = texture(blackoutTexture, st);
+    blkoutColor.rgb = mix(blkoutColor.rgb, texColor.rgb, texColor.a);
+  }
+
+  tColor.rgb = mix(tColor.rgb, blkoutColor.rgb, blkoutColor.a);
 
   // Color control
   vec3 hsvColor = rgb2hsv(tColor);

--- a/src/rendering/framebufferrenderer.cpp
+++ b/src/rendering/framebufferrenderer.cpp
@@ -491,7 +491,10 @@ std::vector<std::string> FramebufferRenderer::shadowGroups() const {
     return res;
 }
 
-void FramebufferRenderer::applyTMO(float blackoutFactor, const glm::ivec4& viewport) {
+void FramebufferRenderer::applyTMO(const glm::vec4& blackoutColor,
+                                   ghoul::opengl::Texture* blackoutTexture,
+                                   const glm::ivec4& viewport)
+{
     ZoneScoped;
     TracyGpuZone("applyTMO");
 
@@ -501,7 +504,19 @@ void FramebufferRenderer::applyTMO(float blackoutFactor, const glm::ivec4& viewp
     hdrFeedingUnit.bind(_pingPongBuffers.colorTexture[_pingPongIndex]);
     _hdrFilteringProgram->setUniform(_hdrUniformCache.hdrFeedingTexture, hdrFeedingUnit);
 
-    _hdrFilteringProgram->setUniform(_hdrUniformCache.blackoutFactor, blackoutFactor);
+    _hdrFilteringProgram->setUniform(_hdrUniformCache.blackoutFactor, blackoutColor);
+    ghoul::opengl::TextureUnit blackoutTextureUnit;
+    if (blackoutTexture) {
+        blackoutTextureUnit.bind(*blackoutTexture);
+    }
+    _hdrFilteringProgram->setUniform(
+        _hdrUniformCache.hasBlackoutTexture,
+        blackoutTexture != nullptr
+    );
+    _hdrFilteringProgram->setUniform(
+        _hdrUniformCache.blackoutTexture,
+        blackoutTextureUnit
+    );
     _hdrFilteringProgram->setUniform(_hdrUniformCache.hdrExposure, _hdrExposure);
     _hdrFilteringProgram->setUniform(_hdrUniformCache.gamma, _gamma);
     _hdrFilteringProgram->setUniform(_hdrUniformCache.hue, _hue);
@@ -1156,7 +1171,10 @@ void FramebufferRenderer::updateDownscaledVolume() {
     );
 }
 
-void FramebufferRenderer::render(Scene* scene, Camera* camera, float blackoutFactor) {
+void FramebufferRenderer::render(Scene* scene, Camera* camera,
+                                 const glm::vec4& blackoutColor,
+                                 ghoul::opengl::Texture* blackoutTexture)
+{
     ZoneScoped;
     TracyGpuZone("FramebufferRenderer");
 
@@ -1294,7 +1312,7 @@ void FramebufferRenderer::render(Scene* scene, Camera* camera, float blackoutFac
         TracyGpuZone("Apply TMO");
         const ghoul::GLDebugGroup group("Apply TMO");
 
-        applyTMO(blackoutFactor, viewport);
+        applyTMO(blackoutColor, blackoutTexture, viewport);
     }
 
     if (_enableFXAA) {

--- a/src/rendering/framebufferrenderer.cpp
+++ b/src/rendering/framebufferrenderer.cpp
@@ -42,6 +42,7 @@
 #include <ghoul/misc/profiling.h>
 #include <ghoul/opengl/openglstatecache.h>
 #include <ghoul/opengl/programobject.h>
+#include <ghoul/opengl/texture.h>
 #include <ghoul/opengl/textureunit.h>
 #include <ghoul/systemcapabilities/openglcapabilitiescomponent.h>
 #include <glm/gtc/type_ptr.hpp>
@@ -504,7 +505,7 @@ void FramebufferRenderer::applyTMO(const glm::vec4& blackoutColor,
     hdrFeedingUnit.bind(_pingPongBuffers.colorTexture[_pingPongIndex]);
     _hdrFilteringProgram->setUniform(_hdrUniformCache.hdrFeedingTexture, hdrFeedingUnit);
 
-    _hdrFilteringProgram->setUniform(_hdrUniformCache.blackoutFactor, blackoutColor);
+    _hdrFilteringProgram->setUniform(_hdrUniformCache.blackoutColor, blackoutColor);
     ghoul::opengl::TextureUnit blackoutTextureUnit;
     if (blackoutTexture) {
         blackoutTextureUnit.bind(*blackoutTexture);

--- a/src/rendering/framebufferrenderer.cpp
+++ b/src/rendering/framebufferrenderer.cpp
@@ -492,7 +492,8 @@ std::vector<std::string> FramebufferRenderer::shadowGroups() const {
     return res;
 }
 
-void FramebufferRenderer::applyTMO(const glm::vec4& blackoutColor,
+void FramebufferRenderer::applyTMO(float blackoutFactor, const glm::vec4& blackoutColor,
+                                   float blackoutTextureFactor,
                                    ghoul::opengl::Texture* blackoutTexture,
                                    const glm::ivec4& viewport)
 {
@@ -505,6 +506,7 @@ void FramebufferRenderer::applyTMO(const glm::vec4& blackoutColor,
     hdrFeedingUnit.bind(_pingPongBuffers.colorTexture[_pingPongIndex]);
     _hdrFilteringProgram->setUniform(_hdrUniformCache.hdrFeedingTexture, hdrFeedingUnit);
 
+    _hdrFilteringProgram->setUniform(_hdrUniformCache.blackoutFactor, blackoutFactor);
     _hdrFilteringProgram->setUniform(_hdrUniformCache.blackoutColor, blackoutColor);
     ghoul::opengl::TextureUnit blackoutTextureUnit;
     if (blackoutTexture) {
@@ -513,6 +515,10 @@ void FramebufferRenderer::applyTMO(const glm::vec4& blackoutColor,
     _hdrFilteringProgram->setUniform(
         _hdrUniformCache.hasBlackoutTexture,
         blackoutTexture != nullptr
+    );
+    _hdrFilteringProgram->setUniform(
+        _hdrUniformCache.blackoutTextureFactor,
+        blackoutTextureFactor
     );
     _hdrFilteringProgram->setUniform(
         _hdrUniformCache.blackoutTexture,
@@ -1172,8 +1178,9 @@ void FramebufferRenderer::updateDownscaledVolume() {
     );
 }
 
-void FramebufferRenderer::render(Scene* scene, Camera* camera,
+void FramebufferRenderer::render(Scene* scene, Camera* camera, float blackoutFactor,
                                  const glm::vec4& blackoutColor,
+                                 float blackoutTextureFactor,
                                  ghoul::opengl::Texture* blackoutTexture)
 {
     ZoneScoped;
@@ -1313,7 +1320,13 @@ void FramebufferRenderer::render(Scene* scene, Camera* camera,
         TracyGpuZone("Apply TMO");
         const ghoul::GLDebugGroup group("Apply TMO");
 
-        applyTMO(blackoutColor, blackoutTexture, viewport);
+        applyTMO(
+            blackoutFactor,
+            blackoutColor,
+            blackoutTextureFactor,
+            blackoutTexture,
+            viewport
+        );
     }
 
     if (_enableFXAA) {

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -363,7 +363,7 @@ RenderEngine::RenderEngine()
         .owner = PropertyOwner(
             { "GlobalBlackout", "Global Blackout", "Blackout settings" }
         ),
-        .factor = FloatProperty(GlobalBlackoutFactorInfo, 1.f, 0.f, 1.f),
+        .factor = FloatProperty(GlobalBlackoutFactorInfo, 0.f, 0.f, 1.f),
         .color = Vec4Property(
             GlobalBlackoutColorInfo,
             glm::vec4(0.f, 0.f, 0.f, 1.f),
@@ -694,15 +694,20 @@ void RenderEngine::updateScreenSpaceRenderables() {
 
     // Not really part of the screenspace renderables but its pretty close
     if (_globalBlackout.imageIsDirty) [[unlikely]] {
-        try {
-            _globalBlackout.imageTexture = ghoul::io::TextureReader::ref().loadTexture(
-                _globalBlackout.imagePath.value(),
-                2
-            );
+        std::string path = _globalBlackout.imagePath;
+        if (path.empty()) {
+            _globalBlackout.imageTexture = nullptr;
         }
-        catch (const ghoul::RuntimeError& e) {
-            LERRORC(e.component, e.message);
+        else {
+            try {
+                _globalBlackout.imageTexture =
+                    ghoul::io::TextureReader::ref().loadTexture(path, 2);
+            }
+            catch (const ghoul::RuntimeError& e) {
+                LERRORC(e.component, e.message);
+            }
         }
+
         _globalBlackout.imageIsDirty = false;
     }
 
@@ -853,7 +858,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         _renderer.render(
             _scene,
             _camera,
-            trueBlackoutFactor,
+            1.f - trueBlackoutFactor,
             _globalBlackout.color.value(),
             _globalBlackout.imageFactor,
             _globalBlackout.imageTexture.get()
@@ -898,7 +903,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         ScreenSpaceRenderable::RenderData data = {
-            .blackoutFactor = trueBlackoutFactor,
+            .blackoutFactor = 1.f - trueBlackoutFactor,
             .hue = _hue / 360.f,
             .value = _value,
             .saturation = _saturation,

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -280,8 +280,9 @@ namespace {
     constexpr Property::PropertyInfo GlobalBlackoutImageFactorInfo = {
         "ImageFactor",
         "Image factor",
-        "Determines the visibility of the image provided by `BlackoutImage`, if no such "
-        "image has been loaded, this value does nothing."
+        "Determines the visibility of the image provided by the `Blackout.Image`, if no "
+        "such image has been loaded, this value does nothing.",
+        Property::Visibility::User
     };
 
     constexpr Property::PropertyInfo GlobalBlackoutImageInfo = {
@@ -289,7 +290,7 @@ namespace {
         "Image Path",
         "The path to an image that is used when the blackout rendering is enabled. "
         "Whether the image is shown or not is controlled by the alpha component of the "
-        "`BlackoutColor` property. It also determines the color shown if the selected "
+        "`Blackout.Color` property. It also determines the color shown if the selected "
         "image has transparency or does not have the same aspect ratio as the render "
         "window.",
         Property::Visibility::User
@@ -692,7 +693,7 @@ void RenderEngine::updateRenderer() {
 void RenderEngine::updateScreenSpaceRenderables() {
     ZoneScoped;
 
-    // Not really part of the screenspace renderables but its pretty close
+    // Not really part of the screenspace renderables but it's pretty close
     if (_globalBlackout.imageIsDirty) [[unlikely]] {
         std::string path = _globalBlackout.imagePath;
         if (path.empty()) {

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -261,11 +261,22 @@ namespace {
         Property::Visibility::User
     };
 
-    constexpr Property::PropertyInfo GlobalBlackoutFactorInfo = {
-        "BlackoutFactor",
-        "Blackout factor",
-        "The blackout factor of the rendering. This can be used for fading in or out the "
-        "rendering window.",
+    constexpr Property::PropertyInfo GlobalBlackoutColorInfo = {
+        "BlackoutColor",
+        "Blackout color",
+        "The color used for the blackout of the rendering. This can be used for fading "
+        "in or out the rendering window.",
+        Property::Visibility::User
+    };
+
+    constexpr Property::PropertyInfo GlobalBlackoutImageInfo = {
+        "BlackoutImage",
+        "Blackout image",
+        "The path to an image that is used when the blackout rendering is enabled. "
+        "Whether the image is shown or not is controlled by the alpha component of the "
+        "`BlackoutColor` property. It also determines the color shown if the selected "
+        "image has transparency or does not have the same aspect ratio as the render "
+        "window.",
         Property::Visibility::User
     };
 
@@ -333,7 +344,13 @@ RenderEngine::RenderEngine()
     , _useNewScreenfolder(UseNewScreenshotFolderInfo)
     , _screenshotUseDateTime(ScreenshotUseDateTimeInfo, false)
     , _disableMasterRendering(DisableMasterInfo, false)
-    , _globalBlackOutFactor(GlobalBlackoutFactorInfo, 1.f, 0.f, 1.f)
+    , _globalBlackoutColor(
+        GlobalBlackoutColorInfo,
+        glm::vec4(0.f),
+        glm::vec4(0.f),
+        glm::vec4(1.f)
+    )
+    , _globalBlackoutImage(GlobalBlackoutImageInfo)
     , _applyBlackoutToMaster(ApplyBlackoutToMasterInfo, true)
     , _enableFXAA(FXAAInfo, true)
     , _disableHDRPipeline(DisableHDRPipelineInfo, false)
@@ -407,7 +424,9 @@ RenderEngine::RenderEngine()
     _value.onChange(setHueValueSaturation);
     addProperty(_value);
 
-    addProperty(_globalBlackOutFactor);
+    addProperty(_globalBlackoutColor);
+    _globalBlackoutImage.onChange([this]() { _blackoutImageIsDirty = true; });
+    addProperty(_globalBlackoutImage);
     addProperty(_applyBlackoutToMaster);
     addProperty(_screenshotWindowIds);
     addProperty(_applyWarping);
@@ -646,6 +665,14 @@ void RenderEngine::updateRenderer() {
 void RenderEngine::updateScreenSpaceRenderables() {
     ZoneScoped;
 
+    // Not really part of the screenspace renderables but its pretty close
+    if (_globalBlackoutImageIsDirty) [[unlikely]] {
+        _globalBlackoutImageTexture = ghoul::io::TextureReader::ref().loadTexture(
+            _globalBlackoutImage.value(),
+            2
+        );
+    }
+
     for (std::unique_ptr<ScreenSpaceRenderable>& ssr : *global::screenSpaceRenderables) {
 #ifdef TRACY_ENABLE
         TracyPlot("RAM", static_cast<int64_t>(global::openSpaceEngine->ramInUse()));
@@ -784,8 +811,20 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
     }
 
     const bool renderingEnabled = delegate.isMaster() ? !_disableMasterRendering : true;
-    if (renderingEnabled && combinedBlackoutFactor() > 0.f) {
-        _renderer.render(_scene, _camera, combinedBlackoutFactor());
+    // If we are the master and we want to not apply the blackout to master, we have to
+    // override the value to be (0,0,0,0) instead
+    const glm::vec4 trueBlackoutColor =
+        global::windowDelegate->isMaster() ?
+        _applyBlackoutToMaster ? _globalBlackoutColor.value() : glm::vec4(0.f) :
+        _globalBlackoutColor.value();
+
+    if (renderingEnabled && trueBlackoutColor.a != 0.f) {
+        _renderer.render(
+            _scene,
+            _camera,
+            trueBlackoutColor,
+            _globalBlackoutImageTexture.get()
+        );
     }
 
     // The CEF webbrowser fix has to be called at least once per frame and we are doing
@@ -826,7 +865,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         ScreenSpaceRenderable::RenderData data = {
-            .blackoutFactor = combinedBlackoutFactor(),
+            .blackoutFactor = trueBlackoutColor.a,
             .hue = _hue / 360.f,
             .value = _value,
             .saturation = _saturation,
@@ -967,15 +1006,6 @@ void RenderEngine::renderDashboard() const {
     );
 
     global::dashboard->render(penPosition);
-}
-
-float RenderEngine::combinedBlackoutFactor() const {
-    if (global::windowDelegate->isMaster()) {
-        return _applyBlackoutToMaster ? _globalBlackOutFactor : 1.f;
-    }
-    else {
-        return _globalBlackOutFactor;
-    }
 }
 
 void RenderEngine::postDraw() {

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -261,17 +261,32 @@ namespace {
         Property::Visibility::User
     };
 
+    constexpr Property::PropertyInfo GlobalBlackoutFactorInfo = {
+        "Factor",
+        "Factor",
+        "The blackout factor of the rendering. This can be used for fading in or out the "
+        "rendering window.",
+        Property::Visibility::User
+    };
+
     constexpr Property::PropertyInfo GlobalBlackoutColorInfo = {
-        "BlackoutColor",
-        "Blackout color",
+        "Color",
+        "Color",
         "The color used for the blackout of the rendering. This can be used for fading "
         "in or out the rendering window.",
         Property::Visibility::User
     };
 
+    constexpr Property::PropertyInfo GlobalBlackoutImageFactorInfo = {
+        "ImageFactor",
+        "Image factor",
+        "Determines the visibility of the image provided by `BlackoutImage`, if no such "
+        "image has been loaded, this value does nothing."
+    };
+
     constexpr Property::PropertyInfo GlobalBlackoutImageInfo = {
-        "BlackoutImage",
-        "Blackout image",
+        "ImagePath",
+        "Image Path",
         "The path to an image that is used when the blackout rendering is enabled. "
         "Whether the image is shown or not is controlled by the alpha component of the "
         "`BlackoutColor` property. It also determines the color shown if the selected "
@@ -281,8 +296,8 @@ namespace {
     };
 
     constexpr Property::PropertyInfo ApplyBlackoutToMasterInfo = {
-        "ApplyBlackoutToMaster",
-        "Apply blackout to master",
+        "ApplyMaster",
+        "Apply to master",
         "If this value is 'true', the blackout factor is applied to the master node. "
         "Regardless of this value, the clients will always adhere to the factor.",
         Property::Visibility::AdvancedUser
@@ -344,14 +359,21 @@ RenderEngine::RenderEngine()
     , _useNewScreenfolder(UseNewScreenshotFolderInfo)
     , _screenshotUseDateTime(ScreenshotUseDateTimeInfo, false)
     , _disableMasterRendering(DisableMasterInfo, false)
-    , _globalBlackoutColor(
-        GlobalBlackoutColorInfo,
-        glm::vec4(0.f),
-        glm::vec4(0.f),
-        glm::vec4(1.f)
-    )
-    , _globalBlackoutImage(GlobalBlackoutImageInfo)
-    , _applyBlackoutToMaster(ApplyBlackoutToMasterInfo, true)
+    , _globalBlackout {
+        .owner = PropertyOwner(
+            { "GlobalBlackout", "Global Blackout", "Blackout settings" }
+        ),
+        .factor = FloatProperty(GlobalBlackoutFactorInfo, 1.f, 0.f, 1.f),
+        .color = Vec4Property(
+            GlobalBlackoutColorInfo,
+            glm::vec4(0.f, 0.f, 0.f, 1.f),
+            glm::vec4(0.f),
+            glm::vec4(1.f)
+        ),
+        .imageFactor = FloatProperty(GlobalBlackoutImageFactorInfo, 1.f, 0.f, 1.f),
+        .imagePath = StringProperty(GlobalBlackoutImageInfo),
+        .applyToMaster = BoolProperty(ApplyBlackoutToMasterInfo, true)
+    }
     , _enableFXAA(FXAAInfo, true)
     , _disableHDRPipeline(DisableHDRPipelineInfo, false)
     , _hdrExposure(HDRExposureInfo, 3.7f, 0.01f, 10.f)
@@ -424,11 +446,15 @@ RenderEngine::RenderEngine()
     _value.onChange(setHueValueSaturation);
     addProperty(_value);
 
-    _globalBlackoutColor.setViewOption(Property::ViewOptions::Color);
-    addProperty(_globalBlackoutColor);
-    _globalBlackoutImage.onChange([this]() { _globalBlackoutImageIsDirty = true; });
-    addProperty(_globalBlackoutImage);
-    addProperty(_applyBlackoutToMaster);
+    _globalBlackout.owner.addProperty(_globalBlackout.factor);
+    _globalBlackout.color.setViewOption(Property::ViewOptions::Color);
+    _globalBlackout.owner.addProperty(_globalBlackout.color);
+    _globalBlackout.owner.addProperty(_globalBlackout.imageFactor);
+    _globalBlackout.imagePath.onChange([this]() { _globalBlackout.imageIsDirty = true; });
+    _globalBlackout.owner.addProperty(_globalBlackout.imagePath);
+    _globalBlackout.owner.addProperty(_globalBlackout.applyToMaster);
+    addPropertySubOwner(_globalBlackout.owner);
+
     addProperty(_screenshotWindowIds);
     addProperty(_applyWarping);
 
@@ -667,12 +693,17 @@ void RenderEngine::updateScreenSpaceRenderables() {
     ZoneScoped;
 
     // Not really part of the screenspace renderables but its pretty close
-    if (_globalBlackoutImageIsDirty) [[unlikely]] {
-        _globalBlackoutImageTexture = ghoul::io::TextureReader::ref().loadTexture(
-            _globalBlackoutImage.value(),
-            2
-        );
-        _globalBlackoutImageIsDirty = false;
+    if (_globalBlackout.imageIsDirty) [[unlikely]] {
+        try {
+            _globalBlackout.imageTexture = ghoul::io::TextureReader::ref().loadTexture(
+                _globalBlackout.imagePath.value(),
+                2
+            );
+        }
+        catch (const ghoul::RuntimeError& e) {
+            LERRORC(e.component, e.message);
+        }
+        _globalBlackout.imageIsDirty = false;
     }
 
     for (std::unique_ptr<ScreenSpaceRenderable>& ssr : *global::screenSpaceRenderables) {
@@ -813,19 +844,19 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
     }
 
     const bool renderingEnabled = delegate.isMaster() ? !_disableMasterRendering : true;
-    // If we are the master and we want to not apply the blackout to master, we have to
-    // override the value to be (0,0,0,0) instead
-    const glm::vec4 trueBlackoutColor =
+    const float trueBlackoutFactor =
         global::windowDelegate->isMaster() ?
-        _applyBlackoutToMaster ? _globalBlackoutColor.value() : glm::vec4(0.f) :
-        _globalBlackoutColor.value();
+        _globalBlackout.applyToMaster ? _globalBlackout.factor : 1.f :
+        _globalBlackout.factor;
 
     if (renderingEnabled) {
         _renderer.render(
             _scene,
             _camera,
-            trueBlackoutColor,
-            _globalBlackoutImageTexture.get()
+            trueBlackoutFactor,
+            _globalBlackout.color.value(),
+            _globalBlackout.imageFactor,
+            _globalBlackout.imageTexture.get()
         );
     }
 
@@ -867,7 +898,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         ScreenSpaceRenderable::RenderData data = {
-            .blackoutFactor = trueBlackoutColor.a,
+            .blackoutFactor = trueBlackoutFactor,
             .hue = _hue / 360.f,
             .value = _value,
             .saturation = _saturation,

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -424,8 +424,9 @@ RenderEngine::RenderEngine()
     _value.onChange(setHueValueSaturation);
     addProperty(_value);
 
+    _globalBlackoutColor.setViewOption(Property::ViewOptions::Color);
     addProperty(_globalBlackoutColor);
-    _globalBlackoutImage.onChange([this]() { _blackoutImageIsDirty = true; });
+    _globalBlackoutImage.onChange([this]() { _globalBlackoutImageIsDirty = true; });
     addProperty(_globalBlackoutImage);
     addProperty(_applyBlackoutToMaster);
     addProperty(_screenshotWindowIds);
@@ -671,6 +672,7 @@ void RenderEngine::updateScreenSpaceRenderables() {
             _globalBlackoutImage.value(),
             2
         );
+        _globalBlackoutImageIsDirty = false;
     }
 
     for (std::unique_ptr<ScreenSpaceRenderable>& ssr : *global::screenSpaceRenderables) {
@@ -818,7 +820,7 @@ void RenderEngine::render(const glm::mat4& sceneMatrix, const glm::mat4& viewMat
         _applyBlackoutToMaster ? _globalBlackoutColor.value() : glm::vec4(0.f) :
         _globalBlackoutColor.value();
 
-    if (renderingEnabled && trueBlackoutColor.a != 0.f) {
+    if (renderingEnabled) {
         _renderer.render(
             _scene,
             _camera,


### PR DESCRIPTION
This adds the ability to change the color used for the global blackout fade configurable through the RenderEngine. It also adds the ability to show an image on top of the blackout image.

Two breaking changes:
1. The blackout values have been moved into a separate PropertyOwner, thus changing the URI to the blackout factor
2. The blackout factor value was inverted compared to the previous solution for consistency with other sliders

Closes #2924