### PR TITLE
Use new relay server for Celestrak

### DIFF
--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/amateur.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/amateur.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Amateur Radio)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_amateur_radio",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=amateur&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=amateur&FORMAT=kvn",
   Filename = "amateur.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/amateur.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/amateur.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Amateur Radio)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_amateur_radio",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=amateur&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=amateur&FORMAT=kvn",
   Filename = "amateur.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/experimental.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/experimental.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Experimental)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_x-comm",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=x-comm&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=x-comm&FORMAT=kvn",
   Filename = "x-comm.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/experimental.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/experimental.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Experimental)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_x-comm",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=x-comm&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=x-comm&FORMAT=kvn",
   Filename = "x-comm.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/geostationary.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/geostationary.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Geostationary)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_geo",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=geo&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=geo&FORMAT=kvn",
   Filename = "geo.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/geostationary.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/geostationary.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Geostationary)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_geo",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=geo&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=geo&FORMAT=kvn",
   Filename = "geo.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/globalstar.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/globalstar.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (GlobalStar)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_globalstar",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=globalstar&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=globalstar&FORMAT=kvn",
   Filename = "globalstar.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/globalstar.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/globalstar.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (GlobalStar)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_globalstar",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=globalstar&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=globalstar&FORMAT=kvn",
   Filename = "globalstar.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/gorizont.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/gorizont.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Gorizont)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_gorizont",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=gorizont&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=gorizont&FORMAT=kvn",
   Filename = "gorizont.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/gorizont.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/gorizont.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Gorizont)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_gorizont",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=gorizont&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=gorizont&FORMAT=kvn",
   Filename = "gorizont.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/intelsat.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/intelsat.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Intelsat)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_intelsat",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=intelsat&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=intelsat&FORMAT=kvn",
   Filename = "intelsat.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/intelsat.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/intelsat.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Intelsat)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_intelsat",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=intelsat&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=intelsat&FORMAT=kvn",
   Filename = "intelsat.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Iridium)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iridium",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=iridium&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=iridium&FORMAT=kvn",
   Filename = "iridium.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Iridium)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iridium",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=iridium&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=iridium&FORMAT=kvn",
   Filename = "iridium.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium_next.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium_next.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Iridium NEXT)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iridium-NEXT",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=iridium-NEXT&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=iridium-NEXT&FORMAT=kvn",
   Filename = "iridium-NEXT.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium_next.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/iridium_next.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Iridium NEXT)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iridium-NEXT",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=iridium-NEXT&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=iridium-NEXT&FORMAT=kvn",
   Filename = "iridium-NEXT.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/kuiper.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/kuiper.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Kuiper)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_kuiper",
-  Url = "https://celestrak.org/NORAD/elements/supplemental/sup-gp.php?FILE=kuiper&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=kuiper&FORMAT=kvn",
   Filename = "kuiper.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/kuiper.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/kuiper.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Kuiper)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_kuiper",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=kuiper&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=kuiper&FORMAT=kvn",
   Filename = "kuiper.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/molniya.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/molniya.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Molniya)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_molniya",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=molniya&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=molniya&FORMAT=kvn",
   Filename = "molniya.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/molniya.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/molniya.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Molniya)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_molniya",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=molniya&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=molniya&FORMAT=kvn",
   Filename = "molniya.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/orbcomm.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/orbcomm.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Orbcomm)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_orbcomm",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=orbcomm&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=orbcomm&FORMAT=kvn",
   Filename = "orbcomm.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/orbcomm.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/orbcomm.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Orbcomm)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_orbcomm",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=orbcomm&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=orbcomm&FORMAT=kvn",
   Filename = "orbcomm.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/other_comm.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/other_comm.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Other comm)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_other-comm",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=other-comm&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=other-comm&FORMAT=kvn",
   Filename = "other-comm.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/other_comm.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/other_comm.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Other comm)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_other-comm",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=other-comm&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=other-comm&FORMAT=kvn",
   Filename = "other-comm.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/raduga.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/raduga.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Raduga)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_raduga",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=raduga&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=raduga&FORMAT=kvn",
   Filename = "raduga.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/raduga.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/raduga.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Raduga)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_raduga",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=raduga&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=raduga&FORMAT=kvn",
   Filename = "raduga.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/ses.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/ses.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (SES)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_ses",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=ses&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=ses&FORMAT=kvn",
   Filename = "ses.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/ses.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/ses.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (SES)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_ses",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=ses&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=ses&FORMAT=kvn",
   Filename = "ses.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/starlink.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/starlink.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Starlink)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_starlink",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=starlink&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=starlink&FORMAT=kvn",
   Filename = "starlink.txt",
   -- The starlink satellites are updated every 2 hours. We reduce this update rate to
   -- every 4 hours to ease the load on the servers a bit

