### PR TITLE
Add Bouncing Interpolation mode to Properties

### DIFF
--- a/include/openspace/properties/numericalproperty.inl
+++ b/include/openspace/properties/numericalproperty.inl
@@ -158,6 +158,8 @@ template <typename T>
 void NumericalProperty<T>::interpolateValue(float t,
                                             ghoul::EasingFunc<float> easingFunction)
 {
+    t = std::clamp(t, 0.f, 1.f);
+
     if (easingFunction) {
         t = easingFunction(t);
     }

--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -177,9 +177,8 @@ public:
      *        finishes
      * \param easingFunction A function that determines who the interpolation occurs
      * \param isBouncing If this value is set to `true`, the property will interpolate to
-     *        the current value, then back to the original value, until manually stopped.
-     *        In this mode, the \p postScript will be called each time the interpolation
-     *        is at the starting value or final value
+     *        the provided new value, then back to the original value, until manually
+     *        stopped.
      *
      * \pre \p prop must not be `nullptr`
      * \pre \p durationSeconds must be positive and not 0

--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -176,8 +176,8 @@ public:
      * \param postScript A Lua script that will be executed when the interpolation
      *        finishes
      * \param easingFunction A function that determines who the interpolation occurs
-     * \param isBouncing If this value is set to `true`, the property will interpolate to
-     *        the provided new value, then back to the original value, until manually
+     * \param shouldBounce If this value is set to `true`, the property will interpolate
+     *        to the provided new value, then back to the original value, until manually
      *        stopped.
      *
      * \pre \p prop must not be `nullptr`
@@ -187,7 +187,7 @@ public:
     void addPropertyInterpolation(Property* prop, float durationSeconds,
         std::string postScript = "",
         ghoul::EasingFunction easingFunction = ghoul::EasingFunction::Linear,
-        bool isBouncing = false);
+        bool shouldBounce = false);
 
     /**
      * Removes the passed \p prop from the list of Property%s that are update each time
@@ -221,7 +221,7 @@ public:
      *
      * \param prop The property whose interpolation should be stopped
      */
-    void stopInterpolation(Property* prop);
+    void stopBouncing(Property* prop);
 
     /**
      * Returns the Lua library that contains all Lua functions available to change the

--- a/include/openspace/scene/scene.h
+++ b/include/openspace/scene/scene.h
@@ -176,6 +176,10 @@ public:
      * \param postScript A Lua script that will be executed when the interpolation
      *        finishes
      * \param easingFunction A function that determines who the interpolation occurs
+     * \param isBouncing If this value is set to `true`, the property will interpolate to
+     *        the current value, then back to the original value, until manually stopped.
+     *        In this mode, the \p postScript will be called each time the interpolation
+     *        is at the starting value or final value
      *
      * \pre \p prop must not be `nullptr`
      * \pre \p durationSeconds must be positive and not 0
@@ -183,7 +187,8 @@ public:
      */
     void addPropertyInterpolation(Property* prop, float durationSeconds,
         std::string postScript = "",
-        ghoul::EasingFunction easingFunction = ghoul::EasingFunction::Linear);
+        ghoul::EasingFunction easingFunction = ghoul::EasingFunction::Linear,
+        bool isBouncing = false);
 
     /**
      * Removes the passed \p prop from the list of Property%s that are update each time
@@ -206,6 +211,18 @@ public:
      * the same for both calls.
      */
     void updateInterpolations();
