### PR TITLE
Fix crash for saveSettingsToProfile

### DIFF
--- a/src/scene/profile_lua.inl
+++ b/src/scene/profile_lua.inl
@@ -76,7 +76,7 @@ namespace {
                                                 bool shouldOverwrite = false)
 {
     const bool receivedSaveFileName = saveFileName.has_value();
-    if (!saveFileName.has_value()) {
+    if (!receivedSaveFileName) {
         std::time_t t = std::time(nullptr);
         std::tm* utcTime = std::gmtime(&t);
         ghoul_assert(utcTime, "Conversion to UTC failed");

--- a/src/scene/profile_lua.inl
+++ b/src/scene/profile_lua.inl
@@ -90,28 +90,16 @@ namespace {
             utcTime->tm_sec
         );
         std::filesystem::path path = global::configuration->profile.profile;
+        const std::string extension = path.extension().string();
         path.replace_extension();
-        std::string newFile = std::format("{}_{}", path, time);
-        std::string sourcePath = std::format(
-            "{}/{}.profile",
-            absPath("${USER_PROFILES}"), global::configuration->profile.profile
-        );
-        std::string destPath = std::format(
-            "{}/{}.profile",
-            absPath("${PROFILES}"), global::configuration->profile.profile
-        );
-        if (!std::filesystem::is_regular_file(sourcePath)) {
-            sourcePath = std::format(
-                "{}/{}.profile",
-                absPath("${USER_PROFILES}"), global::configuration->profile.profile
-            );
-        }
+        const std::string backupPath = std::format("{}_{}{}", path, time, extension);
+        const std::string sourcePath = global::configuration->profile.profile;
         LINFOC(
             "Profile",
-            std::format("Saving a copy of the old profile as '{}'", newFile)
+            std::format("Saving a copy of the old profile as '{}'", backupPath)
         );
-        std::filesystem::copy(sourcePath, destPath);
-        saveFilePath = global::configuration->profile.profile;
+        std::filesystem::copy(sourcePath, backupPath);
+        saveFilePath = path.stem().string();
     }
     if (saveFilePath->empty()) {
         throw ghoul::lua::LuaError("Save filepath string is empty");
@@ -121,7 +109,6 @@ namespace {
     std::string currentTime = std::string(global::timeManager->time().ISO8601());
     NavigationState navState = global::navigationHandler->navigationState();
     global::profile->saveCurrentSettingsToProfile(root, currentTime, navState);
-    global::configuration->profile.profile = *saveFilePath;
 
     if (saveFilePath->contains('/')) {
         throw ghoul::lua::LuaError("Profile filename must not contain (/) elements");
@@ -139,7 +126,9 @@ namespace {
         "{}/{}.profile", absPath("${PROFILES}"), *saveFilePath
     );
     if (!std::filesystem::is_regular_file(absFilename)) {
-        absFilename = absPath("${USER_PROFILES}/" + *saveFilePath + ".profile").string();
+        absFilename = std::format(
+            "{}/{}.profile", absPath("${USER_PROFILES}"), *saveFilePath
+        );
     }
 
     if (std::filesystem::is_regular_file(absFilename) && !shouldOverwrite) {
@@ -150,6 +139,8 @@ namespace {
             )
         );
     }
+
+    global::configuration->profile.profile = absFilename;
 
     std::ofstream outFile = std::ofstream(absFilename, std::ofstream::out);
     if (!outFile.good()) {

--- a/src/scene/profile_lua.inl
+++ b/src/scene/profile_lua.inl
@@ -132,8 +132,7 @@ namespace {
         );
     }
 
-    if (std::filesystem::is_regular_file(absFilename) &&
-        !shouldOverwrite &&
+    if (std::filesystem::is_regular_file(absFilename) && !shouldOverwrite &&
         receivedSaveFileName)
     {
         throw ghoul::lua::LuaError(

--- a/src/scene/profile_lua.inl
+++ b/src/scene/profile_lua.inl
@@ -72,10 +72,11 @@ namespace {
  * file and the original profile will be overwritten. The second argument determines if a
  * file that already exists should be overwritten, which is 'false' by default.
  */
-[[codegen::luawrap]] void saveSettingsToProfile(std::optional<std::string> saveFilePath,
-                                                bool shouldOverwrite = true)
+[[codegen::luawrap]] void saveSettingsToProfile(std::optional<std::string> saveFileName,
+                                                bool shouldOverwrite = false)
 {
-    if (!saveFilePath.has_value()) {
+    const bool receivedSaveFileName = saveFileName.has_value();
+    if (!saveFileName.has_value()) {
         std::time_t t = std::time(nullptr);
         std::tm* utcTime = std::gmtime(&t);
         ghoul_assert(utcTime, "Conversion to UTC failed");
@@ -99,9 +100,9 @@ namespace {
             std::format("Saving a copy of the old profile as '{}'", backupPath)
         );
         std::filesystem::copy(sourcePath, backupPath);
-        saveFilePath = path.stem().string();
+        saveFileName = path.stem().string();
     }
-    if (saveFilePath->empty()) {
+    if (saveFileName->empty()) {
         throw ghoul::lua::LuaError("Save filepath string is empty");
     }
 
@@ -110,28 +111,31 @@ namespace {
     NavigationState navState = global::navigationHandler->navigationState();
     global::profile->saveCurrentSettingsToProfile(root, currentTime, navState);
 
-    if (saveFilePath->contains('/')) {
+    if (saveFileName->contains('/')) {
         throw ghoul::lua::LuaError("Profile filename must not contain (/) elements");
     }
-    else if (saveFilePath->contains(':')) {
+    else if (saveFileName->contains(':')) {
         throw ghoul::lua::LuaError("Profile filename must not contain (:) elements");
     }
-    else if (saveFilePath->contains('.')) {
+    else if (saveFileName->contains('.')) {
         throw ghoul::lua::LuaError(
             "Only provide the filename to save without file extension"
         );
     }
 
     std::string absFilename = std::format(
-        "{}/{}.profile", absPath("${PROFILES}"), *saveFilePath
+        "{}/{}.profile", absPath("${PROFILES}"), *saveFileName
     );
     if (!std::filesystem::is_regular_file(absFilename)) {
         absFilename = std::format(
-            "{}/{}.profile", absPath("${USER_PROFILES}"), *saveFilePath
+            "{}/{}.profile", absPath("${USER_PROFILES}"), *saveFileName
         );
     }
 
-    if (std::filesystem::is_regular_file(absFilename) && !shouldOverwrite) {
+    if (std::filesystem::is_regular_file(absFilename) &&
+        !shouldOverwrite &&
+        receivedSaveFileName)
+    {
         throw ghoul::lua::LuaError(
             std::format(
                 "Unable to save profile '{}'. File of same name already exists",


### PR DESCRIPTION
Fix crash due to path problems when using `openspace.saveSettingsToProfile()`.
Created PR just to for someone else to test the code as we are close to release.

Closes #4100 

Note:
Potential problems where some scripts are being saved in a weird format will be fixed in another issue.
Current fix prevents crash and saves the scripts in the profile.