### PR TITLE
Feature/model node animation

### DIFF
--- a/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
+++ b/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
@@ -1,0 +1,52 @@
+-- Node Transform
+-- This example loads a model and applies a custom transformation to one of its internal
+-- model nodes.
+
+-- Load the example model from OpenSpace servers
+-- If you want to use your own model, this block of code can be safely deleted
+local model = asset.resource({
+  Name = "Animated Box",
+  Type = "HttpSynchronization",
+  Identifier = "animated_box",
+  Version = 1
+})
+
+local Node = {
+  Identifier = "RenderableModel_Example_Node_Transform",
+  Renderable = {
+    Type = "RenderableModel",
+    GeometryFile = model .. "BoxAnimated.glb",
+    -- Use the line below insted of the one above if you want to use your own model
+    --GeometryFile = "C:/path/to/model.fbx",
+    CustomTransformNodeName = "nodes[2]",
+    CustomTransform = {
+      Translation = {
+        Type = "StaticTranslation",
+        Position = {10, 10, 10}
+      }
+    }
+  },
+  GUI = {
+    Name = "RenderableModel - Node Transform",
+    Path = "/Examples"
+  }
+}
+
+
+asset.onInitialize(function()
+  openspace.addSceneGraphNode(Node)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeSceneGraphNode(Node)
+end)
+
+
+-- Model credit
+--[[
+  Author = Cesium, https://cesium.com/
+  URL = https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BoxAnimated
+  License =
+    Creative Commons Attribution 4.0 International License,
+    https://creativecommons.org/licenses/by/4.0/
+]]