+
+    /**
+     * Calling this function will cause the interpolation of the provided property to stop
+     * the next time it is at a defined state. For normal interpolation, calling this
+     * function is a noop, as the interpolation will be automatically stopped at the end
+     * of the interpolation. For bouncing interpolations, it will cause the bouncing
+     * interpolation of the property to be stopped when it reaches the original value the
+     * next time.
+     *
+     * \param prop The property whose interpolation should be stopped
+     */
+    void stopInterpolation(Property* prop);
 
     /**
      * Returns the Lua library that contains all Lua functions available to change the
@@ -304,6 +321,11 @@ private:
 
         ghoul::EasingFunc<float> easingFunction;
         bool isExpired = false;
+
+        bool isBouncing = false;
+        bool bouncingShouldStop = false;
+        float bouncingShouldStopT = -1.f;
+        std::chrono::time_point<std::chrono::steady_clock> bouncingAbortTime;
     };
     std::vector<PropertyInterpolationInfo> _propertyInterpolationInfos;
 

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -671,6 +671,9 @@ void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
             info.postScript = std::move(postScript);
             info.easingFunction = func;
             info.isBouncing = isBouncing;
+            info.bouncingShouldStop = false;
+            info.bouncingShouldStopT = -1.f;
+            info.bouncingAbortTime = std::chrono::time_point<std::chrono::steady_clock>();
             // If we found it, we can break since we make sure that each property is only
             // represented once in this
             return;
@@ -728,7 +731,7 @@ void Scene::updateInterpolations() {
         );
         const float tClamped = std::clamp(t, 0.f, 1.f);
         const float tBounce = [t]() {
-            const float tMod = fmod(t, 2.f);
+            const float tMod = std::fmod(t, 2.f);
             if (tMod <= 1.f) {
                 return tMod;
             }
@@ -798,6 +801,8 @@ void Scene::updateInterpolations() {
 }
 
 void Scene::stopInterpolation(Property* prop) {
+    ghoul_assert(prop, "No property provided");
+
     auto it = std::find_if(
         _propertyInterpolationInfos.begin(),
         _propertyInterpolationInfos.end(),
@@ -910,7 +915,7 @@ LuaLibrary Scene::luaLibrary() {
                     { "duration", "Number?", "0.0" },
                     { "easing", "EasingFunction?", "Linear" },
                     { "postscript", "String?", "" },
-                    { "isBouncing", "Boolean?", "" }
+                    { "isBouncing", "Boolean?", "false" }
                 },
                 "",
                 R"(Sets the property or properties identified by the URI to the specified
@@ -958,9 +963,7 @@ in which the parameter is interpolated. Has to be one of "Linear", "QuadraticEas
 is completed. If a duration larger than 0 was provided, it is at the end of the
 interpolation. If 0 was provided, the script runs immediately
 \\param isBouncing If this value is set to `true`, the property will interpolate to the
-current value, then back to the original value, until manually stopped. In this mode, the
-\p postScript will be called each time the interpolation is at the starting value or final
-value
+provided new value, then back to the original value, until manually stopped.
 )",
                 {
                     std::source_location::current().file_name(),
@@ -1006,9 +1009,7 @@ in which the parameter is interpolated. Has to be one of "Linear", "QuadraticEas
 change of property value is completed. If a duration larger than 0 was provided, it is
 at the end of the interpolation. If 0 was provided, the script runs immediately
 \\param isBouncing If this value is set to `true`, the property will interpolate to the
-current value, then back to the original value, until manually stopped. In this mode, the
-\p postScript will be called each time the interpolation is at the starting value or final
-value
+provided new value, then back to the original value, until manually stopped.
 )",
                 {
                     std::source_location::current().file_name(),

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -47,6 +47,7 @@
 #include <ghoul/misc/stringhelper.h>
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstring>
 #include <iterator>
 #include <limits>
@@ -640,7 +641,8 @@ SceneGraphNode* Scene::loadNode(const ghoul::Dictionary& nodeDictionary) {
 
 void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
                                      std::string postScript,
-                                     ghoul::EasingFunction easingFunction)
+                                     ghoul::EasingFunction easingFunction,
+                                     bool isBouncing)
 {
     ghoul_precondition(prop != nullptr, "prop must not be nullptr");
     ghoul_precondition(durationSeconds > 0.f, "durationSeconds must be positive");
@@ -668,6 +670,7 @@ void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
             info.durationSeconds = durationSeconds;
             info.postScript = std::move(postScript);
             info.easingFunction = func;
+            info.isBouncing = isBouncing;
             // If we found it, we can break since we make sure that each property is only
             // represented once in this
             return;
@@ -679,7 +682,8 @@ void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
         .beginTime = now,
         .durationSeconds = durationSeconds,
         .postScript = std::move(postScript),
-        .easingFunction = func
+        .easingFunction = func,
+        .isBouncing = isBouncing
     };
     _propertyInterpolationInfos.push_back(std::move(i));
 }
@@ -718,22 +722,52 @@ void Scene::updateInterpolations() {
         const long long us =
             duration_cast<std::chrono::microseconds>(now - i.beginTime).count();
 
-        const float t = std::clamp(
-            static_cast<float>(
-                static_cast<double>(us) /
-                static_cast<double>(i.durationSeconds * 1000000)
-            ),
-            0.f,
-            1.f
+        const float t = static_cast<float>(
+            static_cast<double>(us) /
+            static_cast<double>(i.durationSeconds * 1000000)
         );
+        const float tClamped = std::clamp(t, 0.f, 1.f);
+        const float tBounce = [t]() {
+            const float tMod = fmod(t, 2.f);
+            if (tMod <= 1.f) {
+                return tMod;
+            }
+            else {
+                return 2.f - tMod;
+            }
+        }();
+
+        if (i.isBouncing && i.bouncingShouldStop && i.bouncingShouldStopT == -1.f) {
+            i.bouncingShouldStopT = tBounce;
+            i.bouncingAbortTime = now;
+        }
+
+        const long long bouncingAbortUs =
+            duration_cast<std::chrono::microseconds>(now - i.bouncingAbortTime).count();
+        const float bouncingAbortT = static_cast<float>(
+            static_cast<double>(bouncingAbortUs) /
+            static_cast<double>(i.durationSeconds * 1000000)
+        );
+        const float bounceAbortT = glm::mix(i.bouncingShouldStopT, 0.f, bouncingAbortT);
+
+        const float finalT =
+            i.isBouncing ?
+            i.bouncingShouldStop ? bounceAbortT : tBounce :
+            tClamped;
+
 
         // This method might crash if someone deleted the property underneath us. We take
         // care of removing entire PropertyOwners, but we assume that Propertys live as
         // long as their SceneGraphNodes. This is true in general, but if Propertys are
         // created and destroyed often by the SceneGraphNode, this might become a problem
-        i.prop->interpolateValue(t, i.easingFunction);
+        i.prop->interpolateValue(finalT, i.easingFunction);
 
-        i.isExpired = (t == 1.f);
+        if (i.isBouncing) {
+            i.isExpired = i.bouncingShouldStop && (finalT < 0.f || finalT > 1.f);
+        }
+        else {
+            i.isExpired = (t >= 1.f);
+        }
 
         if (i.isExpired) {
             if (!i.postScript.empty()) {
@@ -761,6 +795,22 @@ void Scene::updateInterpolations() {
         ),
         _propertyInterpolationInfos.end()
     );
+}
+
+void Scene::stopInterpolation(Property* prop) {
+    auto it = std::find_if(
+        _propertyInterpolationInfos.begin(),
+        _propertyInterpolationInfos.end(),
+        [prop](const PropertyInterpolationInfo& info) { return info.prop == prop; }
+    );
+
+    if (it == _propertyInterpolationInfos.end()) {
+        throw ghoul::RuntimeError(std::format(
+            "The provided property '{}' is not interpolating", prop->uri()
+        ));
+    }
+
+    it->bouncingShouldStop = true;
 }
 
 void Scene::setPropertiesFromProfile(const Profile& p) {
@@ -792,7 +842,8 @@ void Scene::setPropertiesFromProfile(const Profile& p) {
             0.0,
             groupName,
             ghoul::EasingFunction::Linear,
-            ""
+            "",
+            false
         );
         // Clear lua state stack
         lua_settop(L, 0);
@@ -969,6 +1020,7 @@ at the end of the interpolation. If 0 was provided, the script runs immediately
                     std::source_location::current().line()
                 }
             },
+            codegen::lua::StopPropertyBouncing,
             codegen::lua::HasProperty,
             codegen::lua::Property,
             codegen::lua::PropertyOwner,

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -642,7 +642,7 @@ SceneGraphNode* Scene::loadNode(const ghoul::Dictionary& nodeDictionary) {
 void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
                                      std::string postScript,
                                      ghoul::EasingFunction easingFunction,
-                                     bool isBouncing)
+                                     bool shouldBounce)
 {
     ghoul_precondition(prop != nullptr, "prop must not be nullptr");
     ghoul_precondition(durationSeconds > 0.f, "durationSeconds must be positive");
@@ -670,7 +670,7 @@ void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
             info.durationSeconds = durationSeconds;
             info.postScript = std::move(postScript);
             info.easingFunction = func;
-            info.isBouncing = isBouncing;
+            info.isBouncing = shouldBounce;
             info.bouncingShouldStop = false;
             info.bouncingShouldStopT = -1.f;
             info.bouncingAbortTime = std::chrono::time_point<std::chrono::steady_clock>();
@@ -686,7 +686,7 @@ void Scene::addPropertyInterpolation(Property* prop, float durationSeconds,
         .durationSeconds = durationSeconds,
         .postScript = std::move(postScript),
         .easingFunction = func,
-        .isBouncing = isBouncing
+        .isBouncing = shouldBounce
     };
     _propertyInterpolationInfos.push_back(std::move(i));
 }
@@ -800,7 +800,7 @@ void Scene::updateInterpolations() {
     );
 }
 
-void Scene::stopInterpolation(Property* prop) {
+void Scene::stopBouncing(Property* prop) {
     ghoul_assert(prop, "No property provided");
 
     auto it = std::find_if(

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -909,7 +909,8 @@ LuaLibrary Scene::luaLibrary() {
                     { "value", "Nil | String | Number | Boolean | Table" },
                     { "duration", "Number?", "0.0" },
                     { "easing", "EasingFunction?", "Linear" },
-                    { "postscript", "String?", "" }
+                    { "postscript", "String?", "" },
+                    { "isBouncing", "Boolean?", "" }
                 },
                 "",
                 R"(Sets the property or properties identified by the URI to the specified
@@ -956,6 +957,10 @@ in which the parameter is interpolated. Has to be one of "Linear", "QuadraticEas
 \\param postscript A Lua script that will be executed once the change of property value
 is completed. If a duration larger than 0 was provided, it is at the end of the
 interpolation. If 0 was provided, the script runs immediately
+\\param isBouncing If this value is set to `true`, the property will interpolate to the
+current value, then back to the original value, until manually stopped. In this mode, the
+\p postScript will be called each time the interpolation is at the starting value or final
+value
 )",
                 {
                     std::source_location::current().file_name(),
@@ -970,7 +975,8 @@ interpolation. If 0 was provided, the script runs immediately
                     { "value", "Nil | String | Number | Boolean | Table" },
                     { "duration", "Number?", "0.0" },
                     { "easing", "EasingFunction?", "Linear" },
-                    { "postscript", "String?", "" }
+                    { "postscript", "String?", "" },
+                    { "isBouncing", "Boolean?", "" }
                 },
                 "",
                 R"(Sets the single property identified by the URI to the specified value.
@@ -999,6 +1005,10 @@ in which the parameter is interpolated. Has to be one of "Linear", "QuadraticEas
 \\param postscript This parameter specifies a Lua script that will be executed once the
 change of property value is completed. If a duration larger than 0 was provided, it is
 at the end of the interpolation. If 0 was provided, the script runs immediately
+\\param isBouncing If this value is set to `true`, the property will interpolate to the
+current value, then back to the original value, until manually stopped. In this mode, the
+\p postScript will be called each time the interpolation is at the starting value or final
+value
 )",
                 {
                     std::source_location::current().file_name(),

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -627,7 +627,7 @@ int propertySetValue(lua_State* L) {
         else {
             std::string msg = std::format(
                 "Unexpected type '{}' in argument 6",
-                ghoul::lua::luaTypeToString(lua_type(L, 5))
+                ghoul::lua::luaTypeToString(lua_type(L, 6))
             );
             return ghoul::lua::luaError(L, msg);
         }
@@ -643,6 +643,12 @@ int propertySetValue(lua_State* L) {
         }
 
         easingMethod = ghoul::easingFunctionFromName(easingMethodName);
+    }
+
+    if (isBouncing && interpolationDuration == 0.0) {
+        throw ghoul::lua::LuaError(
+            "When bouncing, a duration of 0 seconds is not allowed"
+        );
     }
 
     defer { lua_settop(L, 0); };
@@ -714,13 +720,17 @@ int propertyGetValue(lua_State* L) {
 namespace {
 
 /**
- * Stops the bouncing interpolation on the provided property. The interpolation will stop
- * when the value has reached the original value the next time.
+ * Stops the bouncing interpolation on the provided property and interpolate the value to
+ * the original starting value over the original duration.
+ * 
  *
  * \param uri The URI of the property whose bouncing interpolation should be stopped
  */
 [[codegen::luawrap]] void stopPropertyBouncing(std::string uri) {
     Property* prop = property(uri);
+    if (!prop) {
+        throw ghoul::lua::LuaError(std::format("Error finding property '{}'", uri));
+    }
     global::renderEngine->scene()->stopInterpolation(prop);
 }
 

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -386,7 +386,7 @@ namespace {
     void applyRegularExpression(lua_State* L, std::string_view regex,
                                 double interpolationDuration, std::string_view groupTag,
                                 ghoul::EasingFunction easingFunction,
-                                std::string postScript)
+                                std::string postScript, bool isBouncing)
     {
         //
         // 1. Retrieve all properties that match the regex
@@ -453,7 +453,8 @@ namespace {
                         prop,
                         static_cast<float>(interpolationDuration),
                         postScript,
-                        easingFunction
+                        easingFunction,
+                        isBouncing
                     );
                 }
             }
