### PR TITLE
Rephrase first docs sentence to get rid of "This XX..."

### DIFF
--- a/modules/base/dashboard/dashboarditemangle.cpp
+++ b/modules/base/dashboard/dashboarditemangle.cpp
@@ -103,7 +103,7 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `DashboardItem` shows the angle between the lines `Source`->`Reference` and
+    // Shows the angle between the lines `Source`->`Reference` and
     // `Source`->`Destination`. Each of `Source`, `Reference`, and `Destination` can be
     // either the identifier of a node, the current focus node, or the position of the
     // camera. The angle cannot be calculated if two of these three items are located in

--- a/modules/base/dashboard/dashboarditemcameraorientation.cpp
+++ b/modules/base/dashboard/dashboarditemcameraorientation.cpp
@@ -34,9 +34,9 @@
 #include <ghoul/misc/profiling.h>
 
 namespace {
-    // This `DashboardItem` shows the current camera orientation in the yaw, pitch, and
-    // roll directions in degrees. Note that the camera's orientation is relative to the
-    // global coordinate system used in the system.
+    // Shows the current camera orientation in the yaw, pitch, and roll directions in
+    // degrees. Note that the camera's orientation is relative to the global coordinate
+    // system used in the system.
     struct [[codegen::Dictionary(DashboardItemCameraOrientation)]] Parameters {};
 } // namespace
 #include "dashboarditemcameraorientation_codegen.cpp"

--- a/modules/base/dashboard/dashboarditemdate.cpp
+++ b/modules/base/dashboard/dashboarditemdate.cpp
@@ -56,10 +56,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `DashboardItem` shows the current in-game simulation time. The `FormatString`
-    // and the `TimeFormat` options provide the ability to customize the output that is
-    // printed. See these two parameters for more information on how to structure the
-    // inputs.
+    // Shows the current in-game simulation time. The `FormatString` and the `TimeFormat`
+    // options provide the ability to customize the output that is printed. See these two
+    // parameters for more information on how to structure the inputs.
     struct [[codegen::Dictionary(DashboardItemDate)]] Parameters {
         // [[codegen::verbatim(FormatStringInfo.description)]]
         std::optional<std::string> formatString;

--- a/modules/base/dashboard/dashboarditemdistance.cpp
+++ b/modules/base/dashboard/dashboarditemdistance.cpp
@@ -108,11 +108,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `DashboardItem` displays the distance between two points. The points can be
-    // defined either by the location of a scene graph node, the surface of a scene graph
-    // node's bounding sphere, the location of the current focus node, or the position of
-    // the camera. These definitions can be mixed and matched to calculate any combination
-    // of positions.
+    // Displays the distance between two points. The points can be defined either by the
+    // location of a scene graph node, the surface of a scene graph node's bounding
+    // sphere, the location of the current focus node, or the position of the camera.
+    // These definitions can be mixed and matched to calculate any combination of
+    // positions.
     //
     // The resulting text can be formatted in the `FormatString` and the measurement unit
     // is chosed by changing the `Simplification` and `RequestedUnit` parameters.

--- a/modules/base/dashboard/dashboarditemelapsedtime.cpp
+++ b/modules/base/dashboard/dashboarditemelapsedtime.cpp
@@ -72,9 +72,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `DashboardItem` displays the remaining time until a provided `ReferenceTime`
-    // or the elapsed time since the `ReferenceTime`. The output can be configured through
-    // the `FormatString` and the unit that is used to display the configurable as well.
+    // Displays the remaining time until a provided `ReferenceTime` or the elapsed time
+    // since the `ReferenceTime`. The output can be configured through the `FormatString`
+    // and the unit that is used to display the configurable as well.
     struct [[codegen::Dictionary(DashboardItemElapsedTime)]] Parameters {
         // [[codegen::verbatim(FormatStringInfo.description)]]
         std::optional<std::string> formatString;

--- a/modules/base/dashboard/dashboarditemframerate.cpp
+++ b/modules/base/dashboard/dashboarditemframerate.cpp
@@ -149,9 +149,9 @@ namespace {
         }
     }
 
-    // This `DashboardItem` provides information about the current framerate at which the
-    // rendering updates. The `FrametimeType` can have different values that will show
-    // different statistical aspects of the framerate.
+    // Displays information about the current framerate at which the rendering updates.
+    // The `FrametimeType` can have different values that will show different statistical
+    // aspects of the framerate.
     //
     //   - `Deltatime`: Shows the time in milliseconds it took to render the previous
     //     frame

--- a/modules/base/dashboard/dashboarditeminputstate.cpp
+++ b/modules/base/dashboard/dashboarditeminputstate.cpp
@@ -71,8 +71,8 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `DashboardItem` shows the current state of the different methods to provide
-    // user input: keyboard, mouse, and/or joystick.
+    // Shows the current state of the different methods to provide user input: keyboard,
+    // mouse, and/or joystick.
     //
     // Each input method has the ability to be selectively disabled, meaning that all
     // inputs from that input method are ignored by the system entirely.

--- a/modules/base/dashboard/dashboarditemmission.cpp
+++ b/modules/base/dashboard/dashboarditemmission.cpp
@@ -54,9 +54,9 @@ namespace {
         return progress;
     }
 
-    // This `DashboardItem` shows information about the currently active mission. This
-    // includes information about the currently active mission phase, the next phase, and
-    // all subphases of the currently active phase.
+    // Shows information about the currently active mission. This includes information
+    // about the currently active mission phase, the next phase, and all subphases of the
+    // currently active phase.
     struct [[codegen::Dictionary(DashboardItemMission)]] Parameters {};
 } // namespace
 #include "dashboarditemmission_codegen.cpp"

