### PR TITLE
Simplify texture reader/writer code

### DIFF
--- a/include/openspace/data/colormaploader.h
+++ b/include/openspace/data/colormaploader.h
@@ -22,25 +22,39 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
  ****************************************************************************************/
 
-#ifndef __OPENSPACE_CORE___SPECKLOADER___H__
-#define __OPENSPACE_CORE___SPECKLOADER___H__
+#ifndef __OPENSPACE_CORE___COLORMAPLOADER___H__
+#define __OPENSPACE_CORE___COLORMAPLOADER___H__
 
-#include <openspace/data/datamapping.h>
+#include <openspace/data/dataloader.h>
+#include <ghoul/opengl/texture.h>
 #include <filesystem>
-#include <optional>
+#include <memory>
 
-namespace openspace::dataloader {
-    struct Dataset;
-    struct Labelset;
-} // namespace openspace::dataloader
+namespace openspace::dataloader::colormap {
 
-namespace openspace::dataloader::speck {
+ColorMap loadCmapFile(std::filesystem::path path);
 
-Dataset loadSpeckFile(std::filesystem::path path,
-    std::optional<DataMapping> specs = std::nullopt);
+/**
+ * Loads a 1-dimensional color map texture from a file and returns it as a texture object.
+ *
+ * This function supports two types of colormap formats:
+ * - `.cmap` files: Custom color map format parsed by `loadCmapFile`
+ * - Standard image formats: Any 1D texture format supported by `ghoul::io::TextureReader`
+ *
+ * \param filename The path to the color map file to load. Must have a valid file
+ *                 extension
+ * \param samplerSettings Optional sampler settings to apply to the texture
+ *
+ * \return A unique pointer to the loaded OpenGL texture
+ *
+ * \throw ghoul::io::TextureReader::MissingReaderException if the file extension is not
+ *        supported
+ * \pre The filename must have a file extension
+ */
+std::unique_ptr<ghoul::opengl::Texture> loadColorMapTexture(
+    const std::filesystem::path& filename,
+    ghoul::opengl::Texture::SamplerInit samplerSettings = {});
 
-Labelset loadLabelFile(std::filesystem::path path);
+} // namespace openspace::dataloader::colormap
 
-} // namespace openspace::dataloader::speck
-
-#endif // __OPENSPACE_CORE___SPECKLOADER___H__
+#endif // __OPENSPACE_CORE___COLORMAPLOADER___H__

--- a/include/openspace/data/colormaploader.h
+++ b/include/openspace/data/colormaploader.h
@@ -44,7 +44,6 @@ ColorMap loadCmapFile(std::filesystem::path path);
  * \param filename The path to the color map file to load. Must have a valid file
  *                 extension
  * \param samplerSettings Optional sampler settings to apply to the texture
- *
  * \return A unique pointer to the loaded OpenGL texture
  *
  * \throw ghoul::io::texture::MissingReaderException if the file extension is not

--- a/include/openspace/data/colormaploader.h
+++ b/include/openspace/data/colormaploader.h
@@ -39,7 +39,7 @@ ColorMap loadCmapFile(std::filesystem::path path);
  *
  * This function supports two types of colormap formats:
  * - `.cmap` files: Custom color map format parsed by `loadCmapFile`
- * - Standard image formats: Any 1D texture format supported by `ghoul::io::TextureReader`
+ * - Standard image formats: Any 1D texture format supported by `ghoul::io::texture::loadTexture`
  *
  * \param filename The path to the color map file to load. Must have a valid file
  *                 extension
@@ -47,7 +47,7 @@ ColorMap loadCmapFile(std::filesystem::path path);
  *
  * \return A unique pointer to the loaded OpenGL texture
  *
- * \throw ghoul::io::TextureReader::MissingReaderException if the file extension is not
+ * \throw ghoul::io::texture::MissingReaderException if the file extension is not
  *        supported
  * \pre The filename must have a file extension
  */

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -994,7 +994,7 @@ void RenderablePointCloud::loadTexture(const std::filesystem::path& path, int in
     }
 
     std::unique_ptr<ghoul::opengl::Texture> t =
-        ghoul::io::TextureReader::loadTexture(path, 2);
+        ghoul::io::texture::loadTexture(path, 2);
 
     bool useAlpha = (t->numberOfChannels() > 3) && _texture.useAlphaChannel;
 

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -994,7 +994,7 @@ void RenderablePointCloud::loadTexture(const std::filesystem::path& path, int in
     }
 
     std::unique_ptr<ghoul::opengl::Texture> t =
-        ghoul::io::TextureReader::ref().loadTexture(path, 2);
+        ghoul::io::TextureReader::loadTexture(path, 2);
 
     bool useAlpha = (t->numberOfChannels() > 3) && _texture.useAlphaChannel;
 

