### PR TITLE
Fix typos in documentation comments

### DIFF
--- a/modules/base/rendering/pointcloud/renderablepointcloud.h
+++ b/modules/base/rendering/pointcloud/renderablepointcloud.h
@@ -61,7 +61,7 @@ struct TextureFormatHash {
 };
 
 /**
- * This class describes a point cloud renderable that can be used to draw billboraded
+ * This class describes a point cloud renderable that can be used to draw billboarded
  * points based on a data file with 3D positions. Alternatively the points can also be
  * colored and sized based on a separate column in the data file.
  */

--- a/modules/touch/touchmodule.h
+++ b/modules/touch/touchmodule.h
@@ -53,7 +53,7 @@ protected:
 
 private:
     /**
-     * Process TUIO touch input that occured since the last frame.
+     * Process TUIO touch input that occurred since the last frame.
      */
     void processNewInput();
 


### PR DESCRIPTION
Corrects two typos in header documentation:

- modules/base/rendering/pointcloud/renderablepointcloud.h: 'billboraded' → 'billboarded'
- modules/touch/touchmodule.h: 'occured' → 'occurred'

Small documentation-only change with no functional impact.