--- a/data/assets/scene/solarsystem/planets/earth/satellites/communications/starlink.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/communications/starlink.asset
@@ -6,9 +6,11 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Starlink)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_starlink",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=starlink&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=starlink&FORMAT=kvn",
   Filename = "starlink.txt",
-  SecondsUntilResync = openspace.time.secondsPerDay()
+  -- The starlink satellites are updated every 2 hours. We reduce this update rate to
+  -- every 4 hours to ease the load on the servers a bit
+  SecondsUntilResync = 4 * 60 * 60
 })
 
 

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_breezem.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_breezem.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Breeze-M Breakup)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_2012-044",
-  Url = "https://relay.openspaceproject.com/celestrak?INTDES=2012-044&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?INTDES=2012-044&FORMAT=kvn",
   Filename = "2012-044.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_breezem.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_breezem.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Breeze-M Breakup)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_2012-044",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?INTDES=2012-044&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?INTDES=2012-044&FORMAT=kvn",
   Filename = "2012-044.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_fengyun.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_fengyun.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Fengyun Debris)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_1999-025",
-  Url = "https://relay.openspaceproject.com/celestrak?INTDES=1999-025&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?INTDES=1999-025&FORMAT=kvn",
   Filename = "1999-025.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_fengyun.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_fengyun.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Fengyun Debris)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_1999-025",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?INTDES=1999-025&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?INTDES=1999-025&FORMAT=kvn",
   Filename = "1999-025.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_iridium33.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_iridium33.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Iridium 33 Debris)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iridium-33-debris",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=iridium-33-debris&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=iridium-33-debris&FORMAT=kvn",
   Filename = "iridium-33-debris.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_iridium33.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_iridium33.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Iridium 33 Debris)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iridium-33-debris",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=iridium-33-debris&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=iridium-33-debris&FORMAT=kvn",
   Filename = "iridium-33-debris.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_kosmos2251.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_kosmos2251.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Kosmos 2251 Debris)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_cosmos-2251-debris",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=cosmos-2251-debris&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=cosmos-2251-debris&FORMAT=kvn",
   Filename = "cosmos-2251-debris.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_kosmos2251.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/debris/debris_kosmos2251.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Kosmos 2251 Debris)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_cosmos-2251-debris",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=cosmos-2251-debris&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=cosmos-2251-debris&FORMAT=kvn",
   Filename = "cosmos-2251-debris.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/active.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/active.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Active)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_active",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=active&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=active&FORMAT=kvn",
   Filename = "active.txt",
   -- The active satellites are updated every 2 hours. We reduce this update rate to every
   -- 4 hours to ease the load on the servers a bit

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/active.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/active.asset
@@ -6,9 +6,11 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Active)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_active",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=active&FORMAT=kvn",
   Filename = "active.txt",
