### PR TITLE
Fix stale Today's Sun surface after timestamp jumps

### DIFF
--- a/modules/fitsfilereader/src/renderabletimevaryingfitssphere.cpp
+++ b/modules/fitsfilereader/src/renderabletimevaryingfitssphere.cpp
@@ -624,17 +624,32 @@ void RenderableTimeVaryingFitsSphere::updateDynamicDownloading(double currentTim
     _dynamicFileDownloader->update(currentTime, deltaTime);
     const std::vector<std::filesystem::path>& filesToRead =
         _dynamicFileDownloader->downloadedFiles();
+
+    const int previousActiveTriggerTimeIndex = _activeTriggerTimeIndex;
+    const std::filesystem::path previousActiveFilePath =
+        (_activeTriggerTimeIndex >= 0 &&
+         static_cast<size_t>(_activeTriggerTimeIndex) < _files.size())
+        ? _files[_activeTriggerTimeIndex].path
+        : std::filesystem::path{};
+
     for (const std::filesystem::path& filePath : filesToRead) {
         if (filePath.extension() == ".fits") {
             readFileFromFits(filePath);
         }
     }
     if (!filesToRead.empty()) {
-        const int previousActiveTriggerTimeIndex = _activeTriggerTimeIndex;
         computeSequenceEndTime();
         updateActiveTriggerTimeIndex(currentTime);
 
-        if (_activeTriggerTimeIndex != previousActiveTriggerTimeIndex) {
+        const std::filesystem::path activeFilePath =
+            (_activeTriggerTimeIndex >= 0 &&
+             static_cast<size_t>(_activeTriggerTimeIndex) < _files.size())
+            ? _files[_activeTriggerTimeIndex].path
+            : std::filesystem::path{};
+
+        if (_activeTriggerTimeIndex != previousActiveTriggerTimeIndex ||
+            activeFilePath != previousActiveFilePath)
+        {
             loadTexture();
         }
     }

--- a/modules/fitsfilereader/src/renderabletimevaryingfitssphere.cpp
+++ b/modules/fitsfilereader/src/renderabletimevaryingfitssphere.cpp
@@ -628,9 +628,9 @@ void RenderableTimeVaryingFitsSphere::updateDynamicDownloading(double currentTim
     const int previousActiveTriggerTimeIndex = _activeTriggerTimeIndex;
     const std::filesystem::path previousActiveFilePath =
         (_activeTriggerTimeIndex >= 0 &&
-         static_cast<size_t>(_activeTriggerTimeIndex) < _files.size())
-        ? _files[_activeTriggerTimeIndex].path
-        : std::filesystem::path{};
+         static_cast<size_t>(_activeTriggerTimeIndex) < _files.size()) ?
+         _files[_activeTriggerTimeIndex].path :
+         std::filesystem::path();
 
     for (const std::filesystem::path& filePath : filesToRead) {
         if (filePath.extension() == ".fits") {
@@ -643,9 +643,9 @@ void RenderableTimeVaryingFitsSphere::updateDynamicDownloading(double currentTim
 
         const std::filesystem::path activeFilePath =
             (_activeTriggerTimeIndex >= 0 &&
-             static_cast<size_t>(_activeTriggerTimeIndex) < _files.size())
-            ? _files[_activeTriggerTimeIndex].path
-            : std::filesystem::path{};
+             static_cast<size_t>(_activeTriggerTimeIndex) < _files.size()) ?
+             _files[_activeTriggerTimeIndex].path :
+             std::filesystem::path();
 
         if (_activeTriggerTimeIndex != previousActiveTriggerTimeIndex ||
             activeFilePath != previousActiveFilePath)


### PR DESCRIPTION
The Today's Sun visual test could keep showing the surface that was active at startup, even after jumping to another timestamp and downloading the correct FITS files. This happened because the texture was only reloaded when the active index changed, not when the selected FITS file changed. The fix tracks the active FITS file before inserting newly downloaded files and reloads the texture if the selected file changes, even when the active index stays the same.