--- a/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
+++ b/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
@@ -18,11 +18,20 @@ local Node = {
     GeometryFile = model .. "BoxAnimated.glb",
     -- Use the line below insted of the one above if you want to use your own model
     --GeometryFile = "C:/path/to/model.fbx",
-    CustomTransformNodeName = "nodes[2]",
-    CustomTransform = {
-      Translation = {
-        Type = "StaticTranslation",
-        Position = {10, 10, 10}
+    CustomTransforms = {
+      {
+        NodeName = "nodes[2]",
+        Translation = {
+          Type = "StaticTranslation",
+          Position = {10, 0, 10}
+        }
+      },
+      {
+        NodeName = "nodes[1]",
+        Translation = {
+          Type = "StaticTranslation",
+          Position = {10, 10, 0}
+        }
       }
     }
   },

--- a/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
+++ b/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
@@ -1,6 +1,6 @@
 -- Node Transform
 -- This example loads a model and applies a custom transformation to one of its internal
--- model nodes.
+-- model nodes identified by name.
 
 -- Load the example model from OpenSpace servers
 -- If you want to use your own model, this block of code can be safely deleted
@@ -18,21 +18,14 @@ local Node = {
     GeometryFile = model .. "BoxAnimated.glb",
     -- Use the line below insted of the one above if you want to use your own model
     --GeometryFile = "C:/path/to/model.fbx",
-    CustomTransformsShouldOverride = false,
     CustomTransforms = {
-      ["nodes[2]"] = {
+      ["nodes[2]"] = { -- Name of the internal node to apply the custom transformation to
         Translation = {
           Type = "StaticTranslation",
           Position = {10, 0, 0}
         }
       }
-    },
-    -- Animation Parameters:
-    EnableAnimation = true,
-    -- Start the animation and play it once at this time
-    AnimationStartTime = "2024 07 09 12:00:00",
-    -- Bounce the animation after the set start time
-    AnimationMode = "BounceFromStart",
+    }
   },
   GUI = {
     Name = "RenderableModel - Node Transform",

--- a/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
+++ b/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
@@ -19,10 +19,10 @@ local Node = {
     -- Use the line below instead of the one above if you want to use your own model
     --GeometryFile = "C:/path/to/model.fbx",
     CustomTransforms = {
-      ["nodes[2]"] = { -- Name of the internal node to apply the custom transformation to
+      ["inner_box"] = { -- Name of the internal node to apply the custom transformation to
         Translation = {
           Type = "StaticTranslation",
-          Position = {10, 0, 0}
+          Position = {10.0, 0.0, 0.0}
         }
       }
     }

--- a/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
+++ b/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
@@ -18,22 +18,21 @@ local Node = {
     GeometryFile = model .. "BoxAnimated.glb",
     -- Use the line below insted of the one above if you want to use your own model
     --GeometryFile = "C:/path/to/model.fbx",
+    CustomTransformsShouldOverride = false,
     CustomTransforms = {
-      {
-        NodeName = "nodes[2]",
+      ["nodes[2]"] = {
         Translation = {
           Type = "StaticTranslation",
-          Position = {10, 0, 10}
-        }
-      },
-      {
-        NodeName = "nodes[1]",
-        Translation = {
-          Type = "StaticTranslation",
-          Position = {10, 10, 0}
+          Position = {10, 0, 0}
         }
       }
-    }
+    },
+    -- Animation Parameters:
+    EnableAnimation = true,
+    -- Start the animation and play it once at this time
+    AnimationStartTime = "2024 07 09 12:00:00",
+    -- Bounce the animation after the set start time
+    AnimationMode = "BounceFromStart",
   },
   GUI = {
     Name = "RenderableModel - Node Transform",

--- a/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
+++ b/data/assets/examples/renderable/renderablemodel/model_node_transform.asset
@@ -16,7 +16,7 @@ local Node = {
   Renderable = {
     Type = "RenderableModel",
     GeometryFile = model .. "BoxAnimated.glb",
-    -- Use the line below insted of the one above if you want to use your own model
+    -- Use the line below instead of the one above if you want to use your own model
     --GeometryFile = "C:/path/to/model.fbx",
     CustomTransforms = {
       ["nodes[2]"] = { -- Name of the internal node to apply the custom transformation to

--- a/modules/base/CMakeLists.txt
+++ b/modules/base/CMakeLists.txt
@@ -133,6 +133,7 @@ set(SOURCE_FILES
   rendering/renderabledistancelabel.cpp
   rendering/renderablelabel.cpp
   rendering/renderablemodel.cpp
+  rendering/renderablemodel_lua.inl
   rendering/renderablenodearrow.cpp
   rendering/renderablenodeline.cpp
   rendering/renderableplane.cpp

--- a/modules/base/basemodule.cpp
+++ b/modules/base/basemodule.cpp
@@ -350,6 +350,7 @@ std::vector<Documentation> BaseModule::documentations() const {
 
 std::vector<LuaLibrary> BaseModule::luaLibraries() const {
     return {
+        RenderableModel::luaLibrary(),
         ScreenSpaceDashboard::luaLibrary()
     };
 }

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -323,7 +323,7 @@ namespace {
             std::optional<ghoul::Dictionary> translation
                 [[codegen::reference("core_translation")]];
 
-            // This describes a rotation that that is applied to an internal model node
+            // This describes a rotation that is applied to an internal model node
             // identified with name and all its children. Depending on the 'Type' of the
             // rotation, this can either be a static rotation or a time-varying one.
             std::optional<ghoul::Dictionary> rotation
@@ -336,14 +336,14 @@ namespace {
         };
 
         // A map of custom transformations to apply to internal model nodes. The keys of
-        // the map are the named of the internal model nodes that the respective
+        // the map are the names of the internal model nodes that the respective
         // transformation should be applied to. The value is the transformation itself,
         // which can be a translation, rotation, and/or scaling.
         std::optional<std::map<std::string, NodeTransform>> customTransforms;
 
         // Whether the custom transformations should replace any existing transformation
-        // of the affected internal mode node or not. If `true` then the custom
-        // transformation will replacce any internal transformation. If `false` then the
+        // of the affected internal model node or not. If `true` then the custom
+        // transformation will replace any internal transformation. If `false` then the
         // custom transformation will be applied on top of any existing transformations.
         std::optional<bool> customTransformsShouldOverride;
     };

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -316,10 +316,10 @@ namespace {
         // [[codegen::verbatim(OverrideColorInfo.description)]]
         std::optional<glm::vec4> overrideColor [[codegen::color()]];
 
-        // Name of a node to put a custom transformation onto.
-        std::optional<std::string> customTransformNodeName;
+        struct NodeTransform {
+            // Name of the node
+            std::string nodeName;
 
-        struct Transform {
             // This node describes a translation that is applied to the scene graph node
             // and all its children. Depending on the 'Type' of the translation, this can
             // either be a static translation or a time-varying one.
@@ -338,8 +338,8 @@ namespace {
             std::optional<ghoul::Dictionary> scale [[codegen::reference("core_scale")]];
         };
 
-        // The custom transformation to apply to the node specified by `CustomTransformNodeName`.
-        std::optional<Transform> customTransform;
+        // The custom transformation
+        std::optional<std::vector<NodeTransform>> customTransforms;
     };
 } // namespace
 #include "renderablemodel_codegen.cpp"
@@ -637,60 +637,46 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
 
     _originalRenderBin = renderBin();
 
-    if (p.customTransform.has_value()) {
-        if (_modelHasAnimation && _enableAnimation) { // TODO
-            LERROR(std::format(
-                "Cannot apply custom transform to model '{}' with pre existing "
-                "animation. A custom transform cannot be applied in addition to an "
-                "animation.", _file
-            ));
-            return; // this has to be the last thing that the constructor does. Or we could use goto
-        }
+    if (p.customTransforms.has_value()) {
+        _hasCustomNodeTransforms = true;
 
-        if (!p.customTransformNodeName.has_value()) {
-            LWARNING(std::format(
-                "Custom transform given for model '{}' without a node name. The custom "
-                "transform will not be applied.", _file
-            ));
-            return; // this has to be the last thing that the constructor does. Or we could use goto
-        }
+        for (const auto& nodeTransform : *p.customTransforms) {
+            _customNodeTransforms.push_back(NodeTransform());
+            _customNodeTransforms.back().nodeName = nodeTransform.nodeName;
 
-        _hasCustomNodeTransform = true;
-        _customNodeTransform.modelNodeName = *p.customTransformNodeName;
+            if (nodeTransform.translation.has_value()) {
+                _customNodeTransforms.back().translation =
+                    Translation::createFromDictionary(*nodeTransform.translation);
 
-        if (p.customTransform->translation.has_value()) {
-            _customNodeTransform.translation = Translation::createFromDictionary(
-                *p.customTransform->translation
-            );
+                LDEBUG(std::format(
+                    "Applied custom translation on node '{}' for model '{}'",
+                    nodeTransform.nodeName, _file
+                ));
+                addPropertySubOwner(_customNodeTransforms.back().translation.get());
+            }
 
-            LDEBUG(std::format(
-                "Applied custom translation on node '{}' for model '{}'",
-                _customNodeTransform.modelNodeName, _file
-            ));
-            addPropertySubOwner(_customNodeTransform.translation.get());
-        }
+            if (nodeTransform.rotation.has_value()) {
+                _customNodeTransforms.back().rotation = Rotation::createFromDictionary(
+                    *nodeTransform.rotation
+                );
 
-        if (p.customTransform->rotation.has_value()) {
-            _customNodeTransform.rotation = Rotation::createFromDictionary(
-                *p.customTransform->rotation
-            );
+                LDEBUG(std::format(
+                    "Applied custom rotation on node '{}' for model '{}'",
+                    nodeTransform.nodeName, _file
+                ));
+                addPropertySubOwner(_customNodeTransforms.back().rotation.get());
+            }
 
-            LDEBUG(std::format(
-                "Applied custom rotation on node '{}' for model '{}'",
-                _customNodeTransform.modelNodeName, _file
-            ));
-            addPropertySubOwner(_customNodeTransform.rotation.get());
-        }
+            if (nodeTransform.scale.has_value()) {
+                _customNodeTransforms.back().scale =
+                    Scale::createFromDictionary(*nodeTransform.scale);
 
-        if (p.customTransform->scale.has_value()) {
-            _customNodeTransform.scale =
-                Scale::createFromDictionary(*p.customTransform->scale);
-
-            LDEBUG(std::format(
-                "Applied custom scale on node '{}' for model '{}'",
-                _customNodeTransform.modelNodeName, _file
-            ));
-            addPropertySubOwner(_customNodeTransform.scale.get());
+                LDEBUG(std::format(
+                    "Applied custom scale on node '{}' for model '{}'",
+                    nodeTransform.nodeName, _file
+                ));
+                addPropertySubOwner(_customNodeTransforms.back().scale.get());
+            }
         }
     }
 }
@@ -698,14 +684,18 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
 void RenderableModel::initialize() {
     ZoneScoped;
 
-    if (_customNodeTransform.translation) {
-        _customNodeTransform.translation->initialize();
-    }
-    if (_customNodeTransform.rotation) {
-        _customNodeTransform.rotation->initialize();
-    }
-    if (_customNodeTransform.scale) {
-        _customNodeTransform.scale->initialize();
+    if (_hasCustomNodeTransforms) {
+        for (const auto& nodeTransform : _customNodeTransforms) {
+            if (nodeTransform.translation) {
+                nodeTransform.translation->initialize();
+            }
+            if (nodeTransform.rotation) {
+                nodeTransform.rotation->initialize();
+            }
+            if (nodeTransform.scale) {
+                nodeTransform.scale->initialize();
+            }
+        }
     }
 
     for (const std::unique_ptr<LightSource>& ls : _lightSources) {
@@ -1256,37 +1246,39 @@ void RenderableModel::update(const UpdateData& data) {
         }
     }
 
-    if (_hasCustomNodeTransform) {
-        glm::dmat4 translation(1.0);
-        if (_customNodeTransform.translation) {
-            _customNodeTransform.translation->update(data);
-            translation = glm::translate(
-                glm::dmat4(1.0),
-                _customNodeTransform.translation->position()
+    if (_hasCustomNodeTransforms) {
+        for (const auto& nodeTransform : _customNodeTransforms) {
+            glm::dmat4 translation(1.0);
+            if (nodeTransform.translation) {
+                nodeTransform.translation->update(data);
+                translation = glm::translate(
+                    glm::dmat4(1.0),
+                    nodeTransform.translation->position()
+                );
+            }
+
+            glm::dmat4 rotation(1.0);
+            if (nodeTransform.rotation) {
+                nodeTransform.rotation->update(data);
+                rotation = glm::dmat4(nodeTransform.rotation->matrix());
+            }
+
+            glm::dmat4 scaling(1.0);
+            if (nodeTransform.scale) {
+                nodeTransform.scale->update(data);
+                scaling = glm::scale(
+                    glm::dmat4(1.0),
+                    nodeTransform.scale->scaleValue()
+                );
+            }
+
+            glm::dmat4 finalTransform = translation * rotation * scaling;
+
+            _geometry->updateCustomNodeTransform(
+                finalTransform,
+                nodeTransform.nodeName
             );
         }
-
-        glm::dmat4 rotation(1.0);
-        if (_customNodeTransform.rotation) {
-            _customNodeTransform.rotation->update(data);
-            rotation = glm::dmat4(_customNodeTransform.rotation->matrix());
-        }
-
-        glm::dmat4 scaling(1.0);
-        if (_customNodeTransform.scale) {
-            _customNodeTransform.scale->update(data);
-            scaling = glm::scale(
-                glm::dmat4(1.0),
-                _customNodeTransform.scale->scaleValue()
-            );
-        }
-
-        glm::dmat4 transform = translation * rotation * scaling;
-
-        _geometry->updateCustomNodeTransform(
-            transform,
-            _customNodeTransform.modelNodeName
-        );
     }
 
     if (_geometry->hasAnimation() && !_animationStart.empty()) {

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -35,6 +35,9 @@
 #include <openspace/util/timeconversion.h>
 #include <openspace/util/updatestructures.h>
 #include <openspace/scene/lightsource.h>
+#include <openspace/scene/rotation.h>
+#include <openspace/scene/scale.h>
+#include <openspace/scene/translation.h>
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/format.h>
 #include <ghoul/io/model/modelgeometry.h>
@@ -312,6 +315,31 @@ namespace {
 
         // [[codegen::verbatim(OverrideColorInfo.description)]]
         std::optional<glm::vec4> overrideColor [[codegen::color()]];
+
+        // Name of a node to put a custom transformation onto.
+        std::optional<std::string> customTransformNodeName;
+
+        struct Transform {
+            // This node describes a translation that is applied to the scene graph node
+            // and all its children. Depending on the 'Type' of the translation, this can
+            // either be a static translation or a time-varying one.
+            std::optional<ghoul::Dictionary> translation
+                [[codegen::reference("core_translation")]];
+
+            // This nodes describes a rotation that is applied to the scene graph node and
+            // all its children. Depending on the 'Type' of the rotation, this can either
+            // be a static rotation or a time-varying one.
+            std::optional<ghoul::Dictionary> rotation
+                [[codegen::reference("core_rotation")]];
+
+            // This node describes a scaling that is applied to the scene graph node and
+            // all its children. Depending on the 'Type' of the scaling, this can either
+            // be a static scaling or a time-varying one.
+            std::optional<ghoul::Dictionary> scale [[codegen::reference("core_scale")]];
+        };
+
+        // The custom transformation to apply to the node specified by `CustomTransformNodeName`.
+        std::optional<Transform> customTransform;
     };
 } // namespace
 #include "renderablemodel_codegen.cpp"
@@ -608,10 +636,77 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
     };
 
     _originalRenderBin = renderBin();
+
+    if (p.customTransform.has_value()) {
+        if (_modelHasAnimation && _enableAnimation) { // TODO
+            LERROR(std::format(
+                "Cannot apply custom transform to model '{}' with pre existing "
+                "animation. A custom transform cannot be applied in addition to an "
+                "animation.", _file
+            ));
+            return; // this has to be the last thing that the constructor does. Or we could use goto
+        }
+
+        if (!p.customTransformNodeName.has_value()) {
+            LWARNING(std::format(
+                "Custom transform given for model '{}' without a node name. The custom "
+                "transform will not be applied.", _file
+            ));
+            return; // this has to be the last thing that the constructor does. Or we could use goto
+        }
+
+        _hasCustomNodeTransform = true;
+        _customNodeTransform.modelNodeName = *p.customTransformNodeName;
+
+        if (p.customTransform->translation.has_value()) {
+            _customNodeTransform.translation = Translation::createFromDictionary(
+                *p.customTransform->translation
+            );
+
+            LDEBUG(std::format(
+                "Applied custom translation on node '{}' for model '{}'",
+                _customNodeTransform.modelNodeName, _file
+            ));
+            addPropertySubOwner(_customNodeTransform.translation.get());
+        }
+
+        if (p.customTransform->rotation.has_value()) {
+            _customNodeTransform.rotation = Rotation::createFromDictionary(
+                *p.customTransform->rotation
+            );
+
+            LDEBUG(std::format(
+                "Applied custom rotation on node '{}' for model '{}'",
+                _customNodeTransform.modelNodeName, _file
+            ));
+            addPropertySubOwner(_customNodeTransform.rotation.get());
+        }
+
+        if (p.customTransform->scale.has_value()) {
+            _customNodeTransform.scale =
+                Scale::createFromDictionary(*p.customTransform->scale);
+
+            LDEBUG(std::format(
+                "Applied custom scale on node '{}' for model '{}'",
+                _customNodeTransform.modelNodeName, _file
+            ));
+            addPropertySubOwner(_customNodeTransform.scale.get());
+        }
+    }
 }
 
 void RenderableModel::initialize() {
     ZoneScoped;
+
+    if (_customNodeTransform.translation) {
+        _customNodeTransform.translation->initialize();
+    }
+    if (_customNodeTransform.rotation) {
+        _customNodeTransform.rotation->initialize();
+    }
+    if (_customNodeTransform.scale) {
+        _customNodeTransform.scale->initialize();
+    }
 
     for (const std::unique_ptr<LightSource>& ls : _lightSources) {
         ls->initialize();
@@ -1161,6 +1256,38 @@ void RenderableModel::update(const UpdateData& data) {
         }
     }
 
+    if (_hasCustomNodeTransform) {
+        glm::dmat4 translation(1.0);
+        if (_customNodeTransform.translation) {
+            _customNodeTransform.translation->update(data);
+            translation = glm::translate(
+                glm::dmat4(1.0),
+                _customNodeTransform.translation->position()
+            );
+        }
+
+        glm::dmat4 rotation(1.0);
+        if (_customNodeTransform.rotation) {
+            _customNodeTransform.rotation->update(data);
+            rotation = glm::dmat4(_customNodeTransform.rotation->matrix());
+        }
+
+        glm::dmat4 scaling(1.0);
+        if (_customNodeTransform.scale) {
+            _customNodeTransform.scale->update(data);
+            scaling = glm::scale(
+                glm::dmat4(1.0),
+                _customNodeTransform.scale->scaleValue()
+            );
+        }
+
+        glm::dmat4 transform = translation * rotation * scaling;
+
+        _geometry->updateCustomNodeTransform(
+            transform,
+            _customNodeTransform.modelNodeName
+        );
+    }
 
     if (_geometry->hasAnimation() && !_animationStart.empty()) {
         double relativeTime = 0.0;

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -317,9 +317,6 @@ namespace {
         std::optional<glm::vec4> overrideColor [[codegen::color()]];
 
         struct NodeTransform {
-            // Name of the node
-            std::string nodeName;
-
             // This node describes a translation that is applied to the scene graph node
             // and all its children. Depending on the 'Type' of the translation, this can
             // either be a static translation or a time-varying one.
@@ -339,7 +336,7 @@ namespace {
         };
 
         // The custom transformation
-        std::optional<std::vector<NodeTransform>> customTransforms;
+        std::optional<std::map<std::string, NodeTransform>> customTransforms;
 
         // Whether the custom transforms should replace the existing transform or add on
         // top if it
@@ -647,42 +644,41 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
     if (p.customTransforms.has_value()) {
         _hasCustomNodeTransforms = true;
 
-        for (const auto& nodeTransform : *p.customTransforms) {
-            _customNodeTransforms.push_back(NodeTransform());
-            _customNodeTransforms.back().nodeName = nodeTransform.nodeName;
+        for (const auto& [nodeName, nodeTransform] : *p.customTransforms) {
+            _customNodeTransforms.insert({ nodeName, NodeTransform() });
 
             if (nodeTransform.translation.has_value()) {
-                _customNodeTransforms.back().translation =
+                _customNodeTransforms[nodeName].translation =
                     Translation::createFromDictionary(*nodeTransform.translation);
 
                 LDEBUG(std::format(
                     "Applied custom translation on node '{}' for model '{}'",
-                    nodeTransform.nodeName, _file
+                    nodeName, _file
                 ));
-                addPropertySubOwner(_customNodeTransforms.back().translation.get());
+                addPropertySubOwner(_customNodeTransforms[nodeName].translation.get());
             }
 
             if (nodeTransform.rotation.has_value()) {
-                _customNodeTransforms.back().rotation = Rotation::createFromDictionary(
+                _customNodeTransforms[nodeName].rotation = Rotation::createFromDictionary(
                     *nodeTransform.rotation
                 );
 
                 LDEBUG(std::format(
                     "Applied custom rotation on node '{}' for model '{}'",
-                    nodeTransform.nodeName, _file
+                    nodeName, _file
                 ));
-                addPropertySubOwner(_customNodeTransforms.back().rotation.get());
+                addPropertySubOwner(_customNodeTransforms[nodeName].rotation.get());
             }
 
             if (nodeTransform.scale.has_value()) {
-                _customNodeTransforms.back().scale =
+                _customNodeTransforms[nodeName].scale =
                     Scale::createFromDictionary(*nodeTransform.scale);
 
                 LDEBUG(std::format(
                     "Applied custom scale on node '{}' for model '{}'",
-                    nodeTransform.nodeName, _file
+                    nodeName, _file
                 ));
-                addPropertySubOwner(_customNodeTransforms.back().scale.get());
+                addPropertySubOwner(_customNodeTransforms[nodeName].scale.get());
             }
         }
     }
@@ -692,7 +688,7 @@ void RenderableModel::initialize() {
     ZoneScoped;
 
     if (_hasCustomNodeTransforms) {
-        for (const auto& nodeTransform : _customNodeTransforms) {
+        for (const auto& [nodeName, nodeTransform] : _customNodeTransforms) {
             if (nodeTransform.translation) {
                 nodeTransform.translation->initialize();
             }
@@ -1254,7 +1250,7 @@ void RenderableModel::update(const UpdateData& data) {
     }
 
     if (_hasCustomNodeTransforms) {
-        for (const auto& nodeTransform : _customNodeTransforms) {
+        for (const auto& [nodeName, nodeTransform] : _customNodeTransforms) {
             glm::dmat4 translation(1.0);
             if (nodeTransform.translation) {
                 nodeTransform.translation->update(data);
@@ -1283,7 +1279,7 @@ void RenderableModel::update(const UpdateData& data) {
 
             _geometry->updateCustomNodeTransform(
                 finalTransform,
-                nodeTransform.nodeName,
+                nodeName,
                 _customNodeTransformsShouldOverride
             );
         }

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -652,6 +652,17 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
         for (const auto& [nodeName, nodeTransform] : *p.customTransforms) {
             _customNodeTransforms.insert({ nodeName, NodeTransform() });
 
+            std::string cleanNodeName = nodeName;
+            std::replace_if(
+                cleanNodeName.begin(),
+                cleanNodeName.end(),
+                [](auto ch) {
+                    std::string toRemove = ". \t\n";
+                    return toRemove.find(ch) != std::string::npos;
+                },
+                '_'
+            );
+
             if (nodeTransform.translation.has_value()) {
                 _customNodeTransforms[nodeName].translation =
                     Translation::createFromDictionary(*nodeTransform.translation);
@@ -660,6 +671,13 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
                     "Applied custom translation on node '{}' for model '{}'",
                     nodeName, _file
                 ));
+
+                _customNodeTransforms[nodeName].translation->setIdentifier(
+                    "CustomNodeTranslation_" + cleanNodeName
+                );
+                _customNodeTransforms[nodeName].translation->setGuiName(
+                    "Custom Node Translation " + nodeName
+                );
                 addPropertySubOwner(_customNodeTransforms[nodeName].translation.get());
             }
 
@@ -672,6 +690,13 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
                     "Applied custom rotation on node '{}' for model '{}'",
                     nodeName, _file
                 ));
+
+                _customNodeTransforms[nodeName].rotation->setIdentifier(
+                    "CustomNodeRotation_" + cleanNodeName
+                );
+                _customNodeTransforms[nodeName].rotation->setGuiName(
+                    "Custom Node Rotation " + nodeName
+                );
                 addPropertySubOwner(_customNodeTransforms[nodeName].rotation.get());
             }
 
@@ -683,6 +708,13 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
                     "Applied custom scale on node '{}' for model '{}'",
                     nodeName, _file
                 ));
+
+                _customNodeTransforms[nodeName].scale->setIdentifier(
+                    "CustomNodeScale_" + cleanNodeName
+                );
+                _customNodeTransforms[nodeName].scale->setGuiName(
+                    "Custom Node Scale " + nodeName
+                );
                 addPropertySubOwner(_customNodeTransforms[nodeName].scale.get());
             }
         }

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -317,29 +317,34 @@ namespace {
         std::optional<glm::vec4> overrideColor [[codegen::color()]];
 
         struct NodeTransform {
-            // This node describes a translation that is applied to the scene graph node
-            // and all its children. Depending on the 'Type' of the translation, this can
-            // either be a static translation or a time-varying one.
+            // This describes a translation that is applied to an internal model node
+            // identified with name and all its children. Depending on the 'Type' of the
+            // translation, this can either be a static translation or a time-varying one.
             std::optional<ghoul::Dictionary> translation
                 [[codegen::reference("core_translation")]];
 
-            // This nodes describes a rotation that is applied to the scene graph node and
-            // all its children. Depending on the 'Type' of the rotation, this can either
-            // be a static rotation or a time-varying one.
+            // This describes a rotation that that is applied to an internal model node
+            // identified with name and all its children. Depending on the 'Type' of the
+            // rotation, this can either be a static rotation or a time-varying one.
             std::optional<ghoul::Dictionary> rotation
                 [[codegen::reference("core_rotation")]];
 
-            // This node describes a scaling that is applied to the scene graph node and
-            // all its children. Depending on the 'Type' of the scaling, this can either
-            // be a static scaling or a time-varying one.
+            // This describes a scaling that is applied to an internal model node
+            // identified with name and all its children. Depending on the 'Type' of the
+            // scaling, this can either be a static scaling or a time-varying one.
             std::optional<ghoul::Dictionary> scale [[codegen::reference("core_scale")]];
         };
 
-        // The custom transformation
+        // A map of custom transformations to apply to internal model nodes. The keys of
+        // the map are the named of the internal model nodes that the respective
+        // transformation should be applied to. The value is the transformation itself,
+        // which can be a translation, rotation, and/or scaling.
         std::optional<std::map<std::string, NodeTransform>> customTransforms;
 
-        // Whether the custom transforms should replace the existing transform or add on
-        // top if it
+        // Whether the custom transformations should replace any existing transformation
+        // of the affected internal mode node or not. If `true` then the custom
+        // transformation will replacce any internal transformation. If `false` then the
+        // custom transformation will be applied on top of any existing transformations.
         std::optional<bool> customTransformsShouldOverride;
     };
 } // namespace
@@ -716,6 +721,7 @@ void RenderableModel::initializeGL() {
         ghoul::io::ModelReader::NotifyInvisibleDropped(_notifyInvisibleDropped)
     );
     _modelHasAnimation = _geometry->hasAnimation();
+    _geometry->setCustomTransformsOverride(_customNodeTransformsShouldOverride);
 
     // @TODO (abock, 2023-06-03) Leaving this here to address issue #2731. The
     // _modelHasAnimation has not been set to true in the constructor causing the
@@ -1277,11 +1283,7 @@ void RenderableModel::update(const UpdateData& data) {
 
             glm::dmat4 finalTransform = translation * rotation * scaling;
 
-            _geometry->updateCustomNodeTransform(
-                finalTransform,
-                nodeName,
-                _customNodeTransformsShouldOverride
-            );
+            _geometry->updateCustomNodeTransform(nodeName, finalTransform);
         }
     }
 

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -39,6 +39,7 @@
 #include <openspace/scene/scale.h>
 #include <openspace/scene/scene.h>
 #include <openspace/scene/translation.h>
+#include <openspace/scripting/lualibrary.h>
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/format.h>
 #include <ghoul/io/model/modelgeometry.h>
@@ -60,6 +61,8 @@
 #include <optional>
 #include <utility>
 #include <variant>
+
+#include "renderablemodel_lua.inl"
 
 namespace {
     using namespace openspace;
@@ -1430,6 +1433,15 @@ glm::dvec3 RenderableModel::center() const {
     transform *= glm::scale(_modelTransform.value(), glm::dvec3(_modelScale));
     glm::dmat4 model = parent()->modelTransform() * transform;
     return model * glm::dvec4(0.0, 0.0, 0.0, 1.0);
+}
+
+LuaLibrary RenderableModel::luaLibrary() {
+    return {
+        "model",
+        {
+            codegen::lua::PrintModelTree
+        }
+    };
 }
 
 } // namespace openspace

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -340,6 +340,10 @@ namespace {
 
         // The custom transformation
         std::optional<std::vector<NodeTransform>> customTransforms;
+
+        // Whether the custom transforms should replace the existing transform or add on
+        // top if it
+        std::optional<bool> customTransformsShouldOverride;
     };
 } // namespace
 #include "renderablemodel_codegen.cpp"
@@ -636,6 +640,9 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
     };
 
     _originalRenderBin = renderBin();
+
+    _customNodeTransformsShouldOverride =
+        p.customTransformsShouldOverride.value_or(_customNodeTransformsShouldOverride);
 
     if (p.customTransforms.has_value()) {
         _hasCustomNodeTransforms = true;
@@ -1276,7 +1283,8 @@ void RenderableModel::update(const UpdateData& data) {
 
             _geometry->updateCustomNodeTransform(
                 finalTransform,
-                nodeTransform.nodeName
+                nodeTransform.nodeName,
+                _customNodeTransformsShouldOverride
             );
         }
     }

--- a/modules/base/rendering/renderablemodel.cpp
+++ b/modules/base/rendering/renderablemodel.cpp
@@ -37,6 +37,7 @@
 #include <openspace/scene/lightsource.h>
 #include <openspace/scene/rotation.h>
 #include <openspace/scene/scale.h>
+#include <openspace/scene/scene.h>
 #include <openspace/scene/translation.h>
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/format.h>
@@ -73,6 +74,18 @@ namespace {
     constexpr int ColorAddingBlending = 4;
 
     constexpr glm::vec4 PosBufferClearVal = glm::vec4(1e32, 1e32, 1e32, 1.f);
+
+    static const PropertyOwner::PropertyOwnerInfo CustomNodeTransformsInfo = {
+        "CustomNodeTransforms",
+        "Custom Node Transforms",
+        "Custom transformations for internal model nodes."
+    };
+
+    static const PropertyOwner::PropertyOwnerInfo CustomNodeTransformInfo = {
+        "CustomNodeTransform",
+        "Custom Node Transform",
+        "Custom transformation for an internal model node."
+    };
 
     constexpr Property::PropertyInfo EnableAnimationInfo = {
         "EnableAnimation",
@@ -345,7 +358,7 @@ namespace {
         // of the affected internal model node or not. If `true` then the custom
         // transformation will replace any internal transformation. If `false` then the
         // custom transformation will be applied on top of any existing transformations.
-        std::optional<bool> customTransformsShouldOverride;
+        std::optional<bool> replaceWithCustomNodeTransforms;
     };
 } // namespace
 #include "renderablemodel_codegen.cpp"
@@ -400,6 +413,7 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
     , _useOverrideColor(UseOverrideColorInfo, false)
     , _overrideColor(OverrideColorInfo, glm::vec4(1.f), glm::vec4(0.f), glm::vec4(1.f))
     , _lightSourcePropertyOwner({ "LightSources", "Light Sources" })
+    , _customNodeTransformsOwner(CustomNodeTransformsInfo)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
 
@@ -643,25 +657,18 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
 
     _originalRenderBin = renderBin();
 
-    _customNodeTransformsShouldOverride =
-        p.customTransformsShouldOverride.value_or(_customNodeTransformsShouldOverride);
+    _replaceWithCustomNodeTransforms =
+        p.replaceWithCustomNodeTransforms.value_or(_replaceWithCustomNodeTransforms);
 
     if (p.customTransforms.has_value()) {
-        _hasCustomNodeTransforms = true;
-
         for (const auto& [nodeName, nodeTransform] : *p.customTransforms) {
-            _customNodeTransforms.insert({ nodeName, NodeTransform() });
+            std::string cleanNodeName = makeIdentifier(nodeName);
 
-            std::string cleanNodeName = nodeName;
-            std::replace_if(
-                cleanNodeName.begin(),
-                cleanNodeName.end(),
-                [](auto ch) {
-                    std::string toRemove = ". \t\n";
-                    return toRemove.find(ch) != std::string::npos;
-                },
-                '_'
-            );
+            _nodeTransformOwners.push_back(PropertyOwner(CustomNodeTransformInfo));
+            _nodeTransformOwners.back().setIdentifier(cleanNodeName);
+            _nodeTransformOwners.back().setGuiName(nodeName);
+
+            _customNodeTransforms.insert({ nodeName, NodeTransform() });
 
             if (nodeTransform.translation.has_value()) {
                 _customNodeTransforms[nodeName].translation =
@@ -671,14 +678,13 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
                     "Applied custom translation on node '{}' for model '{}'",
                     nodeName, _file
                 ));
-
-                _customNodeTransforms[nodeName].translation->setIdentifier(
-                    "CustomNodeTranslation_" + cleanNodeName
-                );
-                _customNodeTransforms[nodeName].translation->setGuiName(
-                    "Custom Node Translation " + nodeName
-                );
-                addPropertySubOwner(_customNodeTransforms[nodeName].translation.get());
+            }
+            else {
+                ghoul::Dictionary translation;
+                translation.setValue("Type", std::string("StaticTranslation"));
+                translation.setValue("Position", glm::dvec3(0.0));
+                _customNodeTransforms[nodeName].translation =
+                    Translation::createFromDictionary(translation);
             }
 
             if (nodeTransform.rotation.has_value()) {
@@ -690,14 +696,13 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
                     "Applied custom rotation on node '{}' for model '{}'",
                     nodeName, _file
                 ));
-
-                _customNodeTransforms[nodeName].rotation->setIdentifier(
-                    "CustomNodeRotation_" + cleanNodeName
-                );
-                _customNodeTransforms[nodeName].rotation->setGuiName(
-                    "Custom Node Rotation " + nodeName
-                );
-                addPropertySubOwner(_customNodeTransforms[nodeName].rotation.get());
+            }
+            else {
+                ghoul::Dictionary rotation;
+                rotation.setValue("Type", std::string("StaticRotation"));
+                rotation.setValue("Rotation", glm::dvec3(0.0));
+                _customNodeTransforms[nodeName].rotation =
+                    Rotation::createFromDictionary(rotation);
             }
 
             if (nodeTransform.scale.has_value()) {
@@ -708,33 +713,43 @@ RenderableModel::RenderableModel(const ghoul::Dictionary& dictionary)
                     "Applied custom scale on node '{}' for model '{}'",
                     nodeName, _file
                 ));
-
-                _customNodeTransforms[nodeName].scale->setIdentifier(
-                    "CustomNodeScale_" + cleanNodeName
-                );
-                _customNodeTransforms[nodeName].scale->setGuiName(
-                    "Custom Node Scale " + nodeName
-                );
-                addPropertySubOwner(_customNodeTransforms[nodeName].scale.get());
             }
+            else {
+                ghoul::Dictionary scale;
+                scale.setValue("Type", std::string("StaticScale"));
+                scale.setValue("Scale", 1.0);
+                _customNodeTransforms[nodeName].scale =
+                    Scale::createFromDictionary(scale);
+            }
+
+            _nodeTransformOwners.back().addPropertySubOwner(
+                _customNodeTransforms[nodeName].translation.get()
+            );
+            _nodeTransformOwners.back().addPropertySubOwner(
+                _customNodeTransforms[nodeName].rotation.get()
+            );
+            _nodeTransformOwners.back().addPropertySubOwner(
+                _customNodeTransforms[nodeName].scale.get()
+            );
+
+            _customNodeTransformsOwner.addPropertySubOwner(_nodeTransformOwners.back());
         }
+        addPropertySubOwner(_customNodeTransformsOwner);
     }
 }
 
 void RenderableModel::initialize() {
     ZoneScoped;
 
-    if (_hasCustomNodeTransforms) {
-        for (const auto& [nodeName, nodeTransform] : _customNodeTransforms) {
-            if (nodeTransform.translation) {
-                nodeTransform.translation->initialize();
-            }
-            if (nodeTransform.rotation) {
-                nodeTransform.rotation->initialize();
-            }
-            if (nodeTransform.scale) {
-                nodeTransform.scale->initialize();
-            }
+    for (const auto& [nodeName, nodeTransform] : _customNodeTransforms) {
+        if (nodeTransform.translation) {
+            nodeTransform.translation->initialize();
+        }
+        if (nodeTransform.rotation) {
+            nodeTransform.rotation->initialize();
+        }
+        if (nodeTransform.scale) {
+            nodeTransform.scale->initialize();
         }
     }
 
@@ -753,7 +768,7 @@ void RenderableModel::initializeGL() {
         ghoul::io::ModelReader::NotifyInvisibleDropped(_notifyInvisibleDropped)
     );
     _modelHasAnimation = _geometry->hasAnimation();
-    _geometry->setCustomTransformsOverride(_customNodeTransformsShouldOverride);
+    _geometry->setReplaceWithCustomTransforms(_replaceWithCustomNodeTransforms);
 
     // @TODO (abock, 2023-06-03) Leaving this here to address issue #2731. The
     // _modelHasAnimation has not been set to true in the constructor causing the
@@ -1287,36 +1302,34 @@ void RenderableModel::update(const UpdateData& data) {
         }
     }
 
-    if (_hasCustomNodeTransforms) {
-        for (const auto& [nodeName, nodeTransform] : _customNodeTransforms) {
-            glm::dmat4 translation(1.0);
-            if (nodeTransform.translation) {
-                nodeTransform.translation->update(data);
-                translation = glm::translate(
-                    glm::dmat4(1.0),
-                    nodeTransform.translation->position()
-                );
-            }
-
-            glm::dmat4 rotation(1.0);
-            if (nodeTransform.rotation) {
-                nodeTransform.rotation->update(data);
-                rotation = glm::dmat4(nodeTransform.rotation->matrix());
-            }
-
-            glm::dmat4 scaling(1.0);
-            if (nodeTransform.scale) {
-                nodeTransform.scale->update(data);
-                scaling = glm::scale(
-                    glm::dmat4(1.0),
-                    nodeTransform.scale->scaleValue()
-                );
-            }
-
-            glm::dmat4 finalTransform = translation * rotation * scaling;
-
-            _geometry->updateCustomNodeTransform(nodeName, finalTransform);
+    for (const auto& [nodeName, nodeTransform] : _customNodeTransforms) {
+        glm::dmat4 translation(1.0);
+        if (nodeTransform.translation) {
+            nodeTransform.translation->update(data);
+            translation = glm::translate(
+                glm::dmat4(1.0),
+                nodeTransform.translation->position()
+            );
         }
+
+        glm::dmat4 rotation(1.0);
+        if (nodeTransform.rotation) {
+            nodeTransform.rotation->update(data);
+            rotation = glm::dmat4(nodeTransform.rotation->matrix());
+        }
+
+        glm::dmat4 scaling(1.0);
+        if (nodeTransform.scale) {
+            nodeTransform.scale->update(data);
+            scaling = glm::scale(
+                glm::dmat4(1.0),
+                nodeTransform.scale->scaleValue()
+            );
+        }
+
+        glm::dmat4 finalTransform = translation * rotation * scaling;
+
+        _geometry->updateCustomNodeTransform(nodeName, finalTransform);
     }
 
     if (_geometry->hasAnimation() && !_animationStart.empty()) {

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -142,13 +142,14 @@ private:
     /**
      * Transformation defined by translation, rotation and scale.
      */
-    struct {
+    struct NodeTransform {
+        std::string nodeName;
         ghoul::mm_unique_ptr<Translation> translation;
         ghoul::mm_unique_ptr<Rotation> rotation;
         ghoul::mm_unique_ptr<Scale> scale;
-        std::string modelNodeName;
-    } _customNodeTransform;
-    bool _hasCustomNodeTransform = false;
+    };
+    std::vector<NodeTransform> _customNodeTransforms;
+    bool _hasCustomNodeTransforms = false;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -148,8 +148,9 @@ private:
         ghoul::mm_unique_ptr<Scale> scale;
     };
     std::map<std::string, NodeTransform> _customNodeTransforms;
-    bool _hasCustomNodeTransforms = false;
-    bool _customNodeTransformsShouldOverride = false;
+    bool _replaceWithCustomNodeTransforms = false;
+    PropertyOwner _customNodeTransformsOwner;
+    std::vector<PropertyOwner> _nodeTransformOwners;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -138,6 +138,17 @@ private:
     Renderable::RenderBin _originalRenderBin;
 
     ghoul::opengl::ProgramObject* _depthMapProgram = nullptr;
+
+    /**
+     * Transformation defined by translation, rotation and scale.
+     */
+    struct {
+        ghoul::mm_unique_ptr<Translation> translation;
+        ghoul::mm_unique_ptr<Rotation> rotation;
+        ghoul::mm_unique_ptr<Scale> scale;
+        std::string modelNodeName;
+    } _customNodeTransform;
+    bool _hasCustomNodeTransform = false;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -150,6 +150,7 @@ private:
     };
     std::vector<NodeTransform> _customNodeTransforms;
     bool _hasCustomNodeTransforms = false;
+    bool _customNodeTransformsShouldOverride = false;
 };
 
 } // namespace openspace

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -143,12 +143,11 @@ private:
      * Transformation defined by translation, rotation and scale.
      */
     struct NodeTransform {
-        std::string nodeName;
         ghoul::mm_unique_ptr<Translation> translation;
         ghoul::mm_unique_ptr<Rotation> rotation;
         ghoul::mm_unique_ptr<Scale> scale;
     };
-    std::vector<NodeTransform> _customNodeTransforms;
+    std::map<std::string, NodeTransform> _customNodeTransforms;
     bool _hasCustomNodeTransforms = false;
     bool _customNodeTransformsShouldOverride = false;
 };

--- a/modules/base/rendering/renderablemodel.h
+++ b/modules/base/rendering/renderablemodel.h
@@ -43,6 +43,7 @@ namespace ghoul::modelgeometry { class ModelGeometry; }
 namespace openspace {
 
 class LightSource;
+struct LuaLibrary;
 
 class RenderableModel : public Renderable, public Shadower {
 public:
@@ -59,6 +60,7 @@ public:
     void update(const UpdateData& data) override;
 
     static openspace::Documentation Documentation();
+    static LuaLibrary luaLibrary();
 
 private:
     enum class AnimationMode {

--- a/modules/base/rendering/renderablemodel_lua.inl
+++ b/modules/base/rendering/renderablemodel_lua.inl
@@ -31,23 +31,19 @@
 namespace {
 
     /**
-     * Prints the model tree of the \p filepath model file. The node names detected during
-     * reading and the hierarchy of the nodes will be printed. This is useful for debugging
-     * and finding correct node names for applying custom transformations to internal model
-     * nodes.
+     * Prints the model tree of the given filepath model file. The node names detected
+     * during reading and the hierarchy of the nodes will be printed. This is useful for
+     * debugging and finding correct node names for applying custom transformations to
+     * internal model nodes.
+     *
+     * The given filepath must not be empty, must contain an extension, and must be a
+     * valid model file that can be read with the `ModelReaderAssimp` reader. The
+     * `ModelReaderAssimp` reader must have been added to the `ModelReader` before calling
+     * this function. Will throw a `ModelLoadException` if there was an error reading the
+     * file, or a `MissingReaderException` if there was no reader for the specified
+     * filepath.
      *
      * \param filepath The model file on disk whose model tree should be printed.
-     *
-     * \throw ModelLoadException If there was an error reading the \p filepath
-     * \throw MissingReaderException If there was no reader for the specified \p filepath
-     * \pre \p filepath must not be empty
-     * \pre \p filepath must have an extension
-     * \pre At least one ModelReaderBase must have been added to the ModelReader before
-     *      (addReader)
-     * \pre The ModelReaderAssimp reader must have been added to the ModelReader before
-     *      (addReader)
-     * \pre The file at \p filepath must be a valid model file that can be read by the
-     *      ModelReaderAssimp reader
      */
 [[codegen::luawrap]] void printModelTree(std::filesystem::path filepath) {
     ghoul_assert(!filepath.empty(), "Filepath must not be empty");

--- a/modules/base/rendering/renderablemodel_lua.inl
+++ b/modules/base/rendering/renderablemodel_lua.inl
@@ -1,0 +1,69 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <ghoul/io/model/modelreader.h>
+#include <ghoul/io/model/modelreaderassimp.h>
+#include <ghoul/io/model/modelreaderbase.h>
+#include <ghoul/logging/logmanager.h>
+#include <ghoul/misc/assert.h>
+
+namespace {
+
+/**
+ * Prints the model tree of the given model file. Will only work for assimp models.
+ */
+[[codegen::luawrap]] void printModelTree(std::filesystem::path filename) {
+    ghoul_assert(!filename.empty(), "Filename must not be empty");
+
+    std::string extension = filename.extension().string();
+    if (!extension.empty()) {
+        extension = extension.substr(1);
+    }
+    ghoul_assert(!extension.empty(), "Filename must have an extension");
+
+    ghoul::io::ModelReaderBase* reader =
+        ghoul::io::ModelReader::ref().readerForExtension(extension);
+
+    if (!reader) {
+        throw ghoul::io::ModelReader::MissingReaderException(extension, filename);
+    }
+
+    // (malej 2026-05-29) Only the ModelReaderAssimp can print model trees
+    ghoul::io::ModelReaderAssimp* typedReader;
+    try {
+        typedReader = &dynamic_cast<ghoul::io::ModelReaderAssimp&>(*reader);
+    }
+    catch (std::exception& e) {
+        LERRORC("RenderableModel", std::format("Cannot find a suitable reader to print "
+            "the model tree for model {}", filename)
+        );
+        return;
+    }
+
+    typedReader->printModelTree(filename);
+}
+
+} // namespace
+
+#include "renderablemodel_lua_codegen.cpp"

--- a/modules/base/rendering/renderablemodel_lua.inl
+++ b/modules/base/rendering/renderablemodel_lua.inl
@@ -30,23 +30,39 @@
 
 namespace {
 
-/**
- * Prints the model tree of the given model file. Will only work for assimp models.
- */
-[[codegen::luawrap]] void printModelTree(std::filesystem::path filename) {
-    ghoul_assert(!filename.empty(), "Filename must not be empty");
+    /**
+     * Prints the model tree of the \p filepath model file. The node names detected during
+     * reading and the hierarchy of the nodes will be printed. This is useful for debugging
+     * and finding correct node names for applying custom transformations to internal model
+     * nodes.
+     *
+     * \param filepath The model file on disk whose model tree should be printed.
+     *
+     * \throw ModelLoadException If there was an error reading the \p filepath
+     * \throw MissingReaderException If there was no reader for the specified \p filepath
+     * \pre \p filepath must not be empty
+     * \pre \p filepath must have an extension
+     * \pre At least one ModelReaderBase must have been added to the ModelReader before
+     *      (addReader)
+     * \pre The ModelReaderAssimp reader must have been added to the ModelReader before
+     *      (addReader)
+     * \pre The file at \p filepath must be a valid model file that can be read by the
+     *      ModelReaderAssimp reader
+     */
+[[codegen::luawrap]] void printModelTree(std::filesystem::path filepath) {
+    ghoul_assert(!filepath.empty(), "Filepath must not be empty");
 
-    std::string extension = filename.extension().string();
+    std::string extension = filepath.extension().string();
     if (!extension.empty()) {
         extension = extension.substr(1);
     }
-    ghoul_assert(!extension.empty(), "Filename must have an extension");
+    ghoul_assert(!extension.empty(), "Filepath must have an extension");
 
     ghoul::io::ModelReaderBase* reader =
         ghoul::io::ModelReader::ref().readerForExtension(extension);
 
     if (!reader) {
-        throw ghoul::io::ModelReader::MissingReaderException(extension, filename);
+        throw ghoul::io::ModelReader::MissingReaderException(extension, filepath);
     }
 
     // (malej 2026-05-29) Only the ModelReaderAssimp can print model trees
@@ -56,12 +72,12 @@ namespace {
     }
     catch (std::exception& e) {
         LERRORC("RenderableModel", std::format("Cannot find a suitable reader to print "
-            "the model tree for model {}", filename)
+            "the model tree for model {}", filepath)
         );
         return;
     }
 
-    typedReader->printModelTree(filename);
+    typedReader->printModelTree(filepath);
 }
 
 } // namespace


### PR DESCRIPTION
To be used with https://github.com/OpenSpace/Ghoul/pull/136

Makes it possible to specify a number of transformations to attach to a number of internal model nodes identified by name. There is a simple example file to demonstrate how it would be used. The idea is to use this feature to attach a separate transformation to the solar panels for ISS as an example to make them point toward the Sun. A parameter can also be specified to either replace any existing transformation on that node or to add it on top of it. This can be useful since we do not know how each model is structured with their transformations. Sometimes, there are nodes containing just transformations, and sometimes there can be nodes with both meshes and transformations. 

EDIT:
There is also a new Lua function (and a new library) to print the model tree to help with finding the correct names for nodes to apply a custom transformation to.