### PR TITLE
Patch molecule via cmake

### DIFF
--- a/modules/molecule/CMakeLists.txt
+++ b/modules/molecule/CMakeLists.txt
@@ -25,15 +25,15 @@
 include(${PROJECT_SOURCE_DIR}/support/cmake/module_definition.cmake)
 
 execute_process(
-  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_1_md_os_h.patch"
+  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_1_md_os_h.patch"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 execute_process(
-  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_2_md_os_c.patch"
+  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_2_md_os_c.patch"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 execute_process(
-  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_3_md_gl_c.patch"
+  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_3_md_gl_c.patch"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 

--- a/modules/molecule/CMakeLists.txt
+++ b/modules/molecule/CMakeLists.txt
@@ -25,15 +25,15 @@
 include(${PROJECT_SOURCE_DIR}/support/cmake/module_definition.cmake)
 
 execute_process(
-  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_1_md_os_h.patch"
+  COMMAND git apply --verbose --recount --whitespace=fix "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_1_md_os_h.patch"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 execute_process(
-  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_2_md_os_c.patch"
+  COMMAND git apply --verbose --recount --whitespace=fix "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_2_md_os_c.patch"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 execute_process(
-  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_3_md_gl_c.patch"
+  COMMAND git apply --verbose --recount --whitespace=fix "${CMAKE_CURRENT_SOURCE_DIR}/pathpatch_3_md_gl_c.patch"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 

--- a/modules/molecule/CMakeLists.txt
+++ b/modules/molecule/CMakeLists.txt
@@ -24,9 +24,18 @@
 
 include(${PROJECT_SOURCE_DIR}/support/cmake/module_definition.cmake)
 
-PATCH_COMMAND git -C "${CMAKE_SOURCE_DIR}/modules/molecule" apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_1_md_os_h.patch"
-           && git -C "${CMAKE_SOURCE_DIR}/modules/molecule" apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_2_md_os_c.patch"
-           && git -C "${CMAKE_SOURCE_DIR}/modules/molecule" apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_3_md_gl_c.patch"
+execute_process(
+  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_1_md_os_h.patch"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_2_md_os_c.patch"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+  COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_3_md_gl_c.patch"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
 set(HEADER_FILES
   moleculemodule.h

--- a/modules/molecule/CMakeLists.txt
+++ b/modules/molecule/CMakeLists.txt
@@ -24,6 +24,10 @@
 
 include(${PROJECT_SOURCE_DIR}/support/cmake/module_definition.cmake)
 
+PATCH_COMMAND git -C "${CMAKE_SOURCE_DIR}/modules/molecule" apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_1_md_os_h.patch"
+           && git -C "${CMAKE_SOURCE_DIR}/modules/molecule" apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_2_md_os_c.patch"
+           && git -C "${CMAKE_SOURCE_DIR}/modules/molecule" apply "${CMAKE_CURRENT_SOURCE_DIR}/patch_3_md_gl_c.patch"
+
 set(HEADER_FILES
   moleculemodule.h
   src/renderablemolecule.h

--- a/modules/molecule/pathpatch_1_md_os_h.patch
+++ b/modules/molecule/pathpatch_1_md_os_h.patch
@@ -1,0 +1,10 @@
+--- a/ext/mold/src/core/md_os.h
++++ b/ext/mold/src/core/md_os.h
+@@ -19,6 +19,10 @@ extern "C" {
+ str_t   md_path_cwd(void);
+ 
++// Gets the directory containing the running executable (with trailing slash).
++// Returns a non-owning reference to a shared static string buffer.
++str_t   md_path_exe_dir(void);
++
+ str_t   md_path_make_canonical(str_t path, struct md_allocator_i* alloc);

--- a/modules/molecule/pathpatch_2_md_os_c.patch
+++ b/modules/molecule/pathpatch_2_md_os_c.patch
@@ -1,0 +1,68 @@
+--- a/ext/mold/src/core/md_os.c
++++ b/ext/mold/src/core/md_os.c
+@@ -6,6 +6,10 @@
+ #include "md_log.h"
+ #include "md_allocator.h"
+ 
++#if MD_PLATFORM_OSX
++#include <mach-o/dyld.h>
++#endif
++
+ #include <stdio.h>
+ #include <stdarg.h>
+@@ -88,6 +92,51 @@ str_t md_path_cwd() {
+     return res;
+ }
+ 
++static char EXE_DIR[MD_MAX_PATH];
++
++str_t md_path_exe_dir(void) {
++    if (EXE_DIR[0] != '\0') {
++        str_t res = { .ptr = EXE_DIR, .len = (int64_t)strnlen(EXE_DIR, sizeof(EXE_DIR)) };
++        return res;
++    }
++
++    char exe_path[MD_MAX_PATH] = "";
++
++#if MD_PLATFORM_WINDOWS
++    DWORD len = GetModuleFileNameA(NULL, exe_path, (DWORD)sizeof(exe_path));
++    if (len == 0 || len >= sizeof(exe_path)) {
++        MD_LOG_ERROR("md_path_exe_dir: GetModuleFileNameA failed");
++        goto fallback;
++    }
++    for (DWORD i = 0; i < len; i++) {
++        if (exe_path[i] == '\\') exe_path[i] = '/';
++    }
++#elif MD_PLATFORM_LINUX
++    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
++    if (len <= 0) {
++        MD_LOG_ERROR("md_path_exe_dir: readlink /proc/self/exe failed");
++        goto fallback;
++    }
++    exe_path[len] = '\0';
++#elif MD_PLATFORM_OSX
++    uint32_t size = (uint32_t)sizeof(exe_path);
++    if (_NSGetExecutablePath(exe_path, &size) != 0) {
++        MD_LOG_ERROR("md_path_exe_dir: _NSGetExecutablePath failed");
++        goto fallback;
++    }
++#else
++    goto fallback;
++#endif
++
++    {
++        char* last_sep = strrchr(exe_path, '/');
++        size_t dir_len = last_sep ? (size_t)(last_sep - exe_path + 1) : 0;
++        strncpy(EXE_DIR, exe_path, dir_len);
++        EXE_DIR[dir_len] = '\0';
++    }
++    goto done;
++
++fallback:
++    strncpy(EXE_DIR, "./", sizeof(EXE_DIR) - 1);
++done:;
++    str_t res = { .ptr = EXE_DIR, .len = (int64_t)strnlen(EXE_DIR, sizeof(EXE_DIR)) };
++    return res;
++}
++
+ static inline str_t internal_fullpath(str_t path, md_allocator_i* alloc) {

--- a/modules/molecule/pathpatch_3_md_gl_c.patch
+++ b/modules/molecule/pathpatch_3_md_gl_c.patch
@@ -1,0 +1,101 @@
+--- a/ext/mold/src/md_gl.c
++++ b/ext/mold/src/md_gl.c
+@@ -25,6 +25,31 @@
+ 
+ #define UBO_SIZE (1 << 10)
+ #define SHADER_BUF_SIZE KILOBYTES(14)
+ 
++// ---------------------------------------------------------------------------
++// Runtime shader path resolution
++//
++// OpenSpace layout on all platforms:
++//   <root>/bin/openspace    <- executable
++//   <root>/modules/molecule/ext/mold/src/shaders/
++//
++// Resolves <exe_dir>/../modules/molecule/ext/mold/src/shaders/<file>
++// at runtime: works for .deb, AppImage, Windows, and macOS.
++// ---------------------------------------------------------------------------
++#define MD_SHADER_PATH_SLOTS 8
++#define MD_SHADER_PATH_LEN   512
++
++static const char* md_gl_shader_path(const char* filename) {
++    static char bufs[MD_SHADER_PATH_SLOTS][MD_SHADER_PATH_LEN];
++    static int slot = 0;
++    char* buf = bufs[slot % MD_SHADER_PATH_SLOTS];
++    slot++;
++    str_t exe_dir = md_path_exe_dir();
++    snprintf(buf, MD_SHADER_PATH_LEN,
++        "%.*s../modules/molecule/ext/mold/src/shaders%s",
++        (int)exe_dir.len, exe_dir.ptr,
++        filename);
++    return buf;
++}
++
+ static const char* default_shader_output = 
+ "layout(location = 0) out vec4 out_color;\n"
+@@ -877,7 +902,7 @@
+         GLuint comp_shader = glCreateShader(GL_COMPUTE_SHADER);
+ 
+         bool err;
+-        if ((err = compile_shader_from_file(comp_shader, MD_SHADER_DIR "/compute_aabb.comp", NULL, NULL)) != true) {
++        if ((err = compile_shader_from_file(comp_shader, md_gl_shader_path("/compute_aabb.comp"), NULL, NULL)) != true) {
+             return err;
+         }
+         ctx.program[GL_PROGRAM_COMPUTE_AABB].id = glCreateProgram();
+@@ -894,9 +919,9 @@
+         GLuint frag_shader = glCreateShader(GL_FRAGMENT_SHADER);
+ 
+         bool err;
+-        if ((err = compile_shader_from_file(vert_shader, MD_SHADER_DIR "/draw_aabb.vert", NULL, NULL)) != true ||
+-            (err = compile_shader_from_file(geom_shader, MD_SHADER_DIR "/draw_aabb.geom", NULL, NULL)) != true ||
+-            (err = compile_shader_from_file(frag_shader, MD_SHADER_DIR "/cull_aabb.frag", NULL, NULL)) != true) {
++        if ((err = compile_shader_from_file(vert_shader, md_gl_shader_path("/draw_aabb.vert"), NULL, NULL)) != true ||
++            (err = compile_shader_from_file(geom_shader, md_gl_shader_path("/draw_aabb.geom"), NULL, NULL)) != true ||
++            (err = compile_shader_from_file(frag_shader, md_gl_shader_path("/cull_aabb.frag"), NULL, NULL)) != true) {
+             return err;
+         }
+         ctx.program[GL_PROGRAM_CULL_AABB].id = glCreateProgram();
+@@ -915,7 +940,7 @@
+     {
+         GLuint vert_shader = glCreateShader(GL_VERTEX_SHADER);
+ 
+-        if (!compile_shader_from_file(vert_shader, MD_SHADER_DIR "/extract_control_points.vert", NULL, NULL)) {
++        if (!compile_shader_from_file(vert_shader, md_gl_shader_path("/extract_control_points.vert"), NULL, NULL)) {
+             return false;
+         }
+         ctx.program[GL_PROGRAM_EXTRACT_CONTROL_POINTS].id = glCreateProgram();
+@@ -931,7 +956,7 @@
+     {
+         GLuint vert_shader = glCreateShader(GL_VERTEX_SHADER);
+ 
+-        if (!compile_shader_from_file(vert_shader, MD_SHADER_DIR "/compute_velocity.vert", NULL, NULL)) {
++        if (!compile_shader_from_file(vert_shader, md_gl_shader_path("/compute_velocity.vert"), NULL, NULL)) {
+             return false;
+         }
+         ctx.program[GL_PROGRAM_COMPUTE_VELOCITY].id = glCreateProgram();
+@@ -951,8 +976,8 @@
+         snprintf(defines, sizeof(defines), "#define NUM_SUBDIVISIONS %i", SPLINE_MAX_SUBDIVISION_COUNT);
+ 
+         bool err;
+-        if ((err = compile_shader_from_file(vert_shader, MD_SHADER_DIR "/compute_spline.vert", defines, NULL)) != true ||
+-            (err = compile_shader_from_file(geom_shader, MD_SHADER_DIR "/compute_spline.geom", defines, NULL)) != true) {
++        if ((err = compile_shader_from_file(vert_shader, md_gl_shader_path("/compute_spline.vert"), defines, NULL)) != true ||
++            (err = compile_shader_from_file(geom_shader, md_gl_shader_path("/compute_spline.geom"), defines, NULL)) != true) {
+             return err;
+         }
+         ctx.program[GL_PROGRAM_COMPUTE_SPLINE].id = glCreateProgram();
+@@ -992,10 +1017,10 @@
+         if (!custom_shader_snippet) {
+             custom_shader_snippet = default_shader_output;
+         }
+-        if (!create_permuted_program(shaders->space_fill, MD_SHADER_DIR "/space_fill.vert", MD_SHADER_DIR "/space_fill.geom", MD_SHADER_DIR "/space_fill.frag",  custom_shader_snippet)) return false;
+-        if (!create_permuted_program(shaders->licorice,   MD_SHADER_DIR "/licorice.vert",   MD_SHADER_DIR "/licorice.geom",   MD_SHADER_DIR "/licorice.frag",    custom_shader_snippet)) return false;
+-        if (!create_permuted_program(shaders->ribbons,    MD_SHADER_DIR "/ribbons.vert",    MD_SHADER_DIR "/ribbons.geom",    MD_SHADER_DIR "/ribbons.frag",     custom_shader_snippet)) return false;
+-        if (!create_permuted_program(shaders->cartoon,    MD_SHADER_DIR "/cartoon.vert",    MD_SHADER_DIR "/cartoon.geom",    MD_SHADER_DIR "/cartoon.frag",     custom_shader_snippet)) return false;
++        if (!create_permuted_program(shaders->space_fill, md_gl_shader_path("/space_fill.vert"), md_gl_shader_path("/space_fill.geom"), md_gl_shader_path("/space_fill.frag"),  custom_shader_snippet)) return false;
++        if (!create_permuted_program(shaders->licorice,   md_gl_shader_path("/licorice.vert"),   md_gl_shader_path("/licorice.geom"),   md_gl_shader_path("/licorice.frag"),    custom_shader_snippet)) return false;
++        if (!create_permuted_program(shaders->ribbons,    md_gl_shader_path("/ribbons.vert"),    md_gl_shader_path("/ribbons.geom"),    md_gl_shader_path("/ribbons.frag"),     custom_shader_snippet)) return false;
++        if (!create_permuted_program(shaders->cartoon,    md_gl_shader_path("/cartoon.vert"),    md_gl_shader_path("/cartoon.geom"),    md_gl_shader_path("/cartoon.frag"),     custom_shader_snippet)) return false;
+     }
+ 
+     return true;


### PR DESCRIPTION
These patches change the hard-coded path to the ViaMD shaders to relative paths for OpenSpace. The patches are applied with `execute_process` in the molecule module's CMakeLists.txt and can be removed once the external dependency is updated with suitable fixes.