--- a/modules/base/rendering/renderableplaneimagelocal.cpp
+++ b/modules/base/rendering/renderableplaneimagelocal.cpp
@@ -171,7 +171,7 @@ void RenderablePlaneImageLocal::loadTexture() {
         std::to_string(hash),
         [path = _texturePath.value()]() -> std::unique_ptr<ghoul::opengl::Texture> {
             std::unique_ptr<ghoul::opengl::Texture> texture =
-                ghoul::io::TextureReader::loadTexture(
+                ghoul::io::texture::loadTexture(
                     absPath(path),
                     2,
                     ghoul::opengl::Texture::SamplerInit {

--- a/modules/base/rendering/renderableplaneimagelocal.cpp
+++ b/modules/base/rendering/renderableplaneimagelocal.cpp
@@ -171,7 +171,7 @@ void RenderablePlaneImageLocal::loadTexture() {
         std::to_string(hash),
         [path = _texturePath.value()]() -> std::unique_ptr<ghoul::opengl::Texture> {
             std::unique_ptr<ghoul::opengl::Texture> texture =
-                ghoul::io::TextureReader::ref().loadTexture(
+                ghoul::io::TextureReader::loadTexture(
                     absPath(path),
                     2,
                     ghoul::opengl::Texture::SamplerInit {

--- a/modules/base/rendering/renderableplaneimageonline.cpp
+++ b/modules/base/rendering/renderableplaneimageonline.cpp
@@ -142,7 +142,7 @@ void RenderablePlaneImageOnline::update(const UpdateData& data) {
         }
 
         try {
-            _texture = ghoul::io::TextureReader::loadTexture(
+            _texture = ghoul::io::texture::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,
@@ -176,7 +176,7 @@ void RenderablePlaneImageOnline::update(const UpdateData& data) {
                 _textureDimensions = textureDim;
             }
         }
-        catch (const ghoul::io::TextureReader::InvalidLoadException& e) {
+        catch (const ghoul::io::texture::InvalidLoadException& e) {
             _textureIsDirty = false;
             LERRORC(e.component, e.message);
         }

--- a/modules/base/rendering/renderableplaneimageonline.cpp
+++ b/modules/base/rendering/renderableplaneimageonline.cpp
@@ -142,7 +142,7 @@ void RenderablePlaneImageOnline::update(const UpdateData& data) {
         }
 
         try {
-            _texture = ghoul::io::TextureReader::ref().loadTexture(
+            _texture = ghoul::io::TextureReader::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,

--- a/modules/base/rendering/renderableplanetimevaryingimage.cpp
+++ b/modules/base/rendering/renderableplanetimevaryingimage.cpp
@@ -117,7 +117,7 @@ void RenderablePlaneTimeVaryingImage::initializeGL() {
 
     _textureFiles.resize(_sourceFiles.size());
     for (size_t i = 0; i < _sourceFiles.size(); i++) {
-        _textureFiles[i] = ghoul::io::TextureReader::loadTexture(
+        _textureFiles[i] = ghoul::io::texture::loadTexture(
             absPath(_sourceFiles[i]),
             2
         );

--- a/modules/base/rendering/renderableplanetimevaryingimage.cpp
+++ b/modules/base/rendering/renderableplanetimevaryingimage.cpp
@@ -117,7 +117,7 @@ void RenderablePlaneTimeVaryingImage::initializeGL() {
 
     _textureFiles.resize(_sourceFiles.size());
     for (size_t i = 0; i < _sourceFiles.size(); i++) {
-        _textureFiles[i] = ghoul::io::TextureReader::ref().loadTexture(
+        _textureFiles[i] = ghoul::io::TextureReader::loadTexture(
             absPath(_sourceFiles[i]),
             2
         );

--- a/modules/base/rendering/renderablesphereimageonline.cpp
+++ b/modules/base/rendering/renderablesphereimageonline.cpp
@@ -134,7 +134,7 @@ void RenderableSphereImageOnline::update(const UpdateData& data) {
         }
 
         try {
-            _texture = ghoul::io::TextureReader::loadTexture(
+            _texture = ghoul::io::texture::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,
@@ -144,7 +144,7 @@ void RenderableSphereImageOnline::update(const UpdateData& data) {
 
             _textureIsDirty = false;
         }
-        catch (const ghoul::io::TextureReader::InvalidLoadException& e) {
+        catch (const ghoul::io::texture::InvalidLoadException& e) {
             _textureIsDirty = false;
             LERRORC(e.component, e.message);
         }

--- a/modules/base/rendering/renderablesphereimageonline.cpp
+++ b/modules/base/rendering/renderablesphereimageonline.cpp
@@ -134,7 +134,7 @@ void RenderableSphereImageOnline::update(const UpdateData& data) {
         }
 
         try {
-            _texture = ghoul::io::TextureReader::ref().loadTexture(
+            _texture = ghoul::io::TextureReader::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,

--- a/modules/base/rendering/renderabletimevaryingsphere.cpp
+++ b/modules/base/rendering/renderabletimevaryingsphere.cpp
@@ -122,7 +122,7 @@ void RenderableTimeVaryingSphere::extractMandatoryInfoFromSourceFolder() {
         std::filesystem::path filePath = e.path();
         const double time = extractTriggerTimeFromFileName(filePath);
         std::unique_ptr<ghoul::opengl::Texture> t =
-            ghoul::io::TextureReader::loadTexture(filePath, 2);
+            ghoul::io::texture::loadTexture(filePath, 2);
         _files.push_back({ std::move(filePath), time, std::move(t) });
     }
 

--- a/modules/base/rendering/renderabletimevaryingsphere.cpp
+++ b/modules/base/rendering/renderabletimevaryingsphere.cpp
@@ -122,7 +122,7 @@ void RenderableTimeVaryingSphere::extractMandatoryInfoFromSourceFolder() {
         std::filesystem::path filePath = e.path();
         const double time = extractTriggerTimeFromFileName(filePath);
         std::unique_ptr<ghoul::opengl::Texture> t =
-            ghoul::io::TextureReader::ref().loadTexture(filePath, 2);
+            ghoul::io::TextureReader::loadTexture(filePath, 2);
         _files.push_back({ std::move(filePath), time, std::move(t) });
     }
 

--- a/modules/base/rendering/screenspaceimagelocal.cpp
+++ b/modules/base/rendering/screenspaceimagelocal.cpp
@@ -116,7 +116,7 @@ void ScreenSpaceImageLocal::update() {
             //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
         };
 
-        _texture = ghoul::io::TextureReader::ref().loadTexture(
+        _texture = ghoul::io::TextureReader::loadTexture(
             absPath(_texturePath),
             2,
             samplerInit

--- a/modules/base/rendering/screenspaceimagelocal.cpp
+++ b/modules/base/rendering/screenspaceimagelocal.cpp
@@ -116,7 +116,7 @@ void ScreenSpaceImageLocal::update() {
             //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
         };
 
-        _texture = ghoul::io::TextureReader::loadTexture(
+        _texture = ghoul::io::texture::loadTexture(
             absPath(_texturePath),
             2,
             samplerInit

--- a/modules/base/rendering/screenspaceimageonline.cpp
+++ b/modules/base/rendering/screenspaceimageonline.cpp
@@ -125,7 +125,7 @@ void ScreenSpaceImageOnline::update() {
                 //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
             };
 
-            _texture = ghoul::io::TextureReader::loadTexture(
+            _texture = ghoul::io::texture::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,
@@ -136,7 +136,7 @@ void ScreenSpaceImageOnline::update() {
             _objectSize = _texture->dimensions();
             _textureIsDirty = false;
         }
-        catch (const ghoul::io::TextureReader::InvalidLoadException& e) {
+        catch (const ghoul::io::texture::InvalidLoadException& e) {
             _textureIsDirty = false;
             LERRORC(e.component, e.message);
         }

--- a/modules/base/rendering/screenspaceimageonline.cpp
+++ b/modules/base/rendering/screenspaceimageonline.cpp
@@ -125,7 +125,7 @@ void ScreenSpaceImageOnline::update() {
                 //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
             };
 
-            _texture = ghoul::io::TextureReader::ref().loadTexture(
+            _texture = ghoul::io::TextureReader::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,

--- a/modules/base/rendering/screenspaceinsetblackout.cpp
+++ b/modules/base/rendering/screenspaceinsetblackout.cpp
@@ -513,7 +513,7 @@ ScreenSpaceInsetBlackout::ScreenSpaceInsetBlackout(const ghoul::Dictionary& dict
                 //.filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap,
                 .filter = ghoul::opengl::Texture::FilterMode::LinearMipMap,
             };
-            _calibrationTexture = ghoul::io::TextureReader::ref().loadTexture(
+            _calibrationTexture = ghoul::io::TextureReader::loadTexture(
                 *optTexturePath,
                 2,
                 samplerInit

--- a/modules/base/rendering/screenspaceinsetblackout.cpp
+++ b/modules/base/rendering/screenspaceinsetblackout.cpp
@@ -513,7 +513,7 @@ ScreenSpaceInsetBlackout::ScreenSpaceInsetBlackout(const ghoul::Dictionary& dict
                 //.filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap,
                 .filter = ghoul::opengl::Texture::FilterMode::LinearMipMap,
             };
-            _calibrationTexture = ghoul::io::TextureReader::loadTexture(
+            _calibrationTexture = ghoul::io::texture::loadTexture(
                 *optTexturePath,
                 2,
                 samplerInit

--- a/modules/base/rendering/screenspacetimevaryingimageonline.cpp
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.cpp
@@ -191,7 +191,7 @@ void ScreenSpaceTimeVaryingImageOnline::update() {
                 //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
             };
 
-            _texture = ghoul::io::TextureReader::ref().loadTexture(
+            _texture = ghoul::io::TextureReader::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,

--- a/modules/base/rendering/screenspacetimevaryingimageonline.cpp
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.cpp
@@ -191,7 +191,7 @@ void ScreenSpaceTimeVaryingImageOnline::update() {
                 //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
             };
 
-            _texture = ghoul::io::TextureReader::loadTexture(
+            _texture = ghoul::io::texture::loadTexture(
                 reinterpret_cast<void*>(imageFile.buffer),
                 imageFile.size,
                 2,
@@ -201,7 +201,7 @@ void ScreenSpaceTimeVaryingImageOnline::update() {
 
             _objectSize = _texture->dimensions();
         }
-        catch (const ghoul::io::TextureReader::InvalidLoadException& e) {
+        catch (const ghoul::io::texture::InvalidLoadException& e) {
             LERRORC(e.component, e.message);
         }
     }

--- a/modules/gaia/rendering/renderablegaiastars.cpp
+++ b/modules/gaia/rendering/renderablegaiastars.cpp
@@ -26,6 +26,7 @@
 
 #include <modules/fitsfilereader/include/fitsfilereader.h>
 #include <modules/gaia/rendering/gaiaoptions.h>
+#include <openspace/data/colormaploader.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/engine/globals.h>
 #include <openspace/engine/windowdelegate.h>
@@ -953,9 +954,8 @@ void RenderableGaiaStars::update(const UpdateData&) {
         LDEBUG("Reloading Color Texture");
         _colorTexture = nullptr;
         if (!_colorTexturePath.value().empty()) {
-            _colorTexture = ghoul::io::TextureReader::loadTexture(
-                absPath(_colorTexturePath),
-                1
+            _colorTexture = dataloader::colormap::loadColorMapTexture(
+                absPath(_colorTexturePath)
             );
             LDEBUG(std::format("Loaded texture from '{}'", _colorTexturePath.value()));
 

--- a/modules/gaia/rendering/renderablegaiastars.cpp
+++ b/modules/gaia/rendering/renderablegaiastars.cpp
@@ -953,7 +953,7 @@ void RenderableGaiaStars::update(const UpdateData&) {
         LDEBUG("Reloading Color Texture");
         _colorTexture = nullptr;
         if (!_colorTexturePath.value().empty()) {
-            _colorTexture = ghoul::io::TextureReader::ref().loadTexture(
+            _colorTexture = ghoul::io::TextureReader::loadTexture(
                 absPath(_colorTexturePath),
                 1
             );

--- a/modules/galaxy/rendering/renderablegalaxy.cpp
+++ b/modules/galaxy/rendering/renderablegalaxy.cpp
@@ -426,7 +426,7 @@ void RenderableGalaxy::initializeGL() {
     );
 
     if (!_pointSpreadFunctionTexturePath.empty()) {
-        _pointSpreadFunctionTexture = ghoul::io::TextureReader::loadTexture(
+        _pointSpreadFunctionTexture = ghoul::io::texture::loadTexture(
             absPath(_pointSpreadFunctionTexturePath),
             2,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/galaxy/rendering/renderablegalaxy.cpp
+++ b/modules/galaxy/rendering/renderablegalaxy.cpp
@@ -426,7 +426,7 @@ void RenderableGalaxy::initializeGL() {
     );
 
     if (!_pointSpreadFunctionTexturePath.empty()) {
-        _pointSpreadFunctionTexture = ghoul::io::TextureReader::ref().loadTexture(
+        _pointSpreadFunctionTexture = ghoul::io::TextureReader::loadTexture(
             absPath(_pointSpreadFunctionTexturePath),
             2,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/globebrowsing/src/ringscomponent.cpp
+++ b/modules/globebrowsing/src/ringscomponent.cpp
@@ -583,7 +583,7 @@ void RingsComponent::loadTexture() {
     using namespace ghoul::opengl;
 
     if (!_texturePath.value().empty()) {
-        _texture = TextureReader::ref().loadTexture(
+        _texture = TextureReader::loadTexture(
             absPath(_texturePath),
             1,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }
@@ -596,7 +596,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureFwrdPath.value().empty()) {
-        _textureForwards = TextureReader::ref().loadTexture(
+        _textureForwards = TextureReader::loadTexture(
             absPath(_textureFwrdPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }
@@ -614,7 +614,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureBckwrdPath.value().empty()) {
-        _textureBackwards = TextureReader::ref().loadTexture(
+        _textureBackwards = TextureReader::loadTexture(
             absPath(_textureBckwrdPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }
@@ -631,7 +631,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureUnlitPath.value().empty()) {
-        _textureUnlit = TextureReader::ref().loadTexture(
+        _textureUnlit = TextureReader::loadTexture(
             absPath(_textureUnlitPath),
             1,
             { . filter = Texture::FilterMode::AnisotropicMipMap }
@@ -646,7 +646,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureColorPath.value().empty()) {
-        _textureColor = TextureReader::ref().loadTexture(
+        _textureColor = TextureReader::loadTexture(
             absPath(_textureColorPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }
@@ -661,7 +661,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureTransparencyPath.value().empty()) {
-        _textureTransparency = TextureReader::ref().loadTexture(
+        _textureTransparency = TextureReader::loadTexture(
             absPath(_textureTransparencyPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }

--- a/modules/globebrowsing/src/ringscomponent.cpp
+++ b/modules/globebrowsing/src/ringscomponent.cpp
@@ -583,7 +583,7 @@ void RingsComponent::loadTexture() {
     using namespace ghoul::opengl;
 
     if (!_texturePath.value().empty()) {
-        _texture = TextureReader::loadTexture(
+        _texture = texture::loadTexture(
             absPath(_texturePath),
             1,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }
@@ -596,7 +596,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureFwrdPath.value().empty()) {
-        _textureForwards = TextureReader::loadTexture(
+        _textureForwards = texture::loadTexture(
             absPath(_textureFwrdPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }
@@ -614,7 +614,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureBckwrdPath.value().empty()) {
-        _textureBackwards = TextureReader::loadTexture(
+        _textureBackwards = texture::loadTexture(
             absPath(_textureBckwrdPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }
@@ -631,7 +631,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureUnlitPath.value().empty()) {
-        _textureUnlit = TextureReader::loadTexture(
+        _textureUnlit = texture::loadTexture(
             absPath(_textureUnlitPath),
             1,
             { . filter = Texture::FilterMode::AnisotropicMipMap }
@@ -646,7 +646,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureColorPath.value().empty()) {
-        _textureColor = TextureReader::loadTexture(
+        _textureColor = texture::loadTexture(
             absPath(_textureColorPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }
@@ -661,7 +661,7 @@ void RingsComponent::loadTexture() {
     }
 
     if (!_textureTransparencyPath.value().empty()) {
-        _textureTransparency = TextureReader::loadTexture(
+        _textureTransparency = texture::loadTexture(
             absPath(_textureTransparencyPath),
             1,
             { .filter = Texture::FilterMode::AnisotropicMipMap }

--- a/modules/globebrowsing/src/tileprovider/singleimagetileprovider.cpp
+++ b/modules/globebrowsing/src/tileprovider/singleimagetileprovider.cpp
@@ -89,7 +89,7 @@ void SingleImageProvider::reset() {
         return;
     }
 
-    _tileTexture = ghoul::io::TextureReader::loadTexture(
+    _tileTexture = ghoul::io::texture::loadTexture(
         _filePath.value(),
         2,
         { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/globebrowsing/src/tileprovider/singleimagetileprovider.cpp
+++ b/modules/globebrowsing/src/tileprovider/singleimagetileprovider.cpp
@@ -89,7 +89,7 @@ void SingleImageProvider::reset() {
         return;
     }
 
-    _tileTexture = ghoul::io::TextureReader::ref().loadTexture(
+    _tileTexture = ghoul::io::TextureReader::loadTexture(
         _filePath.value(),
         2,
         { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/globebrowsing/src/tileprovider/temporaltileprovider.cpp
+++ b/modules/globebrowsing/src/tileprovider/temporaltileprovider.cpp
@@ -28,6 +28,7 @@
 #include <modules/globebrowsing/src/memoryawaretilecache.h>
 #include <modules/globebrowsing/src/tileindex.h>
 #include <modules/globebrowsing/src/tiletextureinitdata.h>
+#include <openspace/data/colormaploader.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/engine/globals.h>
 #include <openspace/engine/moduleengine.h>
@@ -38,7 +39,6 @@
 #include <openspace/util/timemanager.h>
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/format.h>
-#include <ghoul/io/texture/texturereader.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/assert.h>
 #include <ghoul/misc/dictionary.h>
@@ -319,9 +319,8 @@ TemporalTileProvider::TemporalTileProvider(const ghoul::Dictionary& dictionary)
     if (_isInterpolating) {
         _interpolateTileProvider = std::make_unique<InterpolateTileProvider>(dictionary);
         _interpolateTileProvider->initialize();
-        _interpolateTileProvider->colormap = ghoul::io::texture::loadTexture(
+        _interpolateTileProvider->colormap = dataloader::colormap::loadColorMapTexture(
             _colormap,
-            1,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }
         );
     }

--- a/modules/globebrowsing/src/tileprovider/temporaltileprovider.cpp
+++ b/modules/globebrowsing/src/tileprovider/temporaltileprovider.cpp
@@ -319,7 +319,7 @@ TemporalTileProvider::TemporalTileProvider(const ghoul::Dictionary& dictionary)
     if (_isInterpolating) {
         _interpolateTileProvider = std::make_unique<InterpolateTileProvider>(dictionary);
         _interpolateTileProvider->initialize();
-        _interpolateTileProvider->colormap = ghoul::io::TextureReader::loadTexture(
+        _interpolateTileProvider->colormap = ghoul::io::texture::loadTexture(
             _colormap,
             1,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/globebrowsing/src/tileprovider/temporaltileprovider.cpp
+++ b/modules/globebrowsing/src/tileprovider/temporaltileprovider.cpp
@@ -319,7 +319,7 @@ TemporalTileProvider::TemporalTileProvider(const ghoul::Dictionary& dictionary)
     if (_isInterpolating) {
         _interpolateTileProvider = std::make_unique<InterpolateTileProvider>(dictionary);
         _interpolateTileProvider->initialize();
-        _interpolateTileProvider->colormap = ghoul::io::TextureReader::ref().loadTexture(
+        _interpolateTileProvider->colormap = ghoul::io::TextureReader::loadTexture(
             _colormap,
             1,
             { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/iswa/rendering/renderabletexturecygnet.cpp
+++ b/modules/iswa/rendering/renderabletexturecygnet.cpp
@@ -52,13 +52,11 @@ RenderableTextureCygnet::RenderableTextureCygnet(const ghoul::Dictionary& dictio
 }
 
 bool RenderableTextureCygnet::updateTexture() {
-    using namespace ghoul;
-
-    _textures[0] = io::TextureReader::ref().loadTexture(
+    _textures[0] = ghoul::io::texture::loadTexture(
         reinterpret_cast<void*>(_imageFile.buffer),
         _imageFile.size,
         2,
-        { .filter = opengl::Texture::FilterMode::LinearMipMap },
+        { .filter = ghoul::opengl::Texture::FilterMode::LinearMipMap },
         _imageFile.format
     );
 

--- a/modules/space/rendering/renderablerings.cpp
+++ b/modules/space/rendering/renderablerings.cpp
@@ -250,7 +250,7 @@ void RenderableRings::update(const UpdateData& data) {
 void RenderableRings::loadTexture() {
     using namespace ghoul::io;
     using namespace ghoul::opengl;
-    _texture = TextureReader::ref().loadTexture(
+    _texture = TextureReader::loadTexture(
         _texturePath.value(),
         1,
         { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/space/rendering/renderablerings.cpp
+++ b/modules/space/rendering/renderablerings.cpp
@@ -250,7 +250,7 @@ void RenderableRings::update(const UpdateData& data) {
 void RenderableRings::loadTexture() {
     using namespace ghoul::io;
     using namespace ghoul::opengl;
-    _texture = TextureReader::loadTexture(
+    _texture = texture::loadTexture(
         _texturePath.value(),
         1,
         { .filter = ghoul::opengl::Texture::FilterMode::AnisotropicMipMap }

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -790,7 +790,7 @@ void RenderableStars::loadPSFTexture() {
             return;
         }
 
-        component.texture = ghoul::io::TextureReader::ref().loadTexture(
+        component.texture = ghoul::io::TextureReader::loadTexture(
             absPath(path),
             2,
             {
@@ -947,7 +947,7 @@ void RenderableStars::update(const UpdateData&) {
         LDEBUG("Reloading Color Texture");
         _colorTexture = nullptr;
         if (!_colorTexturePath.value().empty()) {
-            _colorTexture = ghoul::io::TextureReader::ref().loadTexture(
+            _colorTexture = ghoul::io::TextureReader::loadTexture(
                 absPath(_colorTexturePath),
                 1
             );
@@ -965,7 +965,7 @@ void RenderableStars::update(const UpdateData&) {
         LDEBUG("Reloading Color Texture");
         _otherDataColorMapTexture = nullptr;
         if (!_otherDataColorMapPath.value().empty()) {
-            _otherDataColorMapTexture = ghoul::io::TextureReader::ref().loadTexture(
+            _otherDataColorMapTexture = ghoul::io::TextureReader::loadTexture(
                 absPath(_otherDataColorMapPath),
                 1
             );

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -791,7 +791,7 @@ void RenderableStars::loadPSFTexture() {
             return;
         }
 
-        component.texture = ghoul::io::TextureReader::loadTexture(
+        component.texture = ghoul::io::texture::loadTexture(
             absPath(path),
             2,
             {

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -24,6 +24,7 @@
 
 #include <modules/space/rendering/renderablestars.h>
 
+#include <openspace/data/colormaploader.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/engine/globals.h>
 #include <openspace/rendering/renderengine.h>
@@ -947,9 +948,8 @@ void RenderableStars::update(const UpdateData&) {
         LDEBUG("Reloading Color Texture");
         _colorTexture = nullptr;
         if (!_colorTexturePath.value().empty()) {
-            _colorTexture = ghoul::io::TextureReader::loadTexture(
-                absPath(_colorTexturePath),
-                1
+            _colorTexture = dataloader::colormap::loadColorMapTexture(
+                absPath(_colorTexturePath)
             );
 
             LDEBUG(std::format("Loaded texture '{}'", _colorTexturePath.value()));
@@ -962,12 +962,11 @@ void RenderableStars::update(const UpdateData&) {
     }
 
     if (_otherDataColorMapIsDirty) [[unlikely]] {
-        LDEBUG("Reloading Color Texture");
+        LDEBUG("Reloading Other Data Color Texture");
         _otherDataColorMapTexture = nullptr;
         if (!_otherDataColorMapPath.value().empty()) {
-            _otherDataColorMapTexture = ghoul::io::TextureReader::loadTexture(
-                absPath(_otherDataColorMapPath),
-                1
+            _otherDataColorMapTexture = dataloader::colormap::loadColorMapTexture(
+                absPath(_otherDataColorMapPath)
             );
             LDEBUG(std::format(
                 "Loaded texture '{}'", _otherDataColorMapPath.value()

--- a/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
@@ -225,7 +225,7 @@ void RenderablePlaneProjection::loadTexture() {
         .filter = ghoul::opengl::Texture::FilterMode::LinearMipMap,
         //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
     };
-    _texture = ghoul::io::TextureReader::ref().loadTexture(_texturePath, 2, samplerInit);
+    _texture = ghoul::io::TextureReader::loadTexture(_texturePath, 2, samplerInit);
 
     _textureFile = std::make_unique<ghoul::filesystem::File>(_texturePath);
     _textureFile->setCallback([this]() { _textureIsDirty = true; });

--- a/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
@@ -225,7 +225,7 @@ void RenderablePlaneProjection::loadTexture() {
         .filter = ghoul::opengl::Texture::FilterMode::LinearMipMap,
         //.swizzleMask = std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE }
     };
-    _texture = ghoul::io::TextureReader::loadTexture(_texturePath, 2, samplerInit);
+    _texture = ghoul::io::texture::loadTexture(_texturePath, 2, samplerInit);
 
     _textureFile = std::make_unique<ghoul::filesystem::File>(_texturePath);
     _textureFile->setCallback([this]() { _textureIsDirty = true; });

--- a/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
@@ -640,7 +640,7 @@ void RenderablePlanetProjection::loadColorTexture() {
             Texture::WrappingMode::MirroredRepeat
         };
 
-        _baseTexture = ghoul::io::TextureReader::ref().loadTexture(
+        _baseTexture = ghoul::io::TextureReader::loadTexture(
             absPath(selectedPath),
             2,
             ghoul::opengl::Texture::SamplerInit {
@@ -660,7 +660,7 @@ void RenderablePlanetProjection::loadHeightTexture() {
     // run out in the case of two large textures
     _heightMapTexture = nullptr;
     if (selectedPath != NoImageText) {
-        _heightMapTexture = ghoul::io::TextureReader::ref().loadTexture(
+        _heightMapTexture = ghoul::io::TextureReader::loadTexture(
             absPath(selectedPath),
             2,
             {

--- a/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
@@ -640,7 +640,7 @@ void RenderablePlanetProjection::loadColorTexture() {
             Texture::WrappingMode::MirroredRepeat
         };
 
-        _baseTexture = ghoul::io::TextureReader::loadTexture(
+        _baseTexture = ghoul::io::texture::loadTexture(
             absPath(selectedPath),
             2,
             ghoul::opengl::Texture::SamplerInit {
@@ -660,7 +660,7 @@ void RenderablePlanetProjection::loadHeightTexture() {
     // run out in the case of two large textures
     _heightMapTexture = nullptr;
     if (selectedPath != NoImageText) {
-        _heightMapTexture = ghoul::io::TextureReader::loadTexture(
+        _heightMapTexture = ghoul::io::texture::loadTexture(
             absPath(selectedPath),
             2,
             {

--- a/modules/spacecraftinstruments/util/labelparser.cpp
+++ b/modules/spacecraftinstruments/util/labelparser.cpp
@@ -256,7 +256,7 @@ bool LabelParser::create() {
             }
             if (count == static_cast<int>(_specsOfInterest.size())) {
                 const std::vector<std::string> extensions =
-                    ghoul::io::TextureReader::ref().supportedExtensions();
+                    ghoul::io::TextureReader::supportedExtensions();
 
                 count = 0;
 

--- a/modules/spacecraftinstruments/util/labelparser.cpp
+++ b/modules/spacecraftinstruments/util/labelparser.cpp
@@ -256,7 +256,7 @@ bool LabelParser::create() {
             }
             if (count == static_cast<int>(_specsOfInterest.size())) {
                 const std::vector<std::string> extensions =
-                    ghoul::io::TextureReader::supportedExtensions();
+                    ghoul::io::texture::supportedReadExtensions();
 
                 count = 0;
 

--- a/modules/spacecraftinstruments/util/projectioncomponent.cpp
+++ b/modules/spacecraftinstruments/util/projectioncomponent.cpp
@@ -362,7 +362,7 @@ bool ProjectionComponent::initializeGL() {
 
     using ghoul::opengl::Texture;
 
-    _placeholderTexture = ghoul::io::TextureReader::ref().loadTexture(
+    _placeholderTexture = ghoul::io::TextureReader::loadTexture(
         absPath(PlaceholderFile),
         2,
         {
@@ -859,7 +859,7 @@ std::shared_ptr<ghoul::opengl::Texture> ProjectionComponent::loadProjectionTextu
         Texture::WrappingMode::Repeat,
         Texture::WrappingMode::MirroredRepeat
     };
-    std::unique_ptr<Texture> texture = ghoul::io::TextureReader::ref().loadTexture(
+    std::unique_ptr<Texture> texture = ghoul::io::TextureReader::loadTexture(
         absPath(texturePath),
         2,
         {

--- a/modules/spacecraftinstruments/util/projectioncomponent.cpp
+++ b/modules/spacecraftinstruments/util/projectioncomponent.cpp
@@ -362,7 +362,7 @@ bool ProjectionComponent::initializeGL() {
 
     using ghoul::opengl::Texture;
 
-    _placeholderTexture = ghoul::io::TextureReader::loadTexture(
+    _placeholderTexture = ghoul::io::texture::loadTexture(
         absPath(PlaceholderFile),
         2,
         {
@@ -859,7 +859,7 @@ std::shared_ptr<ghoul::opengl::Texture> ProjectionComponent::loadProjectionTextu
         Texture::WrappingMode::Repeat,
         Texture::WrappingMode::MirroredRepeat
     };
-    std::unique_ptr<Texture> texture = ghoul::io::TextureReader::loadTexture(
+    std::unique_ptr<Texture> texture = ghoul::io::texture::loadTexture(
         absPath(texturePath),
         2,
         {

--- a/modules/volume/rendering/renderablevectorfield.cpp
+++ b/modules/volume/rendering/renderablevectorfield.cpp
@@ -561,7 +561,7 @@ void RenderableVectorField::update(const UpdateData&) {
         _colorTexture = nullptr;
 
         if (!_colorSettings.colorMap.value().empty()) {
-            _colorTexture = ghoul::io::TextureReader::loadTexture(
+            _colorTexture = ghoul::io::texture::loadTexture(
                 absPath(_colorSettings.colorMap),
                 1,
                 ghoul::opengl::Texture::SamplerInit {

--- a/modules/volume/rendering/renderablevectorfield.cpp
+++ b/modules/volume/rendering/renderablevectorfield.cpp
@@ -561,7 +561,7 @@ void RenderableVectorField::update(const UpdateData&) {
         _colorTexture = nullptr;
 
         if (!_colorSettings.colorMap.value().empty()) {
-            _colorTexture = ghoul::io::TextureReader::ref().loadTexture(
+            _colorTexture = ghoul::io::TextureReader::loadTexture(
                 absPath(_colorSettings.colorMap),
                 1,
                 ghoul::opengl::Texture::SamplerInit {

--- a/modules/volume/rendering/renderablevectorfield.cpp
+++ b/modules/volume/rendering/renderablevectorfield.cpp
@@ -25,18 +25,17 @@
 #include <modules/volume/rendering/renderablevectorfield.h>
 
 #include <modules/volume/rawvolumereader.h>
+#include <openspace/data/colormaploader.h>
 #include <openspace/documentation/documentation.h>
 #include <openspace/engine/globals.h>
 #include <openspace/rendering/renderengine.h>
 #include <openspace/scripting/scriptengine.h>
 #include <ghoul/filesystem/filesystem.h>
-#include <ghoul/io/texture/texturereader.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/csvreader.h>
 #include <ghoul/opengl/texture.h>
 #include <ghoul/opengl/textureunit.h>
 #include <algorithm>
-#include <array>
 #include <execution>
 #include <numeric>
 
@@ -561,9 +560,8 @@ void RenderableVectorField::update(const UpdateData&) {
         _colorTexture = nullptr;
 
         if (!_colorSettings.colorMap.value().empty()) {
-            _colorTexture = ghoul::io::texture::loadTexture(
+            _colorTexture = dataloader::colormap::loadColorMapTexture(
                 absPath(_colorSettings.colorMap),
-                1,
                 ghoul::opengl::Texture::SamplerInit {
                     .filter = ghoul::opengl::Texture::FilterMode::Nearest,
                     .wrapping = ghoul::opengl::Texture::WrappingMode::ClampToEdge

--- a/modules/volume/textureslicevolumereader.inl
+++ b/modules/volume/textureslicevolumereader.inl
@@ -46,7 +46,7 @@ void TextureSliceVolumeReader<VoxelType>::initialize() {
     ghoul_assert(_paths.size() > 0, "No paths to read slices from");
 
     std::shared_ptr<ghoul::opengl::Texture> firstSlice =
-        ghoul::io::TextureReader::loadTexture(_paths[0], 2);
+        ghoul::io::texture::loadTexture(_paths[0], 2);
 
     glm::uvec3 dimensions = firstSlice->dimensions();
     _sliceDimensions = glm::uvec2(dimensions.x, dimensions.y);
@@ -83,7 +83,7 @@ TextureSliceVolumeReader<VoxelType>::getSlice(int sliceIndex) const
 
     if (!_cache.has(sliceIndex)) {
         std::shared_ptr<ghoul::opengl::Texture> texture =
-            ghoul::io::TextureReader::loadTexture(_paths[sliceIndex], 2);
+            ghoul::io::texture::loadTexture(_paths[sliceIndex], 2);
 
         ghoul_assert(
             glm::ivec2(texture->dimensions()) == _sliceDimensions,

--- a/modules/volume/textureslicevolumereader.inl
+++ b/modules/volume/textureslicevolumereader.inl
@@ -46,7 +46,7 @@ void TextureSliceVolumeReader<VoxelType>::initialize() {
     ghoul_assert(_paths.size() > 0, "No paths to read slices from");
 
     std::shared_ptr<ghoul::opengl::Texture> firstSlice =
-        ghoul::io::TextureReader::ref().loadTexture(_paths[0], 2);
+        ghoul::io::TextureReader::loadTexture(_paths[0], 2);
 
     glm::uvec3 dimensions = firstSlice->dimensions();
     _sliceDimensions = glm::uvec2(dimensions.x, dimensions.y);
@@ -83,7 +83,7 @@ TextureSliceVolumeReader<VoxelType>::getSlice(int sliceIndex) const
 
     if (!_cache.has(sliceIndex)) {
         std::shared_ptr<ghoul::opengl::Texture> texture =
-            ghoul::io::TextureReader::ref().loadTexture(_paths[sliceIndex], 2);
+            ghoul::io::TextureReader::loadTexture(_paths[sliceIndex], 2);
 
         ghoul_assert(
             glm::ivec2(texture->dimensions()) == _sliceDimensions,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(OPENSPACE_SOURCE
   openspace.cpp
   camera/camera.cpp
   camera/camerapose.cpp
+  data/colormaploader.cpp
   data/csvloader.cpp
   data/dataloader.cpp
   data/datamapping.cpp
@@ -253,6 +254,7 @@ set(OPENSPACE_HEADER
   ${PROJECT_SOURCE_DIR}/include/openspace/json.h
   ${PROJECT_SOURCE_DIR}/include/openspace/camera/camera.h
   ${PROJECT_SOURCE_DIR}/include/openspace/camera/camerapose.h
+  ${PROJECT_SOURCE_DIR}/include/openspace/data/colormaploader.h
   ${PROJECT_SOURCE_DIR}/include/openspace/data/csvloader.h
   ${PROJECT_SOURCE_DIR}/include/openspace/data/dataloader.h
   ${PROJECT_SOURCE_DIR}/include/openspace/data/datamapping.h

--- a/src/data/colormaploader.cpp
+++ b/src/data/colormaploader.cpp
@@ -160,6 +160,14 @@ loadColorMapTexture(const std::filesystem::path& filename,
 
     if (extension == "cmap") {
         const ColorMap colorMap = loadCmapFile(filename);
+
+        if (colorMap.entries.empty()) {
+            LERROR(std::format(
+                "Could not read any color data from color map file '{}'", filename
+            ));
+            return nullptr;
+        }
+
         return std::make_unique<ghoul::opengl::Texture>(
             ghoul::opengl::Texture::FormatInit{
                 .dimensions = glm::uvec3(static_cast<unsigned int>(colorMap.entries.size()), 1, 1),

--- a/src/data/colormaploader.cpp
+++ b/src/data/colormaploader.cpp
@@ -169,11 +169,11 @@ loadColorMapTexture(const std::filesystem::path& filename,
         // @TODO (emmbr, 2026-04-08) Consider including nanColor, below and above range.
         // These are now ignored in the texture
     }
-    else if (ghoul::io::TextureReader::isSupportedExtension(extension)) {
-        return ghoul::io::TextureReader::loadTexture(filename, 1, samplerSettings);
+    else if (ghoul::io::texture::isSupportedReadExtension(extension)) {
+        return ghoul::io::texture::loadTexture(filename, 1, samplerSettings);
     }
     else {
-        throw ghoul::io::TextureReader::MissingReaderException(extension, filename);
+        throw ghoul::io::texture::MissingReaderException(extension, filename);
     }
 }
 

--- a/src/data/colormaploader.cpp
+++ b/src/data/colormaploader.cpp
@@ -26,8 +26,12 @@
 
 #include <ghoul/io/texture/texturereader.h>
 #include <ghoul/logging/logmanager.h>
+#include <ghoul/misc/assert.h>
+#include <ghoul/misc/exception.h>
 #include <ghoul/misc/stringhelper.h>
 #include <format>
+#include <fstream>
+#include <sstream>
 
 namespace {
     constexpr std::string_view _loggerCat = "ColorMapLoader";

--- a/src/data/colormaploader.cpp
+++ b/src/data/colormaploader.cpp
@@ -1,0 +1,180 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <openspace/data/colormaploader.h>
+
+#include <ghoul/io/texture/texturereader.h>
+#include <ghoul/logging/logmanager.h>
+#include <ghoul/misc/stringhelper.h>
+#include <format>
+
+namespace {
+    constexpr std::string_view _loggerCat = "ColorMapLoader";
+
+    bool startsWith(std::string lhs, std::string_view rhs) noexcept {
+        lhs = ghoul::toLowerCase(lhs);
+        return (rhs.size() <= lhs.size()) && (lhs.substr(0, rhs.size()) == rhs);
+    }
+
+    void strip(std::string& line) noexcept {
+        // 1. Remove all spaces from the beginning
+        // 2. Remove #
+        // 3. Remove all spaces from the new beginning
+        // 4. Remove all spaces from the end
+
+        while (!line.empty() && (line[0] == ' ' || line[0] == '\t')) {
+            line = line.substr(1);
+        }
+
+        if (!line.empty() && line[0] == '#') {
+            line = line.substr(1);
+        }
+
+        while (!line.empty() && (line[0] == ' ' || line[0] == '\t')) {
+            line = line.substr(1);
+        }
+
+        while (!line.empty() && (line.back() == ' ' || line.back() == '\t')) {
+            line = line.substr(0, line.size() - 1);
+        }
+    }
+} // namespace
+
+namespace openspace::dataloader::colormap {
+
+ColorMap loadCmapFile(std::filesystem::path path) {
+    ghoul_assert(std::filesystem::exists(path), "File must exist");
+
+    std::ifstream file = std::ifstream(path);
+    if (!file.good()) {
+        throw ghoul::RuntimeError(std::format(
+            "Failed to open color map file '{}'", path
+        ));
+    }
+
+    ColorMap res;
+    int nColorLines = -1;
+
+    std::string line;
+    while (ghoul::getline(file, line)) {
+        // Ignore empty line or commented-out lines
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+
+        // Guard against wrong line endings (copying files from Windows to Mac) causes
+        // lines to have a final \r
+        if (line.back() == '\r') {
+            line = line.substr(0, line.length() - 1);
+        }
+
+        strip(line);
+
+        if (nColorLines == -1) {
+            // This is the first time we get this far, it will have to be the first number
+            // meaning that it is the number of color values
+
+            std::stringstream str(line);
+            str >> nColorLines;
+            res.entries.reserve(nColorLines);
+        }
+        else {
+            // We have already read the number of color lines, so we are in the process of
+            // reading the individual value lines
+
+            glm::vec4 color;
+            std::string dummy;
+            // Note that startwith converts the input string to all lowercase
+            if (startsWith(line, "belowrange")) {
+                std::stringstream str(line);
+                str >> dummy >> color.x >> color.y >> color.z >> color.w;
+                res.belowRangeColor = color;
+            }
+            else if (startsWith(line, "aboverange")) {
+                std::stringstream str(line);
+                str >> dummy >> color.x >> color.y >> color.z >> color.w;
+                res.aboveRangeColor = color;
+            }
+            else if (startsWith(line, "nan")) {
+                std::stringstream str(line);
+                str >> dummy >> color.x >> color.y >> color.z >> color.w;
+                res.nanColor = color;
+            }
+            else {
+                // TODO: Catch when this is not a color!
+                std::stringstream str(line);
+                str >> color.x >> color.y >> color.z >> color.w;
+                res.entries.push_back(std::move(color));
+            }
+        }
+    }
+
+    res.entries.shrink_to_fit();
+
+    if (nColorLines != static_cast<int>(res.entries.size())) {
+        LWARNING(std::format(
+            "While loading color map '{}', the expected number of color values '{}' "
+            "was different from the actual number of color values '{}'",
+            path, nColorLines, res.entries.size()
+        ));
+    }
+
+    return res;
+}
+
+std::unique_ptr<ghoul::opengl::Texture>
+loadColorMapTexture(const std::filesystem::path& filename,
+                    ghoul::opengl::Texture::SamplerInit samplerSettings)
+{
+    std::string extension = std::filesystem::path(filename).extension().string();
+    if (!extension.empty()) {
+        extension = extension.substr(1);
+    }
+    ghoul_assert(!extension.empty(), "Filename must have an extension");
+    extension = ghoul::toLowerCase(extension);
+
+    if (extension == "cmap") {
+        const ColorMap colorMap = loadCmapFile(filename);
+        return std::make_unique<ghoul::opengl::Texture>(
+            ghoul::opengl::Texture::FormatInit{
+                .dimensions = glm::uvec3(static_cast<unsigned int>(colorMap.entries.size()), 1, 1),
+                .type = GL_TEXTURE_1D,
+                .format = ghoul::opengl::Texture::Format::RGBA,
+                .dataType = GL_FLOAT
+            },
+            samplerSettings,
+            reinterpret_cast<const std::byte*>(colorMap.entries.data())
+        );
+        // @TODO (emmbr, 2026-04-08) Consider including nanColor, below and above range.
+        // These are now ignored in the texture
+    }
+    else if (ghoul::io::TextureReader::isSupportedExtension(extension)) {
+        return ghoul::io::TextureReader::loadTexture(filename, 1, samplerSettings);
+    }
+    else {
+        throw ghoul::io::TextureReader::MissingReaderException(extension, filename);
+    }
+}
+
+} // namespace openspace::dataloader::colormap

--- a/src/data/colormaploader.cpp
+++ b/src/data/colormaploader.cpp
@@ -169,7 +169,7 @@ loadColorMapTexture(const std::filesystem::path& filename,
         }
 
         return std::make_unique<ghoul::opengl::Texture>(
-            ghoul::opengl::Texture::FormatInit{
+            ghoul::opengl::Texture::FormatInit {
                 .dimensions = glm::uvec3(static_cast<unsigned int>(colorMap.entries.size()), 1, 1),
                 .type = GL_TEXTURE_1D,
                 .format = ghoul::opengl::Texture::Format::RGBA,

--- a/src/data/dataloader.cpp
+++ b/src/data/dataloader.cpp
@@ -24,6 +24,7 @@
 
 #include <openspace/data/dataloader.h>
 
+#include <openspace/data/colormaploader.h>
 #include <openspace/data/csvloader.h>
 #include <openspace/data/speckloader.h>
 #include <ghoul/filesystem/cachemanager.h>
@@ -589,7 +590,7 @@ namespace color {
 
         ColorMap res;
         if (extension == ".cmap") {
-            res = speck::loadCmapFile(path);
+            res = colormap::loadCmapFile(path);
         }
         else {
             LERRORC("DataLoader", std::format(

--- a/src/data/speckloader.cpp
+++ b/src/data/speckloader.cpp
@@ -25,8 +25,6 @@
 #include <openspace/data/speckloader.h>
 
 #include <openspace/data/dataloader.h>
-#include <ghoul/format.h>
-#include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/assert.h>
 #include <ghoul/misc/exception.h>
 #include <ghoul/misc/stringhelper.h>
@@ -499,89 +497,6 @@ Labelset loadLabelFile(std::filesystem::path path) {
         if (!rest.empty()) {
             res.entries.push_back(std::move(entry));
         }
-    }
-
-    return res;
-}
-
-ColorMap loadCmapFile(std::filesystem::path path) {
-    ghoul_assert(std::filesystem::exists(path), "File must exist");
-
-    std::ifstream file = std::ifstream(path);
-    if (!file.good()) {
-        throw ghoul::RuntimeError(std::format(
-            "Failed to open color map file '{}'", path
-        ));
-    }
-
-    ColorMap res;
-    int nColorLines = -1;
-
-    std::string line;
-    while (ghoul::getline(file, line)) {
-        // Ignore empty line or commented-out lines
-        if (line.empty() || line[0] == '#') {
-            continue;
-        }
-
-        // Guard against wrong line endings (copying files from Windows to Mac) causes
-        // lines to have a final \r
-        if (line.back() == '\r') {
-            line = line.substr(0, line.length() - 1);
-        }
-
-        strip(line);
-
-        if (nColorLines == -1) {
-            // This is the first time we get this far, it will have to be the first number
-            // meaning that it is the number of color values
-
-            std::stringstream str(line);
-            str >> nColorLines;
-            res.entries.reserve(nColorLines);
-        }
-        else {
-            // We have already read the number of color lines, so we are in the process of
-            // reading the individual value lines
-
-            glm::vec4 color;
-            std::string dummy;
-            // Note that startwith converts the input string to all lowercase
-            if (startsWith(line, "belowrange")) {
-                std::stringstream str(line);
-                str >> dummy >> color.x >> color.y >> color.z >> color.w;
-                res.belowRangeColor = color;
-            }
-            else if (startsWith(line, "aboverange")) {
-                std::stringstream str(line);
-                str >> dummy >> color.x >> color.y >> color.z >> color.w;
-                res.aboveRangeColor = color;
-            }
-            else if (startsWith(line, "nan")) {
-                std::stringstream str(line);
-                str >> dummy >> color.x >> color.y >> color.z >> color.w;
-                res.nanColor = color;
-            }
-            else {
-                // TODO: Catch when this is not a color!
-                std::stringstream str(line);
-                str >> color.x >> color.y >> color.z >> color.w;
-                res.entries.push_back(std::move(color));
-            }
-        }
-    }
-
-    res.entries.shrink_to_fit();
-
-    if (nColorLines != static_cast<int>(res.entries.size())) {
-        LWARNINGC(
-            "SpeckLoader",
-            std::format(
-                "While loading color map '{}', the expected number of color values '{}' "
-                "was different from the actual number of color values '{}'",
-                path, nColorLines, res.entries.size()
-            )
-        );
     }
 
     return res;

--- a/src/engine/openspaceengine_lua.inl
+++ b/src/engine/openspaceengine_lua.inl
@@ -178,7 +178,7 @@ namespace {
         );
 
         try {
-            ghoul::io::TextureWriter::ref().saveTexture(texture, fileName.string());
+            ghoul::io::TextureWriter::saveTexture(texture, fileName.string());
         }
         catch (const std::filesystem::filesystem_error& e) {
             LERRORC("Exception: {}", e.what());
@@ -195,7 +195,7 @@ namespace {
  * \return The size of the image in pixels
  */
 [[codegen::luawrap]] glm::ivec2 imageSize(std::filesystem::path path) {
-    return ghoul::io::TextureReader::ref().imageSize(path);
+    return ghoul::io::TextureReader::imageSize(path);
 }
 
 /**

--- a/src/engine/openspaceengine_lua.inl
+++ b/src/engine/openspaceengine_lua.inl
@@ -178,7 +178,7 @@ namespace {
         );
 
         try {
-            ghoul::io::TextureWriter::saveTexture(texture, fileName.string());
+            ghoul::io::texture::saveTexture(texture, fileName.string());
         }
         catch (const std::filesystem::filesystem_error& e) {
             LERRORC("Exception: {}", e.what());
@@ -195,7 +195,7 @@ namespace {
  * \return The size of the image in pixels
  */
 [[codegen::luawrap]] glm::ivec2 imageSize(std::filesystem::path path) {
-    return ghoul::io::TextureReader::imageSize(path);
+    return ghoul::io::texture::imageSize(path);
 }
 
 /**

--- a/src/rendering/loadingscreen.cpp
+++ b/src/rendering/loadingscreen.cpp
@@ -152,7 +152,7 @@ LoadingScreen::LoadingScreen(ShowMessage showMessage, ShowNodeNames showNodeName
 
     {
         // Logo stuff
-        _logoTexture = ghoul::io::TextureReader::loadTexture(
+        _logoTexture = ghoul::io::texture::loadTexture(
             absPath("${DATA}/openspace-logo.png"),
             2
         );

--- a/src/rendering/loadingscreen.cpp
+++ b/src/rendering/loadingscreen.cpp
@@ -152,7 +152,7 @@ LoadingScreen::LoadingScreen(ShowMessage showMessage, ShowNodeNames showNodeName
 
     {
         // Logo stuff
-        _logoTexture = ghoul::io::TextureReader::ref().loadTexture(
+        _logoTexture = ghoul::io::TextureReader::loadTexture(
             absPath("${DATA}/openspace-logo.png"),
             2
         );

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -55,9 +55,6 @@
 #include <ghoul/io/model/modelreader.h>
 #include <ghoul/io/model/modelreaderassimp.h>
 #include <ghoul/io/model/modelreaderbinary.h>
-#include <ghoul/io/texture/texturereader.h>
-#include <ghoul/io/texture/texturereadercmap.h>
-#include <ghoul/io/texture/texturereaderstb.h>
 #include <ghoul/logging/loglevel.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/assert.h>
@@ -478,8 +475,6 @@ void RenderEngine::initialize() {
     _screenshotUseDate = global::configuration->shouldUseScreenshotDate;
 
     using namespace ghoul::io;
-    TextureReader::ref().addReader(std::make_unique<TextureReaderSTB>());
-    TextureReader::ref().addReader(std::make_unique<TextureReaderCMAP>());
     ModelReader::ref().addReader(std::make_unique<ModelReaderAssimp>());
     ModelReader::ref().addReader(std::make_unique<ModelReaderBinary>());
 }

--- a/src/rendering/renderengine.cpp
+++ b/src/rendering/renderengine.cpp
@@ -58,8 +58,6 @@
 #include <ghoul/io/texture/texturereader.h>
 #include <ghoul/io/texture/texturereadercmap.h>
 #include <ghoul/io/texture/texturereaderstb.h>
-#include <ghoul/io/texture/texturewriter.h>
-#include <ghoul/io/texture/texturewriterstb.h>
 #include <ghoul/logging/loglevel.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/assert.h>
@@ -482,7 +480,6 @@ void RenderEngine::initialize() {
     using namespace ghoul::io;
     TextureReader::ref().addReader(std::make_unique<TextureReaderSTB>());
     TextureReader::ref().addReader(std::make_unique<TextureReaderCMAP>());
-    TextureWriter::ref().addWriter(std::make_unique<TextureWriterSTB>());
     ModelReader::ref().addReader(std::make_unique<ModelReaderAssimp>());
     ModelReader::ref().addReader(std::make_unique<ModelReaderBinary>());
 }

--- a/src/rendering/texturecomponent.cpp
+++ b/src/rendering/texturecomponent.cpp
@@ -70,7 +70,7 @@ void TextureComponent::loadFromFile(const std::filesystem::path& path) {
         return;
     }
 
-    _texture = ghoul::io::TextureReader::ref().loadTexture(
+    _texture = ghoul::io::TextureReader::loadTexture(
         path,
         _nDimensions,
         ghoul::opengl::Texture::SamplerInit {

--- a/src/rendering/texturecomponent.cpp
+++ b/src/rendering/texturecomponent.cpp
@@ -70,7 +70,7 @@ void TextureComponent::loadFromFile(const std::filesystem::path& path) {
         return;
     }
 
-    _texture = ghoul::io::TextureReader::loadTexture(
+    _texture = ghoul::io::texture::loadTexture(
         path,
         _nDimensions,
         ghoul::opengl::Texture::SamplerInit {

--- a/src/rendering/transferfunction.cpp
+++ b/src/rendering/transferfunction.cpp
@@ -212,7 +212,7 @@ void TransferFunction::setTextureFromTxt() {
 }
 
 void TransferFunction::setTextureFromImage() {
-    _texture = ghoul::io::TextureReader::loadTexture(
+    _texture = ghoul::io::texture::loadTexture(
         _filepath,
         1,
         { .wrapping = ghoul::opengl::Texture::WrappingMode::ClampToEdge }

--- a/src/rendering/transferfunction.cpp
+++ b/src/rendering/transferfunction.cpp
@@ -212,7 +212,7 @@ void TransferFunction::setTextureFromTxt() {
 }
 
 void TransferFunction::setTextureFromImage() {
-    _texture = ghoul::io::TextureReader::ref().loadTexture(
+    _texture = ghoul::io::TextureReader::loadTexture(
         _filepath,
         1,
         { .wrapping = ghoul::opengl::Texture::WrappingMode::ClampToEdge }

--- a/src/rendering/transferfunction.cpp
+++ b/src/rendering/transferfunction.cpp
@@ -24,9 +24,9 @@
 
 #include <openspace/rendering/transferfunction.h>
 
+#include <openspace/data/colormaploader.h>
 #include <ghoul/filesystem/file.h>
 #include <ghoul/filesystem/filesystem.h>
-#include <ghoul/io/texture/texturereader.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/exception.h>
 #include <ghoul/misc/stringhelper.h>
@@ -212,9 +212,8 @@ void TransferFunction::setTextureFromTxt() {
 }
 
 void TransferFunction::setTextureFromImage() {
-    _texture = ghoul::io::texture::loadTexture(
+    _texture = dataloader::colormap::loadColorMapTexture(
         _filepath,
-        1,
         { .wrapping = ghoul::opengl::Texture::WrappingMode::ClampToEdge }
     );
 }


### PR DESCRIPTION
Makes the corresponding changes for this Ghoul PR: https://github.com/OpenSpace/Ghoul/pull/132

And also revives the support for reading .cmap files as textures, which used to be part of the texture reader code. Reading color maps as textures is now done using the `openspace::dataloader::colormap::loadColorMapTexture` function, which supports both .cmap files and regular 1D images
* Note that this implementation is very _minimal_, just to make it work as it did before. It should be cleaned up whenever we get to refactoring the color map implementation
* But what's nice is that it now uses the same loading code as the .cmap 

I changed to `loadColorMapTexture` for `RenderableGaiaStars` and `RenderableStars`, since I know we load .cmap files as textures for those. If you know of any more places where this is needed, please let me know!
- Edit: Included `RenderableVectorFiled`, `TransferFunction`, and `TemporalTileProvider`'s color map for interpolation

Nothing should have changed in terms of visuals or functionality. 