--- a/modules/base/dashboard/dashboarditemparallelconnection.cpp
+++ b/modules/base/dashboard/dashboarditemparallelconnection.cpp
@@ -33,11 +33,10 @@
 #include <ghoul/misc/profiling.h>
 
 namespace {
-    // This `DashboardItem` displays information about the status of the parallel
-    // connection, which is whether OpenSpace is directly connected to other OpenSpace
-    // instances and can either control those instances or be controlled by the master of
-    // the session. If OpenSpace is not connected, this `DashboardItem` will not display
-    // anything.
+    // Displays information about the status of the parallel connection, which is whether
+    // OpenSpace is directly connected to other OpenSpace instances and can either control
+    // those instances or be controlled by the master of the session. If OpenSpace is not
+    // connected, this `DashboardItem` will not display anything.
     //
     // The information presented contains how many clients are connected to the same
     // session and whether this machine is currently the host of the session.

--- a/modules/base/dashboard/dashboarditempropertyvalue.cpp
+++ b/modules/base/dashboard/dashboarditempropertyvalue.cpp
@@ -76,9 +76,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `DashboardItem` will show the value of the provided property. Depending on the
-    // type of the property, the `DisplayString` will have to be adapted. See the
-    // documentation for the `DisplayString` for more information.
+    // Shows the value of the provided property. Depending on the type of the property,
+    // the `DisplayString` will have to be adapted. See the documentation for the
+    // `DisplayString` for more information.
     struct [[codegen::Dictionary(DashboardItemPropertyValue)]] Parameters {
         // [[codegen::verbatim(PropertyUriInfo.description)]]
         std::optional<std::string> uri [[codegen::key("URI")]];

--- a/modules/base/dashboard/dashboarditemsimulationincrement.cpp
+++ b/modules/base/dashboard/dashboarditemsimulationincrement.cpp
@@ -93,10 +93,10 @@ namespace {
         return res;
     }
 
-    // This `DashboardItem` shows how fast the in-game time progresses. The display string
-    // for the `RegularFormat` is used when the current simulation increment is not
-    // changing, the `TransitionFormat` is used if the simulation increment is currently
-    // interpolating to a new value.
+    // Shows how fast the in-game time progresses. The display string for the
+    // `RegularFormat` is used when the current simulation increment is not changing, the
+    // `TransitionFormat` is used if the simulation increment is currently interpolating
+    // to a new value.
     struct [[codegen::Dictionary(DashboardItemSimulationIncrement)]] Parameters {
         // [[codegen::verbatim(SimplificationInfo.description)]]
         std::optional<bool> simplification;

--- a/modules/base/dashboard/dashboarditemspacing.cpp
+++ b/modules/base/dashboard/dashboarditemspacing.cpp
@@ -39,8 +39,7 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `DashboardItem` adds a variable amount of spacing between two other
-    // `DashboardItem`s.
+    // Adds a variable amount of spacing between two other `DashboardItem`s.
     struct [[codegen::Dictionary(DashboardItemSpacing)]] Parameters {
         // [[codegen::verbatim(SpacingInfo.description)]]
         std::optional<float> spacing;

--- a/modules/base/dashboard/dashboarditemtext.cpp
+++ b/modules/base/dashboard/dashboarditemtext.cpp
@@ -38,7 +38,6 @@ namespace {
         Property::Visibility::User
     };
 
-    //
     struct [[codegen::Dictionary(DashboardItemText)]] Parameters {
         // [[codegen::verbatim(TextInfo.description)]]
         std::optional<std::string> text;

--- a/modules/base/dashboard/dashboarditemtext.cpp
+++ b/modules/base/dashboard/dashboarditemtext.cpp
@@ -38,6 +38,7 @@ namespace {
         Property::Visibility::User
     };
 
+    //
     struct [[codegen::Dictionary(DashboardItemText)]] Parameters {
         // [[codegen::verbatim(TextInfo.description)]]
         std::optional<std::string> text;

--- a/modules/base/lightsource/cameralightsource.cpp
+++ b/modules/base/lightsource/cameralightsource.cpp
@@ -39,9 +39,8 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // This `LightSource` type represents a light source placed at the position of the
-    // camera. An object with this light source will always be illuminated from the
-    // current view direction.
+    // Represents a light source placed at the position of the camera. An object with
+    // this light source will always be illuminated from the current view direction.
     struct [[codegen::Dictionary(CameraLightSource)]] Parameters {
         // [[codegen::verbatim(IntensityInfo.description)]]
         std::optional<float> intensity;

--- a/modules/base/lightsource/scenegraphlightsource.cpp
+++ b/modules/base/lightsource/scenegraphlightsource.cpp
@@ -50,9 +50,9 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `LightSource` type represents a light source placed at the position of a scene
-    // graph node. That is, the direction of the light will follow the position of an
-    // existing object in the scene. It will also update dynamically as the object moves.
+    // Represents a light source placed at the position of a scene graph node. That is,
+    // the direction of the light will follow the position of an existing object in the
+    // scene. It will also update dynamically as the object moves.
     //
     // Note that the brightness of the light from the light source does not depend on the
     // distance between the two scene graph nodes. Only the `Intensity` value has an

--- a/modules/base/rendering/grids/renderableboxgrid.cpp
+++ b/modules/base/rendering/grids/renderableboxgrid.cpp
@@ -60,7 +60,7 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // A RenderableBoxGrid creates a 3D box that is rendered using grid lines.
+    // Creates a 3D box that is rendered using grid lines.
     //
     // Per default the box is given a uniform size of 1x1x1 meters. It can then be scaled
     // to the desired size. Alternatively, the size in each dimension can be specified.

--- a/modules/base/rendering/grids/renderablegrid.cpp
+++ b/modules/base/rendering/grids/renderablegrid.cpp
@@ -97,8 +97,8 @@ namespace {
         "The labels for the grid."
     };
 
-    // This `Renderable` can be used to create a planar grid, to for example illustrate
-    // distances in 3D space.
+    // Creates a planar grid, that can be useful to for example illustrate distances in 3D
+    // space.
     //
     // The grid is created by specifying a size and how many segments to split each
     // dimension into. A secondary color can be used to highlight grid lines with a given

--- a/modules/base/rendering/grids/renderableradialgrid.cpp
+++ b/modules/base/rendering/grids/renderableradialgrid.cpp
@@ -85,8 +85,8 @@ namespace {
         "The labels for the grid."
     };
 
-    // This `Renderable` creates a planar circular grid with a given size. Optionally, it
-    // may have a hole in the center.
+    // Creates a planar circular grid with a given size. Optionally, it may have a hole in
+    // the center.
     //
     // The size is determined by two radii values: The first (inner) radius defines the
     // hole in the center. The second (outer) radius defines the full grid size. To create

--- a/modules/base/rendering/grids/renderablesphericalgrid.cpp
+++ b/modules/base/rendering/grids/renderablesphericalgrid.cpp
@@ -79,9 +79,11 @@ namespace {
         "The labels for the grid."
     };
 
-    // This `Renderable` creates a grid in the shape of a sphere. Note that the sphere
-    // will always be given a radius of one meter. To change its size, use a `Scale`
-    // transform, such as the [StaticScale](#base_scale_static).
+    // Creates a grid with a spherical shape, given a number of segments in the latitude
+    // and longitude direction.
+    //
+    // Note that the sphere will always be given a radius of one meter. To change its
+    // size, use a `Scale` transform, such as the [StaticScale](#base_scale_static).
     //
     // The grid may be split up into equal segments in both directions using the
     // `Segments` parameter, or different number of segments in the latitudal and

--- a/modules/base/rendering/pointcloud/renderablepointcloud.cpp
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.cpp
@@ -299,11 +299,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // A RenderablePointCloud can be used to render point-based datasets in 3D space,
-    // optionally including color mapping, a sprite texture and labels. There are several
-    // properties that affect the visuals of the points, such as settings for scaling,
-    // fading, sprite texture, color mapping and whether the colors of overlapping points
-    // should be blended additively or not.
+    // Can be used to render point-based datasets in 3D space, optionally including color
+    // mapping, a sprite texture and labels. There are several properties that affect the
+    // visuals of the points, such as settings for scaling, fading, sprite texture, color
+    // mapping and whether the colors of overlapping points should be blended additively
+    // or not.
     //
     // The points are rendered as planes whose size depends on a few different things:
     //

--- a/modules/base/rendering/pointcloud/sizemappingcomponent.cpp
+++ b/modules/base/rendering/pointcloud/sizemappingcomponent.cpp
@@ -72,9 +72,9 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // SizeMappingComponent is a reusable point-cloud helper that controls how per-point
-    // data influences rendered point size. It is intended for datasets where point size
-    // should convey meaning instead of remaining visually uniform.
+    // A reusable component for point-cloud rendering that controls how per-point data
+    // influences rendered point size. It is intended for datasets where point size should
+    // convey meaning instead of remaining visually uniform.
     //
     // When enabled, the component selects one data parameter from the loaded dataset and
     // uses that value as a multiplicative size input for each point. This makes it

--- a/modules/base/rendering/renderablecartesianaxes.cpp
+++ b/modules/base/rendering/renderablecartesianaxes.cpp
@@ -61,10 +61,9 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // The RenderableCartesianAxes can be used to render the local Cartesian coordinate
-    // system, or reference frame, of another scene graph node. The colors of the axes can
-    // be customized but are per default set to Red, Green and Blue, for the X-, Y- and
-    // Z-axis, respectively.
+    // Can be used to render the local Cartesian coordinate system, or reference frame,
+    // of another scene graph node. The colors of the axes can be customized but are per
+    // default set to Red, Green and Blue, for the X-, Y- and Z-axis, respectively.
     //
     // To add the axes, create a scene graph node with the RenderableCartesianAxes
     // renderable and add it as a child to the other scene graph node, i.e. specify the

--- a/modules/base/rendering/renderabledisc.cpp
+++ b/modules/base/rendering/renderabledisc.cpp
@@ -65,8 +65,7 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This renderable can be used to create a circular disc that is colored based on a
-    // one-dimensional texture.
+    // Renders a circular disc that is colored based on a one-dimensional texture.
     //
     // The disc will be filled i.e. a full circle, per default, but may also be made with
     // a hole in the center using the `Width` parameter.

--- a/modules/base/rendering/renderabledistancelabel.cpp
+++ b/modules/base/rendering/renderabledistancelabel.cpp
@@ -72,9 +72,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Renderable` creates a label that shows the distance between two nodes, based
-    // on an existing [RenderableNodeLine](#base_renderable_nodeline). The label will be
-    // placed halfway between the two scene graph nodes that the line connects.
+    // Creates a label that shows the distance between two nodes, based on an existing
+    // [RenderableNodeLine](#base_renderable_nodeline). The label will be placed halfway
+    // between the two scene graph nodes that the line connects.
     //
     // The unit in which the distance is displayed can be customized, as well as the
     // precision of the number.

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -206,11 +206,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Renderable` shows a three-dimensional model. The provided model may contain
-    // textures and animations and is affected by the optionally-provided light sources.
-    // Each model's scale can be adapted by the `ModelScale` and `InvertModelScale`
-    // parameters to account for discrepancies in the units that a model was created in.
-    // See the Documentation page "Scaling of models" for more detailed information.
+    // Renders a 3D model. The provided model may contain textures and animations and is
+    // affected by the optionally-provided light sources. Each model's scale can be
+    // adapted by the `ModelScale` and `InvertModelScale` parameters to account for
+    // discrepancies in the units that a model was created in. See the Documentation
+    // page "Scaling of models" for more detailed information.
     //
     // Limitation: At the time, only animations of the "Keyframe" type are supported. See
     // each specific model format to see if it supports that type of animation.

--- a/modules/base/rendering/renderablenodearrow.cpp
+++ b/modules/base/rendering/renderablenodearrow.cpp
@@ -204,8 +204,8 @@ namespace {
         }
     }
 
-    // A RenderableNodeArrow can be used to create a 3D arrow pointing in the direction
-    // of one scene graph node to another.
+    // Can be used to create a 3D arrow pointing in the direction from one scene graph
+    // node to another.
     //
     // The arrow will be placed at the `StartNode` at a distance of the provided `Offset`
     // value. Per default, the `Length` and `Offset` of the arrow is specified in meters,

--- a/modules/base/rendering/renderablenodeline.cpp
+++ b/modules/base/rendering/renderablenodeline.cpp
@@ -122,8 +122,8 @@ namespace {
         return diffPos;
     }
 
-    // This `Renderable` connects two scene graph nodes by drawing a line between them.
-    // The line will update dynamically if the position of the nodes change.
+    // Connects two scene graph nodes by drawing a line between them. The line will update
+    // dynamically if the position of the nodes change.
     //
     // One use case for the `RenderableNodeLine` is to visualize the distance between two
     // objects. For this, a [RenderableDistanceLabel](#base_renderable_distancelabel) can

--- a/modules/base/rendering/renderableplane.cpp
+++ b/modules/base/rendering/renderableplane.cpp
@@ -149,10 +149,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // A `RenderablePlane` is a renderable that will shows some form of contents projected
-    // on a two-dimensional plane, which in turn is placed in three-dimensional space as
-    // any other `Renderable`. It is possible to specify the `Size` of the plane, whether
-    // it should always face the camera (`Billboard`), and other parameters shown below.
+    // Displays some form of content (usually an image) on a plane. Settable parameters
+    // include the `Size` of the plane, whether it should always face the camera
+    // (`Billboard`), and others shown below.
     struct [[codegen::Dictionary(RenderablePlane)]] Parameters {
         enum class [[codegen::map(RenderOption)]] RenderOption {
             ViewDirection [[codegen::key("Camera View Direction")]],

--- a/modules/base/rendering/renderableplaneimagelocal.cpp
+++ b/modules/base/rendering/renderableplaneimagelocal.cpp
@@ -49,8 +49,7 @@ namespace {
         Property::Visibility::User
     };
 
-    // A `RenderablePlaneImageLocal` creates a textured 3D plane, where the texture is
-    // provided by a local file on disk.
+    // Creates a textured 3D plane, where the texture is provided by a local file on disk.
     struct [[codegen::Dictionary(RenderablePlaneImageLocal)]] Parameters {
         // [[codegen::verbatim(TextureInfo.description)]]
         std::string texture;

--- a/modules/base/rendering/renderableplaneimageonline.cpp
+++ b/modules/base/rendering/renderableplaneimageonline.cpp
@@ -49,7 +49,7 @@ namespace {
     };
 
     // Creates a textured 3D plane, where the texture image is loaded from the internet
-    // though a web URL.
+    // through a web URL.
     struct [[codegen::Dictionary(RenderablePlaneImageOnline)]] Parameters {
         // [[codegen::verbatim(TextureInfo.description)]]
         std::string url [[codegen::key("URL")]];

--- a/modules/base/rendering/renderableplaneimageonline.cpp
+++ b/modules/base/rendering/renderableplaneimageonline.cpp
@@ -48,8 +48,8 @@ namespace {
         Property::Visibility::User
     };
 
-    // A `RenderablePlaneImageOnline` creates a textured 3D plane, where the texture image
-    // is loaded from the internet though a web URL.
+    // Creates a textured 3D plane, where the texture image is loaded from the internet
+    // though a web URL.
     struct [[codegen::Dictionary(RenderablePlaneImageOnline)]] Parameters {
         // [[codegen::verbatim(TextureInfo.description)]]
         std::string url [[codegen::key("URL")]];

--- a/modules/base/rendering/renderablesphere.cpp
+++ b/modules/base/rendering/renderablesphere.cpp
@@ -166,8 +166,8 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Renderable` represents a simple sphere with an image. Per default, the
-    // sphere uses an equirectangular projection for the image mapping.
+    // Creates a simple sphere textured with an image. Per default, the sphere uses an
+    // equirectangular projection for the image mapping.
     //
     // The `Orientation` parameter determines whether the provided image is shown on
     // the inside, outside, or both sides of the sphere.

--- a/modules/base/rendering/renderablesphereimagelocal.cpp
+++ b/modules/base/rendering/renderablesphereimagelocal.cpp
@@ -41,8 +41,8 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Renderable` shows a sphere with an image provided by a local file on disk. To
-    // show a sphere with an image from an online source, see
+    // Shows a sphere with an image provided by a local file on disk. To show a sphere
+    // with an image from an online source, see
     // [RenderableSphereImageOnline](#base_screenspace_imageonline).
     //
     // Per default, the sphere uses an equirectangular projection for the image mapping

--- a/modules/base/rendering/renderablesphereimageonline.cpp
+++ b/modules/base/rendering/renderablesphereimageonline.cpp
@@ -64,9 +64,9 @@ namespace {
         );
     }
 
-    // This `Renderable` shows a sphere with an image provided by an online URL. The image
-    // will be downloaded when the `Renderable` is added to a scene graph node. To show a
-    // sphere with an image from a local file, see
+    // Shows a sphere with an image provided by an online URL. The image will be
+    // downloaded when the `Renderable` is added to a scene graph node. To show a sphere
+    // with an image from a local file, see
     // [RenderableSphereImageLocal](#base_screenspace_imagelocal).
     //
     // Per default, the sphere uses an equirectangular projection for the image mapping

--- a/modules/base/rendering/renderableswitch.cpp
+++ b/modules/base/rendering/renderableswitch.cpp
@@ -41,8 +41,8 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // A RenderableSwitch can be used to render one of two renderables depending on the
-    // distance between the camera and the object's position.
+    // Can be used to render one of two renderables depending on the distance between the
+    // camera and the object's position.
     //
     // The two renderables are specified separately: `RenderableNear` and `RenderableFar`.
     // These can be any renderable types.

--- a/modules/base/rendering/screenspacedashboard.cpp
+++ b/modules/base/rendering/screenspacedashboard.cpp
@@ -48,10 +48,9 @@ namespace {
         Property::Visibility::Developer
     };
 
-    // ScreenSpaceDashboard is a screen-space renderable for displaying dashboard content
-    // as a 2D overlay on top of the scene. Unlike world-space objects, it is anchored to
-    // the screen rather than to any location in the 3D environment, which makes it
-    // suitable for HUD-style information displays.
+    // Displays dashboard content as a 2D overlay on top of the scene. Unlike world-space
+    // objects, it is anchored to the screen rather than to any location in the 3D
+    // environment, which makes it suitable for HUD-style information displays.
     //
     // The class acts as a container and renderer for [DashboardItem](#core_dashboarditem)
     // instances. These items can present textual or status-oriented information such as

--- a/modules/base/rendering/screenspacedate.cpp
+++ b/modules/base/rendering/screenspacedate.cpp
@@ -56,10 +56,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `ScreenSpaceRenderable` shows the current in-game simulation time. The
-    // `FormatString` and the `TimeFormat` options provide the ability to customize the
-    // output that is printed. See these two parameters for more information on how to
-    // structure the inputs.
+    // Shows the current in-game simulation time. The `FormatString` and the `TimeFormat`
+    // options provide the ability to customize the output that is printed. See these two
+    // parameters for more information on how to structure the inputs.
     struct [[codegen::Dictionary(ScreenSpaceTextDate)]] Parameters {
         // [[codegen::verbatim(FormatStringInfo.description)]]
         std::optional<std::string> formatString;

--- a/modules/base/rendering/screenspaceimagelocal.cpp
+++ b/modules/base/rendering/screenspaceimagelocal.cpp
@@ -49,8 +49,7 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `ScreenSpaceRenderable` can be used to display an image from a local file on
-    // disk.
+    // Displays an image from a local file on disk on a plane in screen space.
     //
     // To load an image from a web URL, see
     // [ScreenSpaceImageOnline](#base_screenspace_imageonline).

--- a/modules/base/rendering/screenspaceimageonline.cpp
+++ b/modules/base/rendering/screenspaceimageonline.cpp
@@ -48,7 +48,7 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `ScreenSpaceRenderable` can be used to display an image from a web URL.
+    // Displays an image from a web URL on a plane in screen space.
     //
     // To load an image from a local file on disk, see
     // [`ScreenSpaceImageLocal`](#base_screenspace_imagelocal).

--- a/modules/base/rendering/screenspaceinsetblackout.cpp
+++ b/modules/base/rendering/screenspaceinsetblackout.cpp
@@ -207,11 +207,10 @@ namespace {
         Property::Visibility::Developer
     };
 
-    // A ScreenSpaceInsetBlackout can be used to render a screen-space shape used to black
-    // out part of the rendering. This can be useful in a dome environment where you have
-    // a secondary presentation projector that can project on the dome surface. The
-    // blackout is used to avoid overlapping rendering between the dome projectors and the
-    // presentation projector.
+    // Renders a screen-space shape used to black out part of the rendering. This can be
+    // useful in a dome environment where you have a secondary presentation projector that
+    // can project on the dome surface. The blackout is used to avoid overlapping
+    // rendering between the dome projectors and the presentation projector.
     struct [[codegen::Dictionary(ScreenSpaceInsetBlackout)]] Parameters {
         struct BlackoutShape {
             // List of corner positions for the blackout shape. The order of corner points

--- a/modules/base/rendering/screenspacerenderablerenderable.cpp
+++ b/modules/base/rendering/screenspacerenderablerenderable.cpp
@@ -82,10 +82,9 @@ namespace {
         "Renderable."
     };
 
-    // This [ScreenSpaceRenderable](#core_screenspacerenderable) object can render any
-    // [Renderable](#core_renderable) type into an image that is shown in screen space.
-    // This can be used to display a rendered object as an overlay in front of the regular
-    // 3D rendering of the scene.
+    // Renders any [Renderable](#core_renderable) type into an image that is shown in
+    // screen space. This can be used to display a rendered object as an overlay in front
+    // of the regular 3D rendering of the scene.
     //
     // Note that to use this `ScreenSpaceRenderable`, it might be necessary to specify the
     // `size` parameter, which determines the resolution of the inset window into which

--- a/modules/base/rendering/screenspacetext.cpp
+++ b/modules/base/rendering/screenspacetext.cpp
@@ -38,6 +38,7 @@ namespace {
         Property::Visibility::User
     };
 
+    // Shows a static text that can be changed via a property.
     struct [[codegen::Dictionary(ScreenSpaceText)]] Parameters {
         // [[codegen::verbatim(TextInfo.description)]]
         std::optional<std::string> text;

--- a/modules/base/rendering/screenspacetext.cpp
+++ b/modules/base/rendering/screenspacetext.cpp
@@ -38,9 +38,7 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `ScreenSpaceRenderable` shows a static text that can be changed via a
-    // property.
-    struct [[codegen::Dictionary(DashboardItemText)]] Parameters {
+    struct [[codegen::Dictionary(ScreenSpaceText)]] Parameters {
         // [[codegen::verbatim(TextInfo.description)]]
         std::optional<std::string> text;
     };

--- a/modules/base/rendering/screenspacetimevaryingimageonline.cpp
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.cpp
@@ -54,10 +54,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `ScreenSpaceRenderable` displays an image based on the current in-game
-    // simulation time. The image shown is selected from a JSON file containing
-    // timestamp-URL pairs. The image with the closest timestamp before or equal to the
-    // current time is displayed.
+    // Displays an image based on the current in-game simulation time. The image shown is
+    // selected from a JSON file containing timestamp-URL pairs. The image with the
+    // closest timestamp before or equal to the current time is displayed.
     //
     // Example JSON format:
     // {

--- a/modules/base/rotation/constantrotation.cpp
+++ b/modules/base/rotation/constantrotation.cpp
@@ -47,8 +47,8 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This rotation type will cause a scene graph node to rotate about the provided axis
-    // at a fixed and constant rotation speed.
+    // Will make a scene graph node rotate about the provided axis at a fixed and constant
+    // rotation speed.
     struct [[codegen::Dictionary(ConstantRotation)]] Parameters {
         // [[codegen::verbatim(RotationInfo.description)]]
         std::optional<glm::dvec3> rotationAxis

--- a/modules/base/rotation/constantrotation.cpp
+++ b/modules/base/rotation/constantrotation.cpp
@@ -47,7 +47,7 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // Will make a scene graph node rotate about the provided axis at a fixed and constant
+    // Makes a scene graph node rotate about the provided axis at a fixed and constant
     // rotation speed.
     struct [[codegen::Dictionary(ConstantRotation)]] Parameters {
         // [[codegen::verbatim(RotationInfo.description)]]

--- a/modules/base/rotation/fixedrotation.cpp
+++ b/modules/base/rotation/fixedrotation.cpp
@@ -193,9 +193,8 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Rotation` calculates the rotation in such a way that the attached scene graph
-    // node will always be relative to some other direction or pointing at another scene
-    // graph node.
+    // Calculates the rotation in such a way that the attached scene graph node will
+    // always be relative to some other direction or pointing at another scene graph node.
     //
     // The first use-case of the `FixedRotation` needs exactly two of its three axes
     // (`XAxis`, `YAxis`, `ZAxis`) specified with the last axis being unspecified. The

--- a/modules/base/rotation/globerotation.cpp
+++ b/modules/base/rotation/globerotation.cpp
@@ -95,11 +95,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Rotation` orients the scene graph node in such a way that the y-axis points
-    // away from the provided globe, the x-axis points towards the globe's southern pole
-    // and the z-axis points in a western direction. Using this rotation generally means
-    // using the [GlobeTranslation](#base_translation_globe) to place the scene graph node
-    // at the same position for which the rotation is calculated.
+    // Orients the scene graph node in such a way that the y-axis points away from the
+    // provided globe, the x-axis points towards the globe's southern pole and the z-axis
+    // points in a western direction. Using this rotation generally means using the
+    // [GlobeTranslation](#base_translation_globe) to place the scene graph node at the
+    // same position for which the rotation is calculated.
     struct [[codegen::Dictionary(GlobeRotation)]] Parameters {
         // [[codegen::verbatim(GlobeInfo.description)]]
         std::string globe [[codegen::identifier()]];

--- a/modules/base/rotation/luarotation.cpp
+++ b/modules/base/rotation/luarotation.cpp
@@ -54,11 +54,10 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Rotation` type generates the rotation for the attached scene graph node by
-    // calling the provided Lua script to create the full matrix used to orient the scene
-    // graph node. The returned matrix must be a valid rotation matrix. The script
-    // parameter describes in greater detail how the Lua script file should be
-    // constructed.
+    // Generates the rotation for the attached scene graph node by calling the provided
+    // Lua script to create the full matrix used to orient the scene graph node. The
+    // returned matrix must be a valid rotation matrix. The script parameter describes in
+    // greater detail how the Lua script file should be constructed.
     struct [[codegen::Dictionary(LuaRotation)]] Parameters {
         // [[codegen::verbatim(ScriptInfo.description)]]
         std::filesystem::path script;

--- a/modules/base/rotation/multirotation.cpp
+++ b/modules/base/rotation/multirotation.cpp
@@ -31,9 +31,9 @@
 #include <utility>
 
 namespace {
-    // This Rotation type combines multiple individual rotations that are applied one
-    // after the other. The rotations are applied in the order in which they are specified
-    // in the `Rotations` key.
+    // Combines multiple individual rotations that are applied one after the other. The
+    // rotations are applied in the order in which they are specified in the `Rotations`
+    // key.
     struct [[codegen::Dictionary(MultiRotation)]] Parameters {
         // The list of rotations that are applied one after the other.
         std::vector<ghoul::Dictionary> rotations [[codegen::reference("core_rotation")]];

--- a/modules/base/rotation/staticrotation.cpp
+++ b/modules/base/rotation/staticrotation.cpp
@@ -60,9 +60,9 @@ namespace {
         return res;
     }
 
-    // A StaticRotation is using a fixed and constant rotation factor that does not change
-    // over time. The rotation value is provided as a property that can be changed at
-    // runtime, but it will not change automatically over time.
+    // Creates a fixed and constant rotation that does not change over time. The rotation
+    // value is provided as a property that can be changed at runtime, but it will not
+    // change automatically over time.
     struct [[codegen::Dictionary(StaticRotation)]] Parameters {
         // Stores the static rotation as a vector containing Euler angles, a quaternion
         // representation, or a rotation matrix.

--- a/modules/base/rotation/timelinerotation.cpp
+++ b/modules/base/rotation/timelinerotation.cpp
@@ -43,10 +43,10 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Rotation` uses a timeline of other `Rotation` classes to calculate the
-    // final rotation for the attached scene graph node. The current in-game time is
-    // used to determine which specific keyframe to currently use. It is also possible to
-    // interpolate between two adjacent keyframes.
+    // Uses a timeline of other `Rotation` classes to calculate the final rotation for the
+    // attached scene graph node. The current in-game time is used to determine which
+    // specific keyframe to currently use. It is also possible to interpolate between two
+    // adjacent keyframes.
     struct [[codegen::Dictionary(TimelineRotation)]] Parameters {
         // A table of keyframes, with keys formatted as YYYY-MM-DDTHH:MM:SS and values
         // that are valid Rotation objects.

--- a/modules/base/scale/luascale.cpp
+++ b/modules/base/scale/luascale.cpp
@@ -53,10 +53,10 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Scale` type generates the scale values for the attached scene graph node by
-    // calling the provided Lua script. The script must return three scaling factors, one
-    // for each principal axis. The script parameter describes in greater detail how the
-    // Lua script file should be constructed.
+    // Generates the scale values for the attached scene graph node by calling the
+    // provided Lua script. The script must return three scaling factors, one for each
+    // principal axis. The script parameter describes in greater detail how the Lua
+    // script file should be constructed.
     struct [[codegen::Dictionary(LuaScale)]] Parameters {
         // [[codegen::verbatim(ScriptInfo.description)]]
         std::filesystem::path script;

--- a/modules/base/scale/multiscale.cpp
+++ b/modules/base/scale/multiscale.cpp
@@ -31,8 +31,7 @@
 #include <utility>
 
 namespace {
-    // This Scale type combines multiple individual scale operations that are applied one
-    // after the other.
+    // Combines multiple individual scale operations that are applied one after the other.
     struct [[codegen::Dictionary(MultiScale)]] Parameters {
         // The list of scales that are applied one after the other.
         std::vector<ghoul::Dictionary> scales [[codegen::reference("core_scale")]];

--- a/modules/base/scale/nonuniformstaticscale.cpp
+++ b/modules/base/scale/nonuniformstaticscale.cpp
@@ -38,12 +38,12 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // This Scale type scales the scene graph node that it is attached to by a fixed
-    // amount that does not change over time. It is possible to change the fixed scale
-    // after starting the application, but it otherwise remains unchanged. The scaling is
-    // a simple multiplication so that a `Scale` value of 10 means that the object will be
-    // 10 times larger than its original size. In comparison to the StaticScale type, this
-    // type has the ability to scale an object by different amounts for each direction.
+    // Scales the scene graph node that it is attached to by a fixed amount that does not
+    // change over time. It is possible to change the fixed scale after starting the
+    // application, but it otherwise remains unchanged. The scaling is a simple
+    // multiplication so that a `Scale` value of 10 means that the object will be 10 times
+    // larger than its original size. In comparison to the StaticScale type, this type has
+    // the ability to scale an object by different amounts for each direction.
     //
     // This type can be used to adjust the aspect ratio of Renderable types, for example
     // to make a RenderableSphericalGrid that is not a perfect spherical grid, but a

--- a/modules/base/scale/staticscale.cpp
+++ b/modules/base/scale/staticscale.cpp
@@ -38,11 +38,11 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // This Scale type scales the scene graph node that it is attached to by a fixed
-    // amount that does not change over time. It is possible to change the fixed scale
-    // after starting the application, but it otherwise remains unchanged. The scaling is
-    // a simple multiplication so that a `Scale` value of 10 means that the object will be
-    // 10 times larger than its original size.
+    // Scales the scene graph node that it is attached to by a fixed amount that does not
+    // change over time. It is possible to change the fixed scale after starting the
+    // application, but it otherwise remains unchanged. The scaling is a simple
+    // multiplication so that a `Scale` value of 10 means that the object will be 10 times
+    // larger than its original size.
     struct [[codegen::Dictionary(StaticScale)]] Parameters {
         // [[codegen::verbatim(ScaleInfo.description)]]
         double scale;

--- a/modules/base/scale/timedependentscale.cpp
+++ b/modules/base/scale/timedependentscale.cpp
@@ -62,9 +62,9 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This Scale type provides the ability to scale an object dynamically as time in the
-    // simulation passes. The provided `ReferenceDate`, specifies when the total scale
-    // should be equal to 0 and the scales grows by `Speed` meters for every second in the
+    // Provides the ability to scale an object dynamically as time in the simulation
+    // passes. The provided `ReferenceDate`, specifies when the total scale should be
+    // equal to 0 and the scales grows by `Speed` meters for every second in the
     // simulation. If `ClampToPositive` is specified as `true`, then the resulting scale
     // will always be positive or 0 if the simulation time is before the `ReferenceDate`.
     //

--- a/modules/base/scale/timedependentscale.cpp
+++ b/modules/base/scale/timedependentscale.cpp
@@ -64,7 +64,7 @@ namespace {
 
     // Provides the ability to scale an object dynamically as time in the simulation
     // passes. The provided `ReferenceDate`, specifies when the total scale should be
-    // equal to 0 and the scales grows by `Speed` meters for every second in the
+    // equal to 0 and the scale grows by `Speed` meters for every second in the
     // simulation. If `ClampToPositive` is specified as `true`, then the resulting scale
     // will always be positive or 0 if the simulation time is before the `ReferenceDate`.
     //

--- a/modules/base/scale/timelinescale.cpp
+++ b/modules/base/scale/timelinescale.cpp
@@ -43,10 +43,10 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Scale` uses a timeline of other `Scale` classes to calculate the final
-    // scale factor for the attached scene graph node. The current in-game time is used to
-    // determine which specific keyframe to currently use. It is also possible to
-    // interpolate between two adjacent keyframes.
+    // Uses a timeline of other `Scale` classes to calculate the final scale factor for
+    // the attached scene graph node. The current in-game time is used to determine which
+    // specific keyframe to currently use. It is also possible to interpolate between two
+    // adjacent keyframes.
     struct [[codegen::Dictionary(TimelineScale)]] Parameters {
         // A table of keyframes, with keys formatted as YYYY-MM-DDTHH:MM:SS and values
         // that are valid Scale objects.

--- a/modules/base/task/convertmodeltask.cpp
+++ b/modules/base/task/convertmodeltask.cpp
@@ -30,8 +30,8 @@
 #include <ghoul/misc/dictionary.h>
 
 namespace {
-    // This task converts a 3D model format from a format that is natively supported both
-    // by OpenSpace and common 3D modelling tools and converts it into an OpenSpace
+    // Converts a 3D model format from a format that is natively supported both by
+    // OpenSpace and common 3D modelling tools and converts it into an OpenSpace
     // proprietary format that can be loaded more efficiently, but more important can be
     // distributed without violating terms of service for various 3D model hosting
     // websites.

--- a/modules/base/translation/globetranslation.cpp
+++ b/modules/base/translation/globetranslation.cpp
@@ -100,12 +100,13 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Translation` places the scene graph node at a specific location relative to
-    // another scene graph node. The position is identified via the longitude, latitude,
-    // and altitude parameters. If the provided scene graph node is a globe, the positions
-    // correspond to the native coordinate frame of that object. If it is a node without a
-    // renderable or a non-globe renderable, the latitude/longitude grid used is the
-    // node's interaction sphere.
+    // Places the scene graph node at a specific location relative to another scene graph
+    // node. The position is identified via the longitude, latitude, and altitude
+    // parameters. If the provided scene graph node is a globe, the positions correspond
+    // to the native coordinate frame of that object. If it is a node without a renderable
+    // or a non-globe renderable, the latitude/longitude grid used is the node's
+    // interaction sphere.
+    //
     // This class is useful in conjunction with the
     // [GlobeRotation](#base_rotation_globe) rotation to orient a scene graph node away
     // from the center of the body.

--- a/modules/base/translation/luatranslation.cpp
+++ b/modules/base/translation/luatranslation.cpp
@@ -53,7 +53,7 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // Generates the translation values used to offset the  attached scene graph node's
+    // Generates the translation values used to offset the attached scene graph node's
     // position by calling the provided Lua script. The script must return three
     // translation factors, one for each principal axis, each providing in meters. The
     // script parameter describes in greater detail how the Lua script file should be

--- a/modules/base/translation/luatranslation.cpp
+++ b/modules/base/translation/luatranslation.cpp
@@ -53,11 +53,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Translation` type generates the translation values used to offset the
-    // attached scene graph node's position by calling the provided Lua script. The script
-    // must return three translation factors, one for each principal axis, each providing
-    // in meters. The script parameter describes in greater detail how the Lua script file
-    // should be constructed.
+    // Generates the translation values used to offset the  attached scene graph node's
+    // position by calling the provided Lua script. The script must return three
+    // translation factors, one for each principal axis, each providing in meters. The
+    // script parameter describes in greater detail how the Lua script file should be
+    // constructed.
     struct [[codegen::Dictionary(LuaTranslation)]] Parameters {
         // [[codegen::verbatim(ScriptInfo.description)]]
         std::filesystem::path script;

--- a/modules/base/translation/multitranslation.cpp
+++ b/modules/base/translation/multitranslation.cpp
@@ -31,8 +31,7 @@
 #include <utility>
 
 namespace {
-    // This Translation type combines multiple translations that are applied one after the
-    // other.
+    // Combines multiple translations that are applied one after the other.
     struct [[codegen::Dictionary(MultiTranslation)]] Parameters {
         // The list of translations that are applied one after the other.
         std::vector<ghoul::Dictionary> translations

--- a/modules/base/translation/statictranslation.cpp
+++ b/modules/base/translation/statictranslation.cpp
@@ -38,8 +38,8 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Translation` provides a fixed translation to the attached scene graph node
-    // that does not change unless the `Position` property is changed.
+    // Provides a fixed translation to the attached scene graph node that does not change
+    // unless the `Position` property is changed.
     struct [[codegen::Dictionary(StaticTranslation)]] Parameters {
         // [[codegen::verbatim(PositionInfo.description)]]
         glm::dvec3 position;

--- a/modules/base/translation/timelinetranslation.cpp
+++ b/modules/base/translation/timelinetranslation.cpp
@@ -43,11 +43,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Translation` uses a timeline of other `Translation` classes to calculate the
-    // final translation for the attached scene graph node. The current in-game time is
-    // used to determine which specific keyframe to currently use. It is also possible to
-    // disable the interpolation between two adjacent keyframes by setting the
-    // `ShouldInterpolate` parameter to `false`.
+    // Uses a timeline of other `Translation` classes to calculate the final translation
+    // for the attached scene graph node. The current in-game time is used to determine
+    // which specific keyframe to currently use. It is also possible to disable the
+    // interpolation between two adjacent keyframes by setting the `ShouldInterpolate`
+    // parameter to `false`.
     struct [[codegen::Dictionary(TimelineTranslation)]] Parameters {
         // A table of keyframes, with keys formatted as YYYY-MM-DDTHH:MM:SS and values
         // that are valid Translation objects.

--- a/modules/debugging/rendering/screenspacedebugplane.cpp
+++ b/modules/debugging/rendering/screenspacedebugplane.cpp
@@ -39,8 +39,8 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `ScreenSpaceRenderable` can be used for debugging OpenGL textures. It renders
-    // the content of an existing texture, based on a provided OpenGL texture name.
+    // Useful for debugging OpenGL textures. It renders the content of an existing
+    // texture, based on a provided OpenGL texture name.
     struct [[codegen::Dictionary(ScreenSpaceDebugPlane)]] Parameters {
         // [[codegen::verbatim(TextureInfo.description)]]
         std::optional<int> texture;

--- a/modules/exoplanets/tasks/exoplanetsdatapreparationtask.cpp
+++ b/modules/exoplanets/tasks/exoplanetsdatapreparationtask.cpp
@@ -42,10 +42,9 @@
 namespace {
     constexpr std::string_view _loggerCat = "ExoplanetsDataPreparationTask";
 
-    // This task is used for generating the binary data files that are used for the
-    // exoplanet system loading in OpenSpace. Using this binary file allows efficient data
-    // loading of an arbitrary exoplanet system during runtime, without keeping all data
-    // in memory.
+    // Used for generating the binary data files that are used for the exoplanet system
+    // loading in OpenSpace. Using this binary file allows efficient data loading of an
+    // arbitrary exoplanet system during runtime, without keeping all data in memory.
     //
     // Two output files are generated, whose paths have to be specified: One binary with
     // the data for the exoplanets (OutputBIN) and one look-up table that is used to find

--- a/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
+++ b/modules/fieldlinessequence/rendering/renderablefieldlinessequence.cpp
@@ -236,10 +236,9 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Renderable` visualizes field lines, mainly a sequence of time steps but works
-    // with only one time step, too. A sequence is a data source consisting of multiple
-    // data files that each correspond to a specific time and is therefore time varying
-    // like the name of the renderable suggests.
+    // Visualizes field lines, typically across a sequence of time steps, but also
+    // supports a single step. A sequence is a data source consisting of multiple data
+    // files that each correspond to a specific time.
     //
     // `LoadingType` can be specified in two ways;
     //

--- a/modules/fitsfilereader/src/renderabletimevaryingfitssphere.cpp
+++ b/modules/fitsfilereader/src/renderabletimevaryingfitssphere.cpp
@@ -130,10 +130,9 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `Renderable` reads a data sequence from specifically FITS files and makes
-    // textures from them and wraps them onto a sphere. A sequence is a data source
-    // consisting of multiple data files that each correspond to a specific time and is
-    // therefore time varying like the name of the renderable suggests.
+    // Reads a data sequence from specifically FITS files, makes textures from them, and
+    // wraps them onto a sphere. A sequence is a data source consisting of multiple data
+    // files that each correspond to a specific time.
     //
     // `LoadingType` can be specified in two ways;
     //

--- a/modules/gaia/tasks/readfitstask.cpp
+++ b/modules/gaia/tasks/readfitstask.cpp
@@ -45,12 +45,12 @@ namespace {
     constexpr std::string_view _loggerCat = "ReadFitsTask";
 
     struct [[codegen::Dictionary(ReadFitsTask)]] Parameters {
-        // If SingleFileProcess is set to true then this specifies the path to a single
+        // If `SingleFileProcess` is set to true then this specifies the path to a single
         // FITS file that will be read. Otherwise it specifies the path to a folder with
         // multiple FITS files that are to be read.
         std::string inFileOrFolderPath;
 
-        // If SingleFileProcess is set to true then this specifies the name (including
+        // If `SingleFileProcess` is set to true then this specifies the name (including
         // entire path) to the output file. Otherwise it specifies the path to the output
         // folder which to export binary star data to.
         std::string outFileOrFolderPath;

--- a/modules/globebrowsing/src/dashboarditemglobelocation.cpp
+++ b/modules/globebrowsing/src/dashboarditemglobelocation.cpp
@@ -56,12 +56,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This `DashboardItem` shows the longitude/latitude location of the camera and its
-    // distance to the current focus node. If the current focus node is Earth, these are
-    // provided in the WGS84 reference frame; if the focus is on another planetary body,
-    // it is in the native coordinate frame for that planetary body. If the current focus
-    // node is not a planetary body, a position of (0,0) with a distance of 0 will be
-    // displayed.
+    // Shows the longitude/latitude location of the camera and its distance to the current
+    // focus node. If the current focus node is Earth, these are provided in the WGS84
+    // reference frame; if the focus is on another planetary body, it is in the native
+    // coordinate frame for that planetary body. If the current focus node is not a
+    // planetary body, a position of (0,0) with a distance of 0 will be displayed.
     struct [[codegen::Dictionary(DashboardItemGlobeLocation)]] Parameters {
         enum class DisplayFormat {
             DecimalDegrees,

--- a/modules/globebrowsing/src/layer.cpp
+++ b/modules/globebrowsing/src/layer.cpp
@@ -117,7 +117,7 @@ namespace {
         std::string identifier [[codegen::identifier()]];
 
         // A human-readable name for the user interface. If this is omitted, the
-        // identifier is used instead
+        // identifier is used instead.
         std::optional<std::string> name;
 
         // A human-readable description of the layer to be used in informational texts

--- a/modules/globebrowsing/src/renderableglobe.cpp
+++ b/modules/globebrowsing/src/renderableglobe.cpp
@@ -504,10 +504,10 @@ namespace {
         }
     }
 
-    // RenderableGlobe is responsible for rendering planets, moons, and other ellipsoidal
-    // bodies with tiled surface data. It renders a globe as an ellipsoid whose appearance
-    // is assembled dynamically from one or more layer stacks, such as color imagery,
-    // elevation data, night textures, overlays, and water masks.
+    // Used for rendering planets, moons, and other ellipsoidal bodies with tiled surface
+    // data. It renders a globe as an ellipsoid whose appearance is assembled dynamically
+    // from one or more layer stacks, such as color imagery, elevation data, night
+    // textures, overlays, and water masks.
     //
     // The class is designed for large planetary datasets that cannot be drawn as a single
     // static mesh or texture. Instead, it divides the globe into chunks and continuously

--- a/modules/globebrowsing/src/tileprovider/tileproviderbyindex.cpp
+++ b/modules/globebrowsing/src/tileprovider/tileproviderbyindex.cpp
@@ -32,12 +32,12 @@
 #include <utility>
 
 namespace {
-    // This TileProvider provides the ability to override the contents for tiles at
-    // specific indices. A default tile provider has to be specified that is used by
-    // default for the entire globe. If a tile provider is specified for a specific tile,
-    // then the default tile provide is used for all other indices and the specialized
-    // tile provider `P` is used for the specified index. Any number of specialized tile
-    // providers can be provided to overwrite specific locations on the globe.
+    // Provides the ability to override the contents for tiles at specific indices. A
+    // default tile provider has to be specified that is used by default for the entire
+    // globe. If a tile provider is specified for a specific tile, then the default tile
+    // provider is used for all other indices and the specialized  tile provider `P` is
+    // used for the specified index. Any number of specialized tile providers can be
+    // provided to overwrite specific locations on the globe.
     //
     // This tile provider can be used to, for example, show an inset image that is merged
     // with a larger globe-spanning image.

--- a/modules/globebrowsing/src/tileprovider/tileproviderbyindex.cpp
+++ b/modules/globebrowsing/src/tileprovider/tileproviderbyindex.cpp
@@ -35,7 +35,7 @@ namespace {
     // Provides the ability to override the contents for tiles at specific indices. A
     // default tile provider has to be specified that is used by default for the entire
     // globe. If a tile provider is specified for a specific tile, then the default tile
-    // provider is used for all other indices and the specialized  tile provider `P` is
+    // provider is used for all other indices and the specialized tile provider `P` is
     // used for the specified index. Any number of specialized tile providers can be
     // provided to overwrite specific locations on the globe.
     //

--- a/modules/globebrowsing/src/tileprovider/tileproviderbylevel.cpp
+++ b/modules/globebrowsing/src/tileprovider/tileproviderbylevel.cpp
@@ -33,14 +33,15 @@
 #include <utility>
 
 namespace {
-    // This tile provider will switch between different tile providers specified within
-    // based on the level of detail that is requested by the Globe. All other things being
-    // equal, this corresponds to the distance of the camera to the planet, with a closer
-    // distance resulting in a higher lever. Due to technical reasons, the available
-    // levels are in the range [2, 22] and each increase in levels corresponds to a
-    // doubling in the effective resolution. For a given requested level, the tile
-    // provider that has the largest `MaxLevel` that is not greater than the requested
-    // level will be used.
+    // Switches between different specified tile providers based on the level of detail
+    // that is requested by the Globe. All other things being equal, this corresponds to
+    // the distance of the camera to the planet, with a closer distance resulting in a
+    // higher level.
+    //
+    // Due to technical reasons, the available levels are in the range [2, 22] and each
+    // increase in levels corresponds to a doubling in the effective resolution. For a
+    // given requested level, the tile provider that has the largest `MaxLevel` that is
+    // not greater than the requested level will be used.
     struct [[codegen::Dictionary(TileProviderByLevel)]] Parameters {
         // Each collection describes a distinct layer which can be toggled at a specified
         // max level at which it is requested.

--- a/modules/molecule/src/renderablemolecule.cpp
+++ b/modules/molecule/src/renderablemolecule.cpp
@@ -183,8 +183,8 @@ namespace {
         "reached."
     };
 
-    // This `Renderable` class is used to render a single molecular system, which can be
-    // either static or dynamic. The rendering is done using the rendering engine of the
+    // Used to render a single molecular system, which can be either static or dynamic.
+    // The rendering is done using the rendering engine of the
     // [ViaMD](https://github.com/scanberg/viamd) framework. Many of the parameters are
     // described in greater detail on their [Wiki](https://github.com/scanberg/viamd/wiki)
     // page. It is possible to assign multiple representations to a molecular structure

--- a/modules/molecule/src/renderablesimulationbox.cpp
+++ b/modules/molecule/src/renderablesimulationbox.cpp
@@ -137,16 +137,16 @@ namespace {
         "Falloff exponent of the circle outlining the simulation."
     };
 
-    // This `Renderable` type is capable of rendering a number of different molecules on a
-    // moving path using periodic boundary conditions. This can be used to show, for
-    // example the distribution of different molecules or atoms in a specific spatial
-    // region, such as the atmosphere of a planet.
+
+    // Renders a molecular dynamics simulation with multiple molecule types in a periodic
+    // boundary box. This can for example be used to show the distribution of different
+    // molecules or atoms in a specific spatial region, such as a planet's atmosphere.
     //
     // Multiple molecules can be provided and for each the path containing the structural
     // data and the count of molecules has to be provided. Specifying the trajectory file
     // that describes the movement of each individual molecule in its own relative frame,
     // is optional.
-    struct [[codegen::Dictionary(RenderableMolecule)]] Parameters {
+    struct [[codegen::Dictionary(RenderableSimulationBox)]] Parameters {
         struct MoleculeData {
             // The path to a molecule file that contains the structural information for
             // the molecule.

--- a/modules/skybrowser/src/screenspaceskybrowser.cpp
+++ b/modules/skybrowser/src/screenspaceskybrowser.cpp
@@ -116,9 +116,9 @@ namespace {
         return rgbColor;
     }
 
-    // This `ScreenSpaceRenderable` is used to display a screen space window showing the
-    // integrated World Wide Telescope view. The view will be dynamically updated when
-    // interacting with the view or with images in the SkyBrowser panel.
+    // Displays a screen space window showing the integrated World Wide Telescope view.
+    // The view will be dynamically updated when interacting with the view or with images
+    // in the SkyBrowser panel.
     //
     // A `ScreenSpaceSkyBrowser` should not be created from a `.asset` file, but is rather
     // created from interacting with the SkyBrowser user interface panel. If created in

--- a/modules/space/rendering/renderableconstellationbounds.cpp
+++ b/modules/space/rendering/renderableconstellationbounds.cpp
@@ -69,9 +69,8 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // This `Renderable` type can be used to draw bounding shapes on the night sky, where
-    // each shape encapsulates a group of night sky objects, such as the stars of a
-    // constellation.
+    // Can be used to draw bounding shapes on the night sky, where each shape encapsulates
+    // a group of night sky objects, such as the stars of a constellation.
     //
     // The shapes are defined in a file where each line specifies a vertex location in RA
     // Dec coordinates on the celestial sphere. Each coordinate must also be marked with

--- a/modules/space/rendering/renderableconstellationlines.cpp
+++ b/modules/space/rendering/renderableconstellationlines.cpp
@@ -89,9 +89,7 @@ namespace {
     // @TODO (2025-01-07, emmbr) Also need to update description of names file and labels
     // as part of the labels rewrite
 
-    // This renderable can be used to draw constellations using lines. Each constellation
-    // corresponds to a group of lines between 3D positions that represent the star
-    // positions.
+    // Draws constellations as lines between 3D star positions grouped per constellation.
     //
     // Each constellation is given an abbreviation that acts as the identifier of the
     // constellation. These abbreviations can be mapped to full names in the

--- a/modules/space/rendering/renderablestars.cpp
+++ b/modules/space/rendering/renderablestars.cpp
@@ -315,12 +315,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // RenderableStars renders large star catalogs as a point-based star field using data
-    // loaded from a SPECK file or a CSV file (see
-    // [here](/building-content/point-data/data-formats) for more information on the
-    // available data formats). It is intended for astronomical datasets where each entry
-    // represents a star with position and optional physical metadata such as color index,
-    // luminosity, magnitude, and motion.
+    // Renders large star catalogs as a point-based star field using data loaded from a
+    // SPECK file or a CSV file (see [here](/building-content/point-data/data-formats)
+    // for more information on the available data formats). It is intended for
+    // astronomical datasets where each entry represents a star with position and optional
+    // physical metadata such as color index, luminosity, magnitude, and motion.
     //
     // Visually, each star is drawn as a billboarded light source made up of one or two
     // textured components: a central core and a surrounding glare.

--- a/modules/space/rendering/renderabletravelspeed.cpp
+++ b/modules/space/rendering/renderabletravelspeed.cpp
@@ -103,11 +103,10 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Renderable` can be used to visualize a certain travel speed using a line that
-    // moves at the provided speed from a start object to a target. The start position
-    // will be set from the `Parent` of this scene graph node, and the end position is
-    // set from the provided `Target` scene graph node. Per default, the speed is set to
-    // the speed of light.
+    // Visualizes a certain travel speed using a line that moves at the provided speed
+    // from a start object to a target. The start position will be set from the `Parent`
+    // of this scene graph node, and the end position is set from the provided `Target`
+    // scene graph node. Per default, the speed is set to the speed of light.
     //
     // The length of the travelling line is set based on the travel speed and can be used
     // to show more information related to the distance traveled. For example, a length

--- a/modules/space/rotation/spicerotation.cpp
+++ b/modules/space/rotation/spicerotation.cpp
@@ -65,15 +65,16 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Rotation` type uses [SPICE](https://naif.jpl.nasa.gov/naif/) kernels to
-    // provide rotation information for the attached scene graph node. SPICE is a library
-    // used by scientists and engineers to, among other tasks, plan space missions. If you
-    // are unfamiliar with SPICE, their webpage has both extensive
+    // Uses [SPICE](https://naif.jpl.nasa.gov/naif/) kernels to provide rotation
+    // information for the attached scene graph node. SPICE is a library used by
+    // scientists and engineers to, among other tasks, plan space missions.
+    //
+    // If you are unfamiliar with SPICE, their webpage has both extensive
     // [Tutorials](https://naif.jpl.nasa.gov/naif/tutorials.html) as well as
-    // [Lessions](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Lessons/) that explain
+    // [Lessons](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Lessons/) that explain
     // the system deeper. This class provides access to the
     // [pxform_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/pxform_c.html)
-    // function of the Spice library.
+    // function of the SPICE library.
     struct [[codegen::Dictionary(SpiceRotation)]] Parameters {
         // [[codegen::verbatim(SourceInfo.description)]]
         std::string sourceFrame

--- a/modules/space/translation/gptranslation.cpp
+++ b/modules/space/translation/gptranslation.cpp
@@ -33,11 +33,10 @@
 #include <optional>
 
 namespace {
-    // GPTranslation is a [Translation](#core_translation) component that defines an
-    // object's orbit from a general perturbation ("GP") element source rather than from
-    // explicitly authored Keplerian parameters. It is intended for orbit descriptions
-    // stored in common external formats such as satellite element sets and similar
-    // catalog-style orbital data products.
+    // Defines an object's orbit from a general perturbation ("GP") element source rather
+    // than from explicitly authored Keplerian parameters. It is intended for orbit
+    // descriptions stored in common external formats such as satellite element sets and
+    // similar catalog-style orbital data products.
     //
     // The implementation also supports files that contain multiple element entries. In
     // that case, a specific entry can be selected, allowing a single file to serve as a

--- a/modules/space/translation/horizonstranslation.cpp
+++ b/modules/space/translation/horizonstranslation.cpp
@@ -59,10 +59,9 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // HorizonsTranslation is a file-driven translation component that computes an
-    // object's position from ephemeris data exported from JPL Horizons. It is intended
-    // for bodies whose motion is best represented by sampled positional data over time
-    // rather than by an analytic orbit model.
+    // Computes an object's position from ephemeris data files exported from JPL Horizons.
+    // It is intended for bodies whose motion is best represented by sampled positional
+    // data over time rather than by an analytic orbit model.
     //
     // The class reads one or more Horizons text files and converts their contents into a
     // time-ordered position timeline. At runtime, it evaluates the object's position by

--- a/modules/space/translation/keplertranslation.cpp
+++ b/modules/space/translation/keplertranslation.cpp
@@ -131,15 +131,14 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // KeplerTranslation is a translation component that computes an object's position
-    // from classical Keplerian orbital elements. It is intended for bodies whose motion
-    // can be described analytically as an ellipse around a central body, using a compact
-    // orbital parameter set rather than sampled trajectory data.
-    // The class evaluates orbital motion from the standard elements that define orbit
-    // shape, orientation, and phase. From these values, it reconstructs the orbital
-    // plane, advances the object along the orbit as time progresses, and returns the
-    // corresponding 3D position in space. This makes it a foundational translation type
-    // for planets, moons, spacecraft, and other orbiting objects when an idealized
+    // Computes an object's position from classical Keplerian orbital elements. It is
+    // intended for bodies whose motion can be described analytically as an ellipse around
+    // a central body, using a compact orbital parameter set rather than sampled
+    // trajectory data. The class evaluates orbital motion from the standard elements that
+    // define orbit shape, orientation, and phase. From these values, it reconstructs the
+    // orbital plane, advances the object along the orbit as time progresses, and returns
+    // the corresponding 3D position in space. This makes it a foundational translation
+    // type for planets, moons, spacecraft, and other orbiting objects when an idealized
     // two-body style orbit is sufficient.
     //
     // A key responsibility of KeplerTranslation is converting time into orbital phase. It

--- a/modules/space/translation/spicetranslation.cpp
+++ b/modules/space/translation/spicetranslation.cpp
@@ -82,15 +82,16 @@ namespace {
         Property::Visibility::User
     };
 
-    // This `Translation` type uses [SPICE](https://naif.jpl.nasa.gov/naif/) kernels to
-    // provide translational information for the attached scene graph node. SPICE is a
-    // library used by scientists and engineers to, among other tasks, plan space
-    // missions. If you are unfamiliar with SPICE, their webpage has both extensive
+    // Uses [SPICE](https://naif.jpl.nasa.gov/naif/) kernels to provide translational
+    // information for the attached scene graph node. SPICE is a library used by
+    // scientists and engineers to, among other tasks, plan space missions.
+    //
+    // If you are unfamiliar with SPICE, their webpage has both extensive
     // [Tutorials](https://naif.jpl.nasa.gov/naif/tutorials.html) as well as
     // [Lessions](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Lessons/) that explain
     // the system deeper. This class provides access to the
     // [spkpos_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkpos_c.html)
-    // function of the Spice library.
+    // function of the SPICE library.
     struct [[codegen::Dictionary(SpiceTranslation)]] Parameters {
         // [[codegen::verbatim(TargetInfo.description)]]
         std::variant<std::string, int> target;

--- a/modules/space/translation/spicetranslation.cpp
+++ b/modules/space/translation/spicetranslation.cpp
@@ -88,7 +88,7 @@ namespace {
     //
     // If you are unfamiliar with SPICE, their webpage has both extensive
     // [Tutorials](https://naif.jpl.nasa.gov/naif/tutorials.html) as well as
-    // [Lessions](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Lessons/) that explain
+    // [Lessons](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Lessons/) that explain
     // the system deeper. This class provides access to the
     // [spkpos_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkpos_c.html)
     // function of the SPICE library.

--- a/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.cpp
+++ b/modules/spacecraftinstruments/dashboard/dashboarditeminstruments.cpp
@@ -60,12 +60,11 @@ namespace {
         Property::Visibility::User
     };
 
-    // This dashboard item shows information about the status of individual instruments
-    // onboard a spacecraft with regards to upcoming image capture. An image sequence has
-    // to be registered in order to be able to show the necessary information. The
-    // dashboard item shows a visual representation on how much time has passed since the
-    // previous image capture and how much time remains until the instrument captures the
-    // next image.
+    // Shows information about the status of individual instruments onboard a spacecraft
+    // with regards to upcoming image capture. An image sequence has to be registered in
+    // order to be able to show the necessary information. The dashboard item shows a
+    // visual representation on how much time has passed since the previous image capture
+    // and how much time remains until the instrument captures the next image.
     struct [[codegen::Dictionary(DashboardItemInstruments)]] Parameters {
         // [[codegen::verbatim(ActiveColorInfo.description)]]
         std::optional<glm::vec3> activeColor [[codegen::color()]];

--- a/modules/spacecraftinstruments/rendering/renderablefov.cpp
+++ b/modules/spacecraftinstruments/rendering/renderablefov.cpp
@@ -153,11 +153,11 @@ namespace {
         }
     }
 
-    // This Renderable type shows a visual representation of a spacecraft instrument's
-    // field-of-view. Information about the field-of-view are extracted from SPICE kernels
-    // that must be loaded with the correct information. By default a field-of-view is
-    // only visible while an instrument is active, but the field-of-view can be made
-    // visible at all times through the `AlwaysDrawFov` setting.
+    // Shows a visual representation of a spacecraft instrument's  field-of-view.
+    // Information about the field-of-view are extracted from SPICE kernels that must be
+    // loaded with the correct information. By default a field-of-view is only visible
+    // while an instrument is active, but the field-of-view can be made visible at all
+    // times through the `AlwaysDrawFov` setting.
     struct [[codegen::Dictionary(RenderableFov)]] Parameters {
         // The SPICE name of the source body for which the field of view should be
         // rendered.

--- a/modules/spacecraftinstruments/rendering/renderablefov.cpp
+++ b/modules/spacecraftinstruments/rendering/renderablefov.cpp
@@ -153,7 +153,7 @@ namespace {
         }
     }
 
-    // Shows a visual representation of a spacecraft instrument's  field-of-view.
+    // Shows a visual representation of a spacecraft instrument's field-of-view.
     // Information about the field-of-view are extracted from SPICE kernels that must be
     // loaded with the correct information. By default a field-of-view is only visible
     // while an instrument is active, but the field-of-view can be made visible at all

--- a/modules/spacecraftinstruments/rendering/renderablemodelprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderablemodelprojection.cpp
@@ -57,14 +57,13 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // Similarly to the
+    // A 3D model that acts as a projection target for spacecraft instrument images,
+    // similarly to
     // [RenderablePlaneProjection](spacecraftinstruments_renderable_planeprojection) and
-    // [RenderablePlanetProjection](spacecraftinstruments_renderable_planetprojection),
-    // this Renderable type servers as a potential target for image projections from a
-    // spacecraft's instrument. This renderable will determine whenever an image in a
-    // currently loaded image sequence is projected whether that instrument's field of
-    // view intersects this model and will correctly project the captured image onto the
-    // model.
+    // [RenderablePlanetProjection](spacecraftinstruments_renderable_planetprojection).
+    //
+    // Images from a loaded image sequence will be projected onto the model if the
+    // instrument’s field-of-view intersects it.
     struct [[codegen::Dictionary(RenderableModelProjection)]] Parameters {
         // The file or files that should be loaded, that specifies the model to load. The
         // file can contain filesystem tokens or can be specified relative to the

--- a/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplaneprojection.cpp
@@ -59,13 +59,11 @@ namespace {
         float t;
     };
 
-    // This specialized Renderable type is used as a target for projections from a
-    // spacecraft instrument. Similarly to the
-    // [RenderablePlanetProject](spacecraftinstruments_renderable_planetprojection) it
-    // uses the spacecraft's position and orientation and information about an instruments
-    // field-of-view and set of images to project a captured image. In the case of this
-    // renderable the target geometry is a two-dimensional plane that the image is
-    // projected on.
+    // A 2D plane that acts as a target for projections from a spacecraft instrument.
+    // Similarly to
+    // [RenderablePlanetProjection](spacecraftinstruments_renderable_planetprojection), it
+    // uses the spacecraft's position and orientation and information about an
+    // instrument's field-of-view to project a captured image from a set of images.
     struct [[codegen::Dictionary(RenderablePlaneProjection)]] Parameters {
         // The SPICE name of the spacecraft from which the projection is performed.
         std::string spacecraft;

--- a/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableplanetprojection.cpp
@@ -144,12 +144,12 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This Renderable serves as a potential target for images projected from a
-    // spacecraft's instrument. Images have to be loaded into an image sequence first and
-    // when it is then time to project an image into the world from the point of view of
-    // the instrument, the field-of-view will be checked against the extent of this
-    // planetary body. If the field-of-view intersects, the image gets correctly projected
-    // onto the surface.
+    // Serves as a potential target for images projected from a spacecraft's instrument,
+    // when the observed object is a planetary body. The images first have to be loaded
+    // into an image sequence and when it is then time to project an image onto the world
+    // from the point of view of the instrument, the field-of-view will be checked against
+    // the extent of this planetary body. If the field-of-view intersects, the image gets
+    // correctly projected onto the surface.
     struct [[codegen::Dictionary(RenderablePlanetProjection)]] Parameters {
         // Contains information about projecting onto this planet.
         ghoul::Dictionary projection

--- a/modules/spacecraftinstruments/rendering/renderableshadowcylinder.cpp
+++ b/modules/spacecraftinstruments/rendering/renderableshadowcylinder.cpp
@@ -111,12 +111,11 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // This Renderable displays the shadow cylinder behind a planetary body. Given the
-    // SPICE name of a planetary body and an observer, it will show a cylinder extending
-    // behind the body away from the observer to highlight the areas of space from which
-    // the observer is occluded by the body. A concrete example is using the Sun as the
-    // observer, in which case the shadow cylinder indicates the areas in which there is
-    // darkness.
+    // Displays a shadow cylinder behind a planetary body. Given the SPICE name of a
+    // planetary body and an observer, it will show a cylinder extending behind the body
+    // away from the observer to highlight the areas of space from which the observer is
+    // occluded by the body. A concrete example is using the Sun as the observer, in which
+    // case the shadow cylinder indicates the areas in which there is darkness.
     struct [[codegen::Dictionary(RenderableShadowCylinder)]] Parameters {
         // [[codegen::verbatim(NumberPointsInfo.description)]]
         std::optional<int> numberOfPoints;

--- a/modules/spout/renderableplanespout.cpp
+++ b/modules/spout/renderableplanespout.cpp
@@ -33,7 +33,7 @@
 #include <ghoul/opengl/textureunit.h>
 
 namespace {
-    // Render a plane with a texture that is provided by another application on the same
+    // Renders a plane with a texture that is provided by another application on the same
     // computer using the SPOUT library.
     //
     // Note: The SPOUT library is only available on Windows.

--- a/modules/spout/renderableplanespout.cpp
+++ b/modules/spout/renderableplanespout.cpp
@@ -33,9 +33,10 @@
 #include <ghoul/opengl/textureunit.h>
 
 namespace {
-    // This `Renderable` type can be used to render a plane with a texture that is
-    // provided by another application on the same computer using the SPOUT library.
-    // Note: The Spout library is only available on Windows.
+    // Render a plane with a texture that is provided by another application on the same
+    // computer using the SPOUT library.
+    //
+    // Note: The SPOUT library is only available on Windows.
     struct [[codegen::Dictionary(RenderablePlaneSpout)]] Parameters {};
 } // namespace
 #include "renderableplanespout_codegen.cpp"

--- a/modules/spout/renderablespherespout.cpp
+++ b/modules/spout/renderablespherespout.cpp
@@ -33,9 +33,10 @@
 #include <ghoul/opengl/textureunit.h>
 
 namespace {
-    // This `Renderable` type can be used to render a sphere with a texture that is
-    // provided by another application on the same computer using the SPOUT library.
-    // Note: The Spout library is only available on Windows.
+    // Renders a sphere with a texture that is provided by another application on the
+    // same computer using the SPOUT library.
+    //
+    // Note: The SPOUT library is only available on Windows.
     struct [[codegen::Dictionary(RenderableSphereSpout)]] Parameters {};
 } // namespace
 #include "renderablespherespout_codegen.cpp"

--- a/modules/video/src/renderablevideoplane.cpp
+++ b/modules/video/src/renderablevideoplane.cpp
@@ -32,7 +32,7 @@
 #include <limits>
 
 namespace {
-    // This `Renderable` creates a textured 3D plane where the texture is a video.
+    // Creates a textured 3D plane where the texture is a video.
     //
     // The video can either be played back based on a given simulation time
     // (`PlaybackMode` MapToSimulationTime) or through the user interface (for

--- a/modules/video/src/renderablevideosphere.cpp
+++ b/modules/video/src/renderablevideosphere.cpp
@@ -30,10 +30,10 @@
 #include <ghoul/opengl/textureunit.h>
 
 namespace {
-    // This `Renderable` creates a textured 3D sphere where the texture is a video. Per
-    // default, the sphere uses an equirectangular projection for the image mapping
-    // and hence expects a video in equirectangular format. However, it can also be used
-    // to play fisheye videos by changing the `TextureProjection`.
+    // Creates a textured 3D sphere where the texture is a video. Per default, the sphere
+    // uses an equirectangular projection for the image mapping and hence expects a video
+    // in equirectangular format. However, it can also be used to play fisheye videos by
+    // changing the `TextureProjection`.
     //
     // The video can either be played back based on a given simulation time
     // (`PlaybackMode` MapToSimulationTime) or through the user interface (for

--- a/modules/video/src/screenspacevideo.cpp
+++ b/modules/video/src/screenspacevideo.cpp
@@ -31,7 +31,7 @@
 #include <filesystem>
 
 namespace {
-    // This `ScreenSpaceRenderable` can be used to render a video in front of the camera.
+    // Can be used to render a video in front of the camera.
     //
     // The video can either be played back based on a given simulation time
     // (`PlaybackMode` MapToSimulationTime) or through the user interface (for

--- a/modules/video/src/videotileprovider.cpp
+++ b/modules/video/src/videotileprovider.cpp
@@ -36,7 +36,7 @@
 namespace {
     constexpr std::string_view _loggerCat = "VideoTileProvider";
 
-    // This `TileProvider` can be used to render a video on the globe.
+    // Renders a video on the globe.
     //
     // The video can either be played back based on a given simulation time
     // (`PlaybackMode` MapToSimulationTime) or through the user interface (for

--- a/modules/volume/rendering/renderablevectorfield.cpp
+++ b/modules/volume/rendering/renderablevectorfield.cpp
@@ -123,9 +123,8 @@ namespace {
         Property::Visibility::AdvancedUser
     };
 
-    // A RenderableVectorField can be used to render vectors from a given 3D volumetric
-    // dataset or a sparse point-like dataset, optionally including color mapping and
-    // custom filtering via Lua script.
+    // Renders vectors from a given 3D volumetric dataset or a sparse point-like dataset,
+    // optionally including color mapping and custom filtering via Lua script.
     //
     // If `mode` is set to `Volume`, the vector field is defined on a regular 3D grid
     // specified by `Dimensions`, and occupies the spatial domain defined by `MinDomain`

--- a/modules/webbrowser/src/screenspacebrowser.cpp
+++ b/modules/webbrowser/src/screenspacebrowser.cpp
@@ -79,12 +79,11 @@ namespace {
         Property::Visibility::NoviceUser
     };
 
-    // This `ScreenSpaceRenderable` can be used to render a webpage in front of the
-    // camera. This can be used to show various dynamic content, for example using the
-    // scripting API.
+    // Can be used to render a webpage in front of the camera. This can be used to show
+    // various dynamic content, for example using the scripting API.
     //
-    // Note that mouse input will not be passed to the rendered view, so it will not be
-    // possible to interact with the web page.
+    // Note that mouse or keyboard input will not be passed to the rendered view, so it
+    // will not be possible to interact with the webpage.
     struct [[codegen::Dictionary(ScreenSpaceBrowser)]] Parameters {
         // A unique identifier for this screen space browser.
         std::optional<std::string> identifier [[codegen::identifier()]];

--- a/src/navigation/navigationstate.cpp
+++ b/src/navigation/navigationstate.cpp
@@ -41,7 +41,7 @@ namespace {
 
     constexpr double Epsilon = 1E-7;
 
-    // A NavigationState is an object describing an exact camera position and rotation,
+    // A `NavigationState` is an object describing an exact camera position and rotation,
     // in a certain reference frame (per default, the one of the specified Anchor node).
     // It can be used to set the same camera position at a later point in time, or
     // navigating to a specific camera position using the pathnavigation system.
@@ -53,9 +53,9 @@ namespace {
     // To get the current navigation state of the camera, use the
     // `openspace.navigation.navigationState()` function in the Scripting API.
     //
-    // Note that when loading a NavigationState, the visuals may be different depending
+    // Note that when loading a `NavigationState`, the visuals may be different depending
     // on what the simulation timestamp is, as the relative positions of objects in the
-    // scene may have changed. The get the exact same visuals as when the NavigationState
+    // scene may have changed. The get the exact same visuals as when the`NavigationState`
     // was saved you need to also set the simulation time to correpsond to the timestamp.
     struct [[codegen::Dictionary(NavigationState)]] Parameters {
         // The identifier of the anchor node.

--- a/src/navigation/navigationstate.cpp
+++ b/src/navigation/navigationstate.cpp
@@ -55,8 +55,8 @@ namespace {
     //
     // Note that when loading a `NavigationState`, the visuals may be different depending
     // on what the simulation timestamp is, as the relative positions of objects in the
-    // scene may have changed. The get the exact same visuals as when the`NavigationState`
-    // was saved you need to also set the simulation time to correpsond to the timestamp.
+    // scene may have changed. To get the exact same visuals as when the `NavigationState`
+    // was saved you need to also set the simulation time to correspond to the timestamp.
     struct [[codegen::Dictionary(NavigationState)]] Parameters {
         // The identifier of the anchor node.
         std::string anchor;

--- a/src/navigation/path.cpp
+++ b/src/navigation/path.cpp
@@ -92,8 +92,8 @@ namespace {
     }
 
 
-    // A PathInstruction is a table describing the specification for a camera path. It is
-    // used as an input to the `openspace.pathnavigation.createPath` function.
+    // This is a table describing the specification for a camera path. It is used as an
+    // input to the `openspace.pathnavigation.createPath` function.
     //
     // There are two types of paths that can be created, as specified by the required
     // TargetType parameter: 'Node' or 'NavigationState'. The difference is what kind of

--- a/src/rendering/screenspacerenderabletext.cpp
+++ b/src/rendering/screenspacerenderabletext.cpp
@@ -50,7 +50,7 @@ namespace {
         Property::Visibility::User
     };
 
-    struct [[codegen::Dictionary(DashboardTextItem)]] Parameters {
+    struct [[codegen::Dictionary(ScreenSpaceRenderableText)]] Parameters {
         // [[codegen::verbatim(FontNameInfo.description)]]
         std::optional<std::string> fontName;
 


### PR DESCRIPTION
Reduces repetition and makes the docs easier to read. 

Skipped `TimeFrame` for now, as that required some more thinking

No need to spend time reviewing this PR, as the changes to the texts are (mostly) minimal. I made it for visibility and to have Copilot look for typos. 

Also found some copy-paste errors that results in faulty documentation for certain classes, so that's great