-  SecondsUntilResync = openspace.time.secondsPerDay()
+  -- The active satellites are updated every 2 hours. We reduce this update rate to every
+  -- 4 hours to ease the load on the servers a bit
+  SecondsUntilResync = 4 * 60 * 60
 })
 
 

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/brightest.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/brightest.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (100 Brightest)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_visual",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=visual&FORMAT=kvn",
   Filename = "visual.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/brightest.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/brightest.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (100 Brightest)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_visual",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=visual&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=visual&FORMAT=kvn",
   Filename = "visual.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/cubesats.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/cubesats.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (CubeSat)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_cubesat",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=cubesat&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=cubesat&FORMAT=kvn",
   Filename = "cubesat.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/cubesats.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/cubesats.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (CubeSat)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_cubesat",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=cubesat&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=cubesat&FORMAT=kvn",
   Filename = "cubesat.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/hubble_trail.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/hubble_trail.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Hubble)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_hst",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=20580&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=20580&FORMAT=kvn",
   Filename = "hst.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/hubble_trail.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/hubble_trail.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Hubble)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_hst",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=20580&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=20580&FORMAT=kvn",
   Filename = "hst.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -22,7 +22,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (ISS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iss",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=25544&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=25544&FORMAT=kvn",
   Filename = "ISS.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })
@@ -31,7 +31,7 @@ local tle = asset.resource({
   Name = "Satellite TLE Data (ISS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_tle_data_iss",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=25544&FORMAT=tle",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=25544&FORMAT=tle",
   Filename = "ISS.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/iss.asset
@@ -22,7 +22,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (ISS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_iss",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=25544&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=25544&FORMAT=kvn",
   Filename = "ISS.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })
@@ -31,7 +31,7 @@ local tle = asset.resource({
   Name = "Satellite TLE Data (ISS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_tle_data_iss",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=25544&FORMAT=tle",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=25544&FORMAT=tle",
   Filename = "ISS.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/military.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/military.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Military)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_military",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=military&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=military&FORMAT=kvn",
   Filename = "military.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/military.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/military.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Military)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_military",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=military&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=military&FORMAT=kvn",
   Filename = "military.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/other.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/other.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Other)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_other",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=other&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=other&FORMAT=kvn",
   Filename = "other.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/other.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/other.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Other)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_other",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=other&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=other&FORMAT=kvn",
   Filename = "other.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/radar.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/radar.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Radar Calibration)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_radar",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=radar&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=radar&FORMAT=kvn",
   Filename = "radar.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/radar.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/radar.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Radar Calibration)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_radar",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=radar&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=radar&FORMAT=kvn",
   Filename = "radar.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/spacestations.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/spacestations.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (SpaceStations)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_stations",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=stations&FORMAT=kvn",
   Filename = "stations.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/spacestations.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/spacestations.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (SpaceStations)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_stations",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=stations&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=stations&FORMAT=kvn",
   Filename = "stations.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/tiangong.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/tiangong.asset
@@ -14,7 +14,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Tiangong)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_tiangong",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=48274&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=48274&FORMAT=kvn",
   Filename = "Tiangong.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/tiangong.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/tiangong.asset
@@ -14,7 +14,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Tiangong)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_tiangong",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=48274&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=48274&FORMAT=kvn",
   Filename = "Tiangong.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/tle-new.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/tle-new.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Last 30 Days)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_tle-new",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=last-30-days&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=last-30-days&FORMAT=kvn",
   Filename = "tle-new.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/misc/tle-new.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/misc/tle-new.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Last 30 Days)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_tle-new",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=last-30-days&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=last-30-days&FORMAT=kvn",
   Filename = "tle-new.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/beidou.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/beidou.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Beidou)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_beidou",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=beidou&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=beidou&FORMAT=kvn",
   Filename = "beidou.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/beidou.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/beidou.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Beidou)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_beidou",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=beidou&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=beidou&FORMAT=kvn",
   Filename = "beidou.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/galileo.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/galileo.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Galileo)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_galileo",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=galileo&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=galileo&FORMAT=kvn",
   Filename = "galileo.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/galileo.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/galileo.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Galileo)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_galileo",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=galileo&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=galileo&FORMAT=kvn",
   Filename = "galileo.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/glosnass.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/glosnass.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Glosnass)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_glo-ops",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=glo-ops&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=glo-ops&FORMAT=kvn",
   Filename = "glo-ops.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/glosnass.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/glosnass.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Glosnass)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_glo-ops",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=glo-ops&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=glo-ops&FORMAT=kvn",
   Filename = "glo-ops.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/gps.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/gps.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (GPS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_gps-ops",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=gps-ops&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=gps-ops&FORMAT=kvn",
   Filename = "gps-ops.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/gps.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/gps.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (GPS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_gps-ops",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=gps-ops&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=gps-ops&FORMAT=kvn",
   Filename = "gps-ops.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/musson.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/musson.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Russian LEO Navigation)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_musson",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=musson&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=musson&FORMAT=kvn",
   Filename = "musson.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/musson.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/musson.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Russian LEO Navigation)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_musson",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=musson&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=musson&FORMAT=kvn",
   Filename = "musson.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/nnss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/nnss.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Navy Navigation Satellite System)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_nnss",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=nnss&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=nnss&FORMAT=kvn",
   Filename = "nnss.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/nnss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/nnss.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Navy Navigation Satellite System)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_nnss",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=nnss&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=nnss&FORMAT=kvn",
   Filename = "nnss.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/sbas.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/sbas.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Satellite Based Augmentation System)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_sbas",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=sbas&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=sbas&FORMAT=kvn",
   Filename = "sbas.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/navigation/sbas.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/navigation/sbas.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Satellite Based Augmentation System)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_sbas",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=sbas&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=sbas&FORMAT=kvn",
   Filename = "sbas.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/education.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/education.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Education)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_education",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=education&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=education&FORMAT=kvn",
   Filename = "education.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/education.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/education.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Education)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_education",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=education&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=education&FORMAT=kvn",
   Filename = "education.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/engineering.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/engineering.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Engineering)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_engineering",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=engineering&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=engineering&FORMAT=kvn",
   Filename = "engineering.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/engineering.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/engineering.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Engineering)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_engineering",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=engineering&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=engineering&FORMAT=kvn",
   Filename = "engineering.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/geodetic.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/geodetic.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Geodetic)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_geodetic",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=geodetic&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=geodetic&FORMAT=kvn",
   Filename = "geodetic.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/geodetic.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/geodetic.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Geodetic)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_geodetic",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=geodetic&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=geodetic&FORMAT=kvn",
   Filename = "geodetic.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/spaceearth.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/spaceearth.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Space & Earth Science)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_science",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=science&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=science&FORMAT=kvn",
   Filename = "science.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/science/spaceearth.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/science/spaceearth.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Space & Earth Science)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_science",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=science&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=science&FORMAT=kvn",
   Filename = "science.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/aqua.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/aqua.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Aqua)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_aqua",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=27424&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=27424&FORMAT=kvn",
   Filename = "Aqua.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/aqua.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/aqua.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Aqua)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_aqua",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=27424&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=27424&FORMAT=kvn",
   Filename = "Aqua.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/argos.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/argos.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (ARGOS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_argos",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=argos&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=argos&FORMAT=kvn",
   Filename = "argos.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/argos.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/argos.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (ARGOS)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_argos",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=argos&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=argos&FORMAT=kvn",
   Filename = "argos.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/dmc.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/dmc.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Disaster Monitoring)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_dmc",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=dmc&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=dmc&FORMAT=kvn",
   Filename = "dmc.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/dmc.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/dmc.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Disaster Monitoring)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_dmc",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=dmc&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=dmc&FORMAT=kvn",
   Filename = "dmc.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/earth_resources.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/earth_resources.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Earth Resources)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_resource",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=resource&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=resource&FORMAT=kvn",
   Filename = "resource.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/earth_resources.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/earth_resources.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Earth Resources)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_resource",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=resource&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=resource&FORMAT=kvn",
   Filename = "resource.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/goes.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/goes.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (GOES)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_goes",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=goes&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=goes&FORMAT=kvn",
   Filename = "goes.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/goes.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/goes.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (GOES)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_goes",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=goes&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=goes&FORMAT=kvn",
   Filename = "goes.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/noaa.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/noaa.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (NOAA)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_noaa",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=noaa&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=noaa&FORMAT=kvn",
   Filename = "noaa.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/noaa.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/noaa.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (NOAA)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_noaa",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=noaa&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=noaa&FORMAT=kvn",
   Filename = "noaa.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/planet.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/planet.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Planet)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_planet",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=planet&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=planet&FORMAT=kvn",
   Filename = "planet.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/planet.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/planet.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Planet)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_planet",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=planet&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=planet&FORMAT=kvn",
   Filename = "planet.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/sarsat.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/sarsat.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Search & Rescue (SARSAT))",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_sarsat",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=sarsat&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=sarsat&FORMAT=kvn",
   Filename = "sarsat.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/sarsat.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/sarsat.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Search & Rescue (SARSAT))",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_sarsat",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=sarsat&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=sarsat&FORMAT=kvn",
   Filename = "sarsat.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/snpp.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/snpp.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (SNPP)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_snpp",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=37849&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=37849&FORMAT=kvn",
   Filename = "SNPP.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/snpp.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/snpp.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (SNPP)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_snpp",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=37849&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=37849&FORMAT=kvn",
   Filename = "SNPP.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/spire.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/spire.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Spire)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_spire",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=spire&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=spire&FORMAT=kvn",
   Filename = "spire.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/spire.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/spire.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Spire)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_spire",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=spire&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=spire&FORMAT=kvn",
   Filename = "spire.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/tdrss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/tdrss.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Tracking and Data Relay Satellite System (TDRSS))",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_tdrss",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=tdrss&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=tdrss&FORMAT=kvn",
   Filename = "tdrss.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/tdrss.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/tdrss.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Tracking and Data Relay Satellite System (TDRSS))",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_tdrss",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=tdrss&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=tdrss&FORMAT=kvn",
   Filename = "tdrss.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/terra.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/terra.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Terra)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_terra",
-  Url = "https://relay.openspaceproject.com/celestrak?CATNR=25994&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?CATNR=25994&FORMAT=kvn",
   Filename = "Terra.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/terra.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/terra.asset
@@ -7,7 +7,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Terra)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_terra",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?CATNR=25994&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?CATNR=25994&FORMAT=kvn",
   Filename = "Terra.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/weather.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/weather.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Weather)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_weather",
-  Url = "http://www.celestrak.org/NORAD/elements/gp.php?GROUP=weather&FORMAT=kvn",
+  Url = "https://relay.openspaceproject.com/celestrak?GROUP=weather&FORMAT=kvn",
   Filename = "weather.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })

--- a/data/assets/scene/solarsystem/planets/earth/satellites/weather/weather.asset
+++ b/data/assets/scene/solarsystem/planets/earth/satellites/weather/weather.asset
@@ -6,7 +6,7 @@ local omm = asset.resource({
   Name = "Satellite OMM Data (Weather)",
   Type = "UrlSynchronization",
   Identifier = "satellite_omm_data_weather",
-  Url = "https://relay.openspaceproject.com/celestrak?GROUP=weather&FORMAT=kvn",
+  Url = "https://liu-se.relay.openspaceproject.com/celestrak?GROUP=weather&FORMAT=kvn",
   Filename = "weather.txt",
   SecondsUntilResync = openspace.time.secondsPerDay()
 })


### PR DESCRIPTION
New branch https://github.com/OpenSpace/OpenSpace/tree/issue/3973-celestrak that uses a new relay server set up to (i) ease load on the Celestrak server and (ii) not have the rate limiting.

The source for the relay server is here: https://github.com/openspace/relay.openspaceproject.com

Instead of requesting:
http://www.celestrak.org/NORAD/elements/gp.php?GROUP=x-comm&FORMAT=kvn

we now request:
https://relay.openspaceproject.com/celestrak?GROUP=x-comm&FORMAT=kvn

instead.  The server will only download a new copy if 12h have passed since the last request.


Every other solution was failing for some reason; the final straw was support for dome environments where multiple computers were requesting data from Celestrak from the same public IP, which meant the first computer managed to download the files correctly and the other image generators received the error message

Closes #3973