@@ -469,7 +470,7 @@ namespace {
 
     int setPropertyCallSingle(Property& prop, const std::string& uri, lua_State* L,
                               double duration, ghoul::EasingFunction easingFunction,
-                              std::string postScript)
+                              std::string postScript, bool isBouncing)
     {
         using ghoul::lua::errorLocation;
         using ghoul::lua::luaTypeToString;
@@ -504,7 +505,8 @@ namespace {
                     &prop,
                     static_cast<float>(duration),
                     std::move(postScript),
-                    easingFunction
+                    easingFunction,
+                    isBouncing
                 );
             }
         }
@@ -568,12 +570,14 @@ int propertySetValue(lua_State* L) {
     std::string easingMethodName;
     ghoul::EasingFunction easingMethod = ghoul::EasingFunction::Linear;
     std::string postScript;
+    bool isBouncing = false;
 
     // Extracting the parameters. These are the options that we have:
     // 1. <uri> <value>
     // 2. <uri> <value> <duration>
     // 3. <uri> <value> <duration> <easing>
     // 4. <uri> <value> <duration> <easing> <postscript>
+    // 5. <uri> <value> <duration> <easing> <postscript> <bouncing>
 
     if (nParameters >= 3) {
         // Later functions expect the value to be at the last position on the stack
@@ -604,7 +608,7 @@ int propertySetValue(lua_State* L) {
             return ghoul::lua::luaError(L, msg);
         }
     }
-    if (nParameters == 5) {
+    if (nParameters >= 5) {
         if (ghoul::lua::hasValue<std::string>(L, 5)) {
             postScript = ghoul::lua::value<std::string>(L, 5, ghoul::lua::PopValue::No);
         }
@@ -615,6 +619,19 @@ int propertySetValue(lua_State* L) {
             );
             return ghoul::lua::luaError(L, msg);
         }
+    }
+    if (nParameters >= 6) {
+        if (ghoul::lua::hasValue<bool>(L, 6)) {
+            isBouncing = ghoul::lua::value<bool>(L, 6, ghoul::lua::PopValue::No);
+        }
+        else {
+            std::string msg = std::format(
+                "Unexpected type '{}' in argument 6",
+                ghoul::lua::luaTypeToString(lua_type(L, 5))
+            );
+            return ghoul::lua::luaError(L, msg);
+        }
+
     }
 
     if (!easingMethodName.empty()) {
@@ -649,7 +666,8 @@ int propertySetValue(lua_State* L) {
             L,
             interpolationDuration,
             easingMethod,
-            std::move(postScript)
+            std::move(postScript),
+            isBouncing
         );
     }
     else {
@@ -665,7 +683,8 @@ int propertySetValue(lua_State* L) {
             interpolationDuration,
             tag,
             easingMethod,
-            std::move(postScript)
+            std::move(postScript),
+            isBouncing
         );
     }
     return 0;
@@ -693,6 +712,17 @@ int propertyGetValue(lua_State* L) {
 } // namespace openspace::luascriptfunctions
 
 namespace {
+
+/**
+ * Stops the bouncing interpolation on the provided property. The interpolation will stop
+ * when the value has reached the original value the next time.
+ *
+ * \param uri The URI of the property whose bouncing interpolation should be stopped
+ */
+[[codegen::luawrap]] void stopPropertyBouncing(std::string uri) {
+    Property* prop = property(uri);
+    global::renderEngine->scene()->stopInterpolation(prop);
+}
 
 /**
  * Returns whether a property with the given URI exists. The `uri` identifies the property

--- a/src/scene/scene_lua.inl
+++ b/src/scene/scene_lua.inl
@@ -731,7 +731,7 @@ namespace {
     if (!prop) {
         throw ghoul::lua::LuaError(std::format("Error finding property '{}'", uri));
     }
-    global::renderEngine->scene()->stopInterpolation(prop);
+    global::renderEngine->scene()->stopBouncing(prop);
 }
 
 /**

--- a/tests/test_lua_setpropertyvalue.cpp
+++ b/tests/test_lua_setpropertyvalue.cpp
@@ -318,6 +318,78 @@ TEST_CASE("SetPropertyValueSingle: PostScript 0 duration", "[setpropertyvalue]")
     }
 }
 
+TEST_CASE("SetPropertyValueSingle: Bouncing", "[setpropertyvalue]") {
+#ifdef NDEBUG
+    // Disabling this test in Debug mode as it is very sensitive to performance-based
+    // timers
+
+    std::unique_ptr<Scene> scene = std::make_unique<Scene>(
+        std::make_unique<SceneInitializer>()
+    );
+    global::renderEngine->setScene(scene.get());
+    defer { global::renderEngine->setScene(nullptr); };
+
+    PropertyOwner owner = PropertyOwner({ "base" });
+    global::rootPropertyOwner->addPropertySubOwner(owner);
+    defer { global::rootPropertyOwner->removePropertySubOwner(owner); };
+    FloatProperty p1 = FloatProperty(Property::PropertyInfo("p1", "a", "b"), 1.f);
+    owner.addProperty(p1);
+    FloatProperty p2 = FloatProperty(Property::PropertyInfo("p2", "a", "b"), 1.f);
+    owner.addProperty(p2);
+
+    {
+        LogMgr.resetMessageCounters();
+        defer { LogMgr.resetMessageCounters(); };
+
+        global::scriptEngine->queueScript(R"(
+            openspace.setPropertyValueSingle(
+                'base.p1',
+                2.0,
+                0.1,
+                'Linear',
+                [[openspace.setPropertyValueSingle('base.p2', 0.75)]],
+                true
+            )
+        )");
+        defer { scene->removePropertyInterpolation(&p1); };
+
+        CHECK(p1 == 1.f);
+        CHECK(p2 == 1.f);
+        triggerScriptRun();
+        updateInterpolations(std::chrono::milliseconds(50));
+        CHECK_THAT(p1, Catch::Matchers::WithinAbs(1.5, 0.05));
+        CHECK(p2 == 1.f);
+
+        updateInterpolations(std::chrono::milliseconds(50));
+        CHECK_THAT(p1, Catch::Matchers::WithinAbs(2.0, 0.05));
+        CHECK(p2 == 1.f);
+
+        updateInterpolations(std::chrono::milliseconds(50));
+        CHECK_THAT(p1, Catch::Matchers::WithinAbs(1.5, 0.05));
+        CHECK(p2 == 1.f);
+
+        updateInterpolations(std::chrono::milliseconds(50));
+        CHECK_THAT(p1, Catch::Matchers::WithinAbs(1.0, 0.05));
+        CHECK(p2 == 1.f);
+
+        updateInterpolations(std::chrono::milliseconds(50));
+        CHECK_THAT(p1, Catch::Matchers::WithinAbs(1.5, 0.05));
+        CHECK(p2 == 1.f);
+
+
+        global::scriptEngine->queueScript(R"(
+            openspace.stopPropertyInterpolation('base.p1',)
+        )");
+
+        triggerScriptRun();
+        updateInterpolations(std::chrono::milliseconds(100));
+        triggerScriptRun();
+        CHECK(p1 == 1.f);
+        CHECK(p2 == 2.f);
+    }
+#endif // !(defined(NDEBUG) || defined(DEBUG))
+}
+
 TEST_CASE("SetPropertyValue: Basic", "[setpropertyvalue]") {
     PropertyOwner owner = PropertyOwner({ "base" });
     global::rootPropertyOwner->addPropertySubOwner(owner);


### PR DESCRIPTION
Add as the ability bounce (or pingpong) between property values.  Adds a new 6th optional boolean parameter to the `setPropertyValue` and `setPropertyValueSingle` functions to control whether a parameter change should bounce between the current value and the new value.

Example:
```lua
openspace.setPropertyValueSingle("Scene.Earth.Renderable.Opacity", 1.0);
openspace.setPropertyValueSingle("Scene.Earth.Renderable.Opacity", 0.0, 3, "Linear", "", true);
```

Will cause the opacity of Earth to fade from 1.0 to 0.0 over 3 seconds, then back to 1.0 over 3 seconds, back to 0.0 over seconds etc.
Any property that is interpolatable (anything that derives from `NumericalProperty` can be used for this.


Also adds a new function `openspace.stopPropertyBouncing` that takes the URI of a property and stops the bouncing interpolation. As soon as the call is made, it will interpolate back to the original value.


Note: The implementation is really ugly, but it works and I couldn't think of a way to improve it at the moment