### PR TITLE
Add option to blend `solarimagery` with background

### DIFF
--- a/modules/solarbrowsing/rendering/renderablesolarimagery.cpp
+++ b/modules/solarbrowsing/rendering/renderablesolarimagery.cpp
@@ -43,6 +43,7 @@
 #include <ghoul/filesystem/filesystem.h>
 #include <ghoul/glm.h>
 #include <ghoul/logging/logmanager.h>
+#include <ghoul/opengl/openglstatecache.h>
 #include <ghoul/opengl/texture.h>
 #include <ghoul/opengl/textureunit.h>
 #include <fstream>
@@ -117,6 +118,15 @@ namespace {
         "instrument. Note that data may not be continuously available across the entire "
         "displayed time span.",
         Property::Visibility::User
+    };
+
+    constexpr Property::PropertyInfo UseAdditiveBlendingInfo = {
+        "UseAdditiveBlending",
+        "Use additive blending",
+        "If enabled (default), the plane is blended additively with the background. If "
+        "disabled, the plane is rendered fully opaque. Note that this may lead to weird "
+        "behaviors when the plane is rendered with transparency.",
+        Property::Visibility::AdvancedUser
     };
 
     constexpr Property::PropertyInfo ContrastValueInfo = {
@@ -203,6 +213,9 @@ namespace {
         // [[codegen::verbatim(DownsamplingLevelInfo.description)]]
         std::optional<int> downsamplingLevel;
 
+        // [[codegen::verbatim(UseAdditiveBlendingInfo.description)]]
+        std::optional<bool> useAdditiveBlending;
+
         // [[codegen::verbatim(ContrastValueInfo.description)]]
         std::optional<float> contrast;
 
@@ -238,6 +251,7 @@ RenderableSolarImagery::RenderableSolarImagery(const ghoul::Dictionary& dictiona
     , _enableBorder(EnableBorderInfo, false)
     , _enableFrustum(EnableFrustumInfo, false)
     , _faceMode(FaceModeInfo)
+    , _useAdditiveBlending(UseAdditiveBlendingInfo, true)
     , _gammaValue(GammaValueInfo, 0.9f, 0.1f, 10.f)
     , _moveFactor(MoveFactorInfo, 1.0, 0.0, 1.0)
     , _downsamplingLevel(DownsamplingLevelInfo, 2, 0, 5)
@@ -355,6 +369,9 @@ RenderableSolarImagery::RenderableSolarImagery(const ghoul::Dictionary& dictiona
     _moveFactor = p.moveFactor.value_or(_moveFactor);
     _moveFactor.onChange([this]() { createPlaneAndFrustum(_moveFactor); });
     addProperty(_moveFactor);
+
+    _useAdditiveBlending = p.useAdditiveBlending.value_or(_useAdditiveBlending);
+    addProperty(_useAdditiveBlending);
 
     _gammaValue = p.gamma.value_or(_gammaValue);
     addProperty(_gammaValue);
@@ -547,17 +564,11 @@ void RenderableSolarImagery::render(const RenderData& data, RendererTasks&) {
 
     _rotation = std::move(rot);
 
-    const glm::dmat4 modelTransform =
+    const glm::dmat4 planeModelTransform =
         glm::translate(glm::dmat4(1.0), _position) *
         _rotation *
         glm::scale(glm::dmat4(1.0), glm::dvec3(data.modelTransform.scale));
-    const glm::dmat4 modelViewTransform = viewMatrix * modelTransform;
-
-    // For frustum
-    const glm::dmat4 spacecraftModelTransform =
-        glm::translate(glm::dmat4(1.0), spacecraftPosWorld) *
-        _rotation *
-        glm::scale(glm::dmat4(1.0), glm::dvec3(data.modelTransform.scale));
+    const glm::dmat4 modelViewTransform = viewMatrix * planeModelTransform;
 
     _planeShader->activate();
     ghoul::opengl::TextureUnit imageUnit;
@@ -584,11 +595,31 @@ void RenderableSolarImagery::render(const RenderData& data, RendererTasks&) {
     // Must bind all sampler2D, otherwise undefined behavior
     _planeShader->setUniform(_uniformCachePlane.lut, tfUnit);
     _planeShader->setUniform(_uniformCachePlane.faceMode, _faceMode);
+    _planeShader->setUniform(
+        _uniformCachePlane.useAdditiveBlending,
+        _useAdditiveBlending
+    );
+
+    if (_useAdditiveBlending) {
+        glEnablei(GL_BLEND, 0);
+        glDepthMask(false);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+    }
+    else {
+        glDisablei(GL_BLEND, 0);
+    }
 
     glBindVertexArray(_quadVao);
     glDrawArrays(GL_TRIANGLES, 0, 6);
 
     _planeShader->deactivate();
+
+    // Render frustum
+    const glm::dmat4 spacecraftModelTransform =
+        glm::translate(glm::dmat4(1.0), spacecraftPosWorld) *
+        _rotation *
+        glm::scale(glm::dmat4(1.0), glm::dvec3(data.modelTransform.scale));
+
     _frustumShader->activate();
 
     _frustumShader->setUniform(_uniformCacheFrustum.scale, _currentScale);
@@ -617,6 +648,9 @@ void RenderableSolarImagery::render(const RenderData& data, RendererTasks&) {
     _frustumShader->deactivate();
 
     glDisable(GL_CULL_FACE);
+
+    global::renderEngine->openglStateCache().resetBlendState();
+    global::renderEngine->openglStateCache().resetDepthState();
 }
 
 void RenderableSolarImagery::update(const UpdateData& data) {

--- a/modules/solarbrowsing/rendering/renderablesolarimagery.cpp
+++ b/modules/solarbrowsing/rendering/renderablesolarimagery.cpp
@@ -123,7 +123,7 @@ namespace {
     constexpr Property::PropertyInfo UseAdditiveBlendingInfo = {
         "UseAdditiveBlending",
         "Use additive blending",
-        "If enabled, the plane is blended additively with the background. If disabled,  "
+        "If enabled, the plane is blended additively with the background. If disabled, "
         "the plane is rendered fully opaque. Note that this may lead to weird behaviors "
         "when the plane is rendered with transparency.",
         Property::Visibility::AdvancedUser
@@ -612,6 +612,9 @@ void RenderableSolarImagery::render(const RenderData& data, RendererTasks&) {
     glBindVertexArray(_quadVao);
     glDrawArrays(GL_TRIANGLES, 0, 6);
 
+    global::renderEngine->openglStateCache().resetBlendState();
+    global::renderEngine->openglStateCache().resetDepthState();
+
     _planeShader->deactivate();
 
     // Render frustum
@@ -648,9 +651,6 @@ void RenderableSolarImagery::render(const RenderData& data, RendererTasks&) {
     _frustumShader->deactivate();
 
     glDisable(GL_CULL_FACE);
-
-    global::renderEngine->openglStateCache().resetBlendState();
-    global::renderEngine->openglStateCache().resetDepthState();
 }
 
 void RenderableSolarImagery::update(const UpdateData& data) {

--- a/modules/solarbrowsing/rendering/renderablesolarimagery.cpp
+++ b/modules/solarbrowsing/rendering/renderablesolarimagery.cpp
@@ -123,9 +123,9 @@ namespace {
     constexpr Property::PropertyInfo UseAdditiveBlendingInfo = {
         "UseAdditiveBlending",
         "Use additive blending",
-        "If enabled (default), the plane is blended additively with the background. If "
-        "disabled, the plane is rendered fully opaque. Note that this may lead to weird "
-        "behaviors when the plane is rendered with transparency.",
+        "If enabled, the plane is blended additively with the background. If disabled,  "
+        "the plane is rendered fully opaque. Note that this may lead to weird behaviors "
+        "when the plane is rendered with transparency.",
         Property::Visibility::AdvancedUser
     };
 
@@ -251,7 +251,7 @@ RenderableSolarImagery::RenderableSolarImagery(const ghoul::Dictionary& dictiona
     , _enableBorder(EnableBorderInfo, false)
     , _enableFrustum(EnableFrustumInfo, false)
     , _faceMode(FaceModeInfo)
-    , _useAdditiveBlending(UseAdditiveBlendingInfo, true)
+    , _useAdditiveBlending(UseAdditiveBlendingInfo, false)
     , _gammaValue(GammaValueInfo, 0.9f, 0.1f, 10.f)
     , _moveFactor(MoveFactorInfo, 1.0, 0.0, 1.0)
     , _downsamplingLevel(DownsamplingLevelInfo, 2, 0, 5)

--- a/modules/solarbrowsing/rendering/renderablesolarimagery.h
+++ b/modules/solarbrowsing/rendering/renderablesolarimagery.h
@@ -104,6 +104,7 @@ private:
     BoolProperty _enableBorder;
     BoolProperty _enableFrustum;
     OptionProperty _faceMode;
+    BoolProperty _useAdditiveBlending;
     FloatProperty _gammaValue;
     DoubleProperty _moveFactor;
     IntProperty _downsamplingLevel;
@@ -134,7 +135,7 @@ private:
     // Image plane and frustum
     UniformCache(isCoronaGraph, scale, centerPixel, imageryTexture, planeOpacity,
         gammaValue, contrastValue, modelViewProjectionTransform, hasLut,
-        lut, faceMode) _uniformCachePlane;
+        lut, faceMode, useAdditiveBlending) _uniformCachePlane;
 
     UniformCache(planeOpacity, modelViewProjectionTransform,
         modelViewProjectionTransformPlane, scale, centerPixel) _uniformCacheFrustum;

--- a/modules/solarbrowsing/shaders/spacecraftimageplane_fs.glsl
+++ b/modules/solarbrowsing/shaders/spacecraftimageplane_fs.glsl
@@ -35,6 +35,7 @@ uniform sampler1D lut;
 uniform float contrastValue;
 uniform float gammaValue;
 uniform float planeOpacity;
+uniform bool useAdditiveBlending;
 uniform bool hasLut;
 uniform bool isCoronaGraph;
 uniform int faceMode;
@@ -90,6 +91,6 @@ Fragment getFragment() {
   Fragment frag;
   frag.color = vec4(outColor.rgb, planeOpacity);
   frag.depth = in_data.depth;
-  frag.blend = BlendModeAdditive;
+  frag.blend = useAdditiveBlending ? BlendModeAdditive : BlendModeNormal;
   return frag;
 }


### PR DESCRIPTION
This is a possible fix to blend the `RenderableSolarImagery` with its background. It looks good when viewed from the front but worse from the side due to issues with rendering order (?) that I do not have time to look into now. As you can see in img 3 vs 4, the flare will show slightly, but the sphere will render on top, and so it results in weird-looking visuals.

Before 
<img width="1703" height="986" alt="solarbrowsing-no-blending" src="https://github.com/user-attachments/assets/af6cedc7-4335-4ab3-8cfb-3b7baca71b30" />
After
<img width="1707" height="989" alt="solarbrowsing-blending" src="https://github.com/user-attachments/assets/29f727bd-be3c-4084-a0af-57826f5f2f20" />

Side before: 
<img width="1709" height="990" alt="solarbrowsing-no-blending-side" src="https://github.com/user-attachments/assets/ae2b9188-90ce-4f7b-89fd-2d92ad4fea4b" />

Side after:
<img width="1708" height="987" alt="solarbrowsing-blending-side" src="https://github.com/user-attachments/assets/cd28f8cd-ddb2-445c-ba0a-a498807b14af" />
