### PR TITLE
Add chips for multiple tags

### DIFF
--- a/apps/AssetBuilder/CMakeLists.txt
+++ b/apps/AssetBuilder/CMakeLists.txt
@@ -41,8 +41,10 @@ set(HEADER_FILES
   include/welcomedialog.h
   include/form/collapsiblesection.h
   include/form/colorwidget.h
+  include/form/flowlayout.h
   include/form/matrixwidget.h
   include/form/schemaformwidget.h
+  include/form/stringlistwidget.h
   include/form/searchdropdown.h
   include/schema/assetschema.h
 )
@@ -63,8 +65,10 @@ set(SOURCE_FILES
   src/welcomedialog.cpp
   src/form/collapsiblesection.cpp
   src/form/colorwidget.cpp
+  src/form/flowlayout.cpp
   src/form/matrixwidget.cpp
   src/form/schemaformwidget.cpp
+  src/form/stringlistwidget.cpp
   src/form/searchdropdown.cpp
   src/schema/assetschema.cpp
 )

--- a/apps/AssetBuilder/include/form/flowlayout.h
+++ b/apps/AssetBuilder/include/form/flowlayout.h
@@ -41,7 +41,7 @@ public:
      * \param vSpacing Vertical spacing between rows
      * \param parent Parent widget
      */
-    explicit FlowLayout(int hSpacing, int vSpacing, QWidget* parent);
+    FlowLayout(int hSpacing, int vSpacing, QWidget* parent);
 
     ~FlowLayout() override;
 

--- a/apps/AssetBuilder/include/form/flowlayout.h
+++ b/apps/AssetBuilder/include/form/flowlayout.h
@@ -1,0 +1,143 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+// Based on the Qt Flow Layout example (BSD license):
+// https://doc.qt.io/qt-6/qtwidgets-layouts-flowlayout-example.html
+
+#ifndef __OPENSPACE_ASSETBUILDER___FLOWLAYOUT___H__
+#define __OPENSPACE_ASSETBUILDER___FLOWLAYOUT___H__
+
+#include <QLayout>
+
+/**
+ * Custom layout that arranges child widgets left-to-right, wrapping to the next row when
+ * horizontal space runs out.
+ */
+class FlowLayout final : public QLayout {
+public:
+    /**
+     * \param hSpacing Horizontal spacing between items
+     * \param vSpacing Vertical spacing between rows
+     * \param parent Parent widget
+     */
+    explicit FlowLayout(int hSpacing, int vSpacing, QWidget* parent);
+
+    ~FlowLayout() override;
+
+    /**
+     * Adds an item to the layout. Ownership is transferred to the layout.
+     *
+     * \param item The layout item to add
+     */
+    void addItem(QLayoutItem* item) override;
+
+    /**
+     * Returns the number of items in the layout.
+     *
+     * \return Item count
+     */
+    int count() const override;
+
+    /**
+     * Returns the item at the given index, or `nullptr` if out of range.
+     *
+     * \param index Zero-based item index
+     * \return The layout item, or `nullptr`
+     */
+    QLayoutItem* itemAt(int index) const override;
+
+    /**
+     * Removes and returns the item at the given index, or `nullptr` if out of range.
+     *
+     * \param index Zero-based item index
+     * \return The removed layout item, or `nullptr`
+     */
+    QLayoutItem* takeAt(int index) override;
+
+    /**
+     * QLayout's default returns Qt::Horizontal | Qt::Vertical, which tells parent layouts
+     * that this layout wants to grow to fill available space. We return empty
+     * orientations instead so the flow layout only takes the height it actually
+     * needs for its content, rather than stretching to fill the parent.
+     *
+     * \return Empty Qt::Orientations
+     */
+    Qt::Orientations expandingDirections() const override;
+
+    /**
+     * Returns `true` since the layout height depends on the available width.
+     *
+     * \return Always `true`
+     */
+    bool hasHeightForWidth() const override;
+
+    /**
+     * Returns the required height to lay out all items within the given width.
+     *
+     * \param width Available horizontal space in pixels
+     * \return Total height consumed by the laid-out items
+     */
+    int heightForWidth(int width) const override;
+
+    /**
+     * Returns the minimum size needed to fit the largest single item.
+     *
+     * \return Minimum layout size
+     */
+    QSize minimumSize() const override;
+
+    /**
+     * Returns the preferred size (same as minimumSize).
+     *
+     * \return Preferred layout size
+     */
+    QSize sizeHint() const override;
+
+    /**
+     * Arranges all items within the given rectangle, wrapping to new rows as needed.
+     *
+     * \param rect The available rectangle for layout
+     */
+    void setGeometry(const QRect& rect) override;
+
+private:
+    /**
+     * Performs the wrapping layout calculation.
+     *
+     * \param rect Available rectangle
+     * \param testOnly When `true`, only computes height without moving widgets
+     * \return Total height consumed by the laid-out items
+     */
+    int doLayout(const QRect& rect, bool testOnly) const;
+
+    /// The layout items managed by this layout, in insertion order. Owned by the layout
+    /// and freed in the destructor
+    QList<QLayoutItem*> _items;
+    /// Horizontal spacing in pixels between items on the same row
+    int _hSpacing = 4;
+    /// Vertical spacing in pixels between rows
+    int _vSpacing = 4;
+};
+
+#endif // __OPENSPACE_ASSETBUILDER___FLOWLAYOUT___H__

--- a/apps/AssetBuilder/include/form/stringlistwidget.h
+++ b/apps/AssetBuilder/include/form/stringlistwidget.h
@@ -1,0 +1,90 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_ASSETBUILDER___STRINGLISTWIDGET___H__
+#define __OPENSPACE_ASSETBUILDER___STRINGLISTWIDGET___H__
+
+#include <QWidget>
+
+class QLineEdit;
+class QPushButton;
+
+/**
+ * Tag-style chip widget for editing a list of strings. Each entry is rendered as a
+ * removable chip in a flow layout, with an input field and add button at the bottom.
+ */
+class StringListWidget : public QWidget {
+Q_OBJECT
+public:
+    explicit StringListWidget(QWidget* parent = nullptr);
+
+    /**
+     * Returns the current list of string values from all chips.
+     *
+     * \return One entry per chip, in display order
+     */
+    QStringList values() const;
+
+    /**
+     * Replaces all chips with the given list of values.
+     *
+     * \param vals The strings to display as chips
+     */
+    void setValues(const QStringList& vals);
+
+    /**
+     * Returns `true` if at least one chip exists.
+     *
+     * \return `true` if the list is non-empty
+     */
+    bool hasContent() const;
+
+    /**
+     * Removes all chips and emits valueChanged.
+     */
+    void clear();
+
+signals:
+    /**
+     * Emitted whenever a chip is added or removed.
+     */
+    void valueChanged();
+
+private:
+    /**
+     * Creates a chip frame for the given text and adds it to the chip area.
+     *
+     * \param text The string value for this chip
+     */
+    void addChip(const QString& text);
+
+    /// Container widget whose layout holds the chip frames
+    QWidget* _chipArea = nullptr;
+    /// Text field for entering new values
+    QLineEdit* _input = nullptr;
+    /// Button to add the current input as a new chip
+    QPushButton* _addButton = nullptr;
+};
+
+#endif // __OPENSPACE_ASSETBUILDER___STRINGLISTWIDGET___H__

--- a/apps/AssetBuilder/include/form/stringlistwidget.h
+++ b/apps/AssetBuilder/include/form/stringlistwidget.h
@@ -27,6 +27,8 @@
 
 #include <QWidget>
 
+#include <QStringList>
+
 class QLineEdit;
 class QPushButton;
 

--- a/apps/AssetBuilder/resources/qss/assetbuilder.qss
+++ b/apps/AssetBuilder/resources/qss/assetbuilder.qss
@@ -595,6 +595,29 @@ QPushButton#field-remove-button:hover {
   color: #cc6666;
 }
 
+/* String list chips */
+
+QFrame#string-list-chip {
+  background-color: #2d4a6e;
+  border: 1px solid #3a6090;
+  border-radius: 10px;
+  padding: 1px 4px 1px 8px;
+}
+
+QPushButton#chip-remove-button {
+  background-color: transparent;
+  border: none;
+  color: #8ab4e0;
+  font-size: 10pt;
+  padding: 0 2px;
+  min-width: 16px;
+  max-width: 16px;
+}
+
+QPushButton#chip-remove-button:hover {
+  color: #cc6666;
+}
+
 /* Documentation browser */
 
 QTextBrowser#docs-browser {

--- a/apps/AssetBuilder/src/form/flowlayout.cpp
+++ b/apps/AssetBuilder/src/form/flowlayout.cpp
@@ -66,7 +66,7 @@ QLayoutItem* FlowLayout::takeAt(int index) {
 }
 
 Qt::Orientations FlowLayout::expandingDirections() const {
-    return {};
+    return Qt::Orientations();
 }
 
 bool FlowLayout::hasHeightForWidth() const {

--- a/apps/AssetBuilder/src/form/flowlayout.cpp
+++ b/apps/AssetBuilder/src/form/flowlayout.cpp
@@ -28,6 +28,7 @@
 #include "form/flowlayout.h"
 
 #include <QWidget>
+#include <algorithm>
 
 FlowLayout::FlowLayout(int hSpacing, int vSpacing, QWidget* parent)
     : QLayout(parent)

--- a/apps/AssetBuilder/src/form/flowlayout.cpp
+++ b/apps/AssetBuilder/src/form/flowlayout.cpp
@@ -1,0 +1,133 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+// Based on the Qt Flow Layout example (BSD license):
+// https://doc.qt.io/qt-6/qtwidgets-layouts-flowlayout-example.html
+
+#include "form/flowlayout.h"
+
+#include <QWidget>
+
+FlowLayout::FlowLayout(int hSpacing, int vSpacing, QWidget* parent)
+    : QLayout(parent)
+    , _hSpacing(hSpacing)
+    , _vSpacing(vSpacing)
+{}
+
+FlowLayout::~FlowLayout() {
+    // QLayoutItem does not inherit QObject, so items in _items have no Qt parent-child
+    // ownership and must be freed manually
+    while (QLayoutItem* item = takeAt(0)) {
+        delete item;
+    }
+}
+
+void FlowLayout::addItem(QLayoutItem* item) {
+    _items.append(item);
+}
+
+int FlowLayout::count() const {
+    return _items.size();
+}
+
+QLayoutItem* FlowLayout::itemAt(int index) const {
+    if (index >= 0 && index < _items.size()) {
+        return _items[index];
+    }
+    return nullptr;
+}
+
+QLayoutItem* FlowLayout::takeAt(int index) {
+    if (index >= 0 && index < _items.size()) {
+        return _items.takeAt(index);
+    }
+    return nullptr;
+}
+
+Qt::Orientations FlowLayout::expandingDirections() const {
+    return {};
+}
+
+bool FlowLayout::hasHeightForWidth() const {
+    return true;
+}
+
+int FlowLayout::heightForWidth(int width) const {
+    return doLayout(QRect(0, 0, width, 0), true);
+}
+
+QSize FlowLayout::minimumSize() const {
+    QSize size;
+    for (const QLayoutItem* item : _items) {
+        size = size.expandedTo(item->minimumSize());
+    }
+    // Add the layout's padding (space between the layout edge and its content) to the
+    // minimum size so the parent reserves enough room
+    const QMargins m = contentsMargins();
+    size += QSize(m.left() + m.right(), m.top() + m.bottom());
+    return size;
+}
+
+QSize FlowLayout::sizeHint() const {
+    return minimumSize();
+}
+
+void FlowLayout::setGeometry(const QRect& rect) {
+    QLayout::setGeometry(rect);
+    doLayout(rect, false);
+}
+
+int FlowLayout::doLayout(const QRect& rect, bool testOnly) const {
+    // Inset the available rectangle by the layout's padding so items are not placed
+    // directly against the layout edge. adjusted() adds offsets to each edge, so right
+    // and bottom are negated to move those edges inward rather than outward
+    const QMargins m = contentsMargins();
+    const QRect effective = rect.adjusted(m.left(), m.top(), -m.right(), -m.bottom());
+    int x = effective.x();
+    int y = effective.y();
+    int rowHeight = 0;
+
+    for (QLayoutItem* item : _items) {
+        const QSize itemSize = item->sizeHint();
+        // effective.right() is inclusive (left + width - 1), so + 1 gives the right edge
+        // that the item must not cross
+        const bool exceedsWidth = x + itemSize.width() > effective.right() + 1;
+        // Never wrap when the current row is still empty, otherwise an item wider than
+        // the row would push to a new row that is equally too narrow
+        const bool rowHasItems = rowHeight > 0;
+        // Wrap to next row if this item exceeds the available width
+        if (exceedsWidth && rowHasItems) {
+            x = effective.x();
+            y += rowHeight + _vSpacing;
+            rowHeight = 0;
+        }
+        if (!testOnly) {
+            item->setGeometry(QRect(QPoint(x, y), itemSize));
+        }
+        x += itemSize.width() + _hSpacing;
+        rowHeight = std::max(rowHeight, itemSize.height());
+    }
+    // Total height: content rows plus bottom padding
+    return y + rowHeight - rect.y() + m.bottom();
+}

--- a/apps/AssetBuilder/src/form/schemaformwidget.cpp
+++ b/apps/AssetBuilder/src/form/schemaformwidget.cpp
@@ -29,6 +29,7 @@
 #include "form/colorwidget.h"
 #include "form/matrixwidget.h"
 #include "form/searchdropdown.h"
+#include "form/stringlistwidget.h"
 #include "identifierregistry.h"
 #include "schema/assetschema.h"
 #include "path.h"
@@ -161,6 +162,9 @@ namespace {
         if (auto* checkBox = qobject_cast<QCheckBox*>(widget);  checkBox) {
             return checkBox->isChecked();
         }
+        if (auto* listWidget = qobject_cast<StringListWidget*>(widget);  listWidget) {
+            return listWidget->hasContent();
+        }
         if (auto* matrix = qobject_cast<MatrixWidget*>(widget);  matrix) {
             return matrix->hasContent();
         }
@@ -178,10 +182,35 @@ namespace {
     }
 
     void clearWidget(QWidget* widget) {
+        // Union containers: clear every child field widget and reset the combo to index 0
+        if (widget->objectName() == UnionContainerName) {
+            const auto children = widget->findChildren<QWidget*>(
+                QString(),
+                Qt::FindDirectChildrenOnly
+            );
+            for (QWidget* child : children) {
+                if (child->objectName() != UnionTypeComboName) {
+                    clearWidget(child);
+                }
+            }
+            if (auto* combo = widget->findChild<QComboBox*>(UnionTypeComboName);  combo) {
+                combo->blockSignals(true);
+                combo->setCurrentIndex(0);
+                combo->blockSignals(false);
+            }
+            return;
+        }
         if (auto* checkBox = qobject_cast<QCheckBox*>(widget);  checkBox) {
             checkBox->blockSignals(true);
             checkBox->setChecked(false);
             checkBox->blockSignals(false);
+        }
+        else if (auto* listWidget = qobject_cast<StringListWidget*>(widget);
+                 listWidget)
+        {
+            listWidget->blockSignals(true);
+            listWidget->clear();
+            listWidget->blockSignals(false);
         }
         else if (auto* matrix = qobject_cast<MatrixWidget*>(widget);  matrix) {
             matrix->blockSignals(true);
@@ -201,7 +230,7 @@ namespace {
                 lineEditFile->blockSignals(false);
             }
         }
-        else if (auto* combo = widget->findChild<QComboBox*>();  combo) {
+        else if (auto* combo = widget->findChild<QComboBox*>(); combo) {
             combo->blockSignals(true);
             combo->setCurrentText("");
             combo->blockSignals(false);
@@ -209,10 +238,23 @@ namespace {
     }
 
     void populateWidget(QWidget* widget, const PropertyValue& propertyValue) {
-        if (auto* checkBox = qobject_cast<QCheckBox*>(widget);  checkBox) {
+        if (auto* checkBox = qobject_cast<QCheckBox*>(widget); checkBox) {
             checkBox->blockSignals(true);
             checkBox->setChecked(propertyValue.isBool() ? propertyValue.toBool() : false);
             checkBox->blockSignals(false);
+        }
+        else if (auto* list = qobject_cast<StringListWidget*>(widget); list){
+            list->blockSignals(true);
+            if (propertyValue.isList()) {
+                QStringList items;
+                for (const PropertyValue& v : propertyValue.toList()) {
+                    if (v.isString()) {
+                        items << QString::fromStdString(v.toString());
+                    }
+                }
+                list->setValues(items);
+            }
+            list->blockSignals(false);
         }
         else if (auto* matrix = qobject_cast<MatrixWidget*>(widget);  matrix) {
             matrix->blockSignals(true);
@@ -316,7 +358,7 @@ namespace {
             for (int i = 0; i < typeCombo->count(); i++) {
                 const QString text = typeCombo->itemText(i);
                 if (text.startsWith("Vector") || text.startsWith("Color") ||
-                    text.startsWith("Matrix"))
+                    text.startsWith("Matrix") || text == "List of strings")
                 {
                     matchIndex = i;
                     break;
@@ -338,18 +380,24 @@ namespace {
         // setCurrentIndex triggers the show/hide lambda
         typeCombo->setCurrentIndex(matchIndex);
 
-        // Populate the now-visible field widget
+        // Populate the field widget for the matched type. The form is populated inside
+        // the constructor, before it is shown, so isVisible() reports false for every
+        // child here and cannot be used to find the active page. Instead rely on child
+        // order: the container's direct children are the type combo followed by the
+        // per-type field widgets in combo order, so the widget at matchIndex (after
+        // skipping the combo) is the one to fill.
+        QList<QWidget*> fieldWidgets;
         const auto children = container->findChildren<QWidget*>(
             QString(),
             Qt::FindDirectChildrenOnly
         );
-        for (QWidget* fieldWidget : children) {
-            if (fieldWidget->isVisible() &&
-                fieldWidget->objectName() != UnionTypeComboName)
-            {
-                populateWidget(fieldWidget, value);
-                break;
+        for (QWidget* child : children) {
+            if (child->objectName() != UnionTypeComboName) {
+                fieldWidgets.append(child);
             }
+        }
+        if (matchIndex >= 0 && matchIndex < fieldWidgets.size()) {
+            populateWidget(fieldWidgets[matchIndex], value);
         }
     }
 
@@ -1046,7 +1094,7 @@ void SchemaFormWidget::syncFieldWith(const std::string& memberName,
             &SchemaFormWidget::optionalFieldToggled,
             receiver,
             [receiver, memberName](const QString& name, bool active) {
-                if (name == memberName) {
+                if (name.toStdString() == memberName) {
                     receiver->setFieldActive(memberName, active);
                 }
             }
@@ -1770,14 +1818,51 @@ QWidget* SchemaFormWidget::createFlatWidget(const SchemaMember& member) {
             typeWidgets.append(widget);
         }
 
+        // Track the previously selected index so we can prompt before discarding a value
+        // when the user switches the union to a different type
+        auto previousIndex = std::make_shared<int>(typeCombo->currentIndex());
         connect(
             typeCombo,
             &QComboBox::currentIndexChanged,
             this,
-            [typeWidgets](int index) {
+            [this, typeWidgets, typeCombo, member, onChange, previousIndex](int index) {
+                const int previous = *previousIndex;
+                if (index == previous) {
+                    return;
+                }
+                // All union types write to the same property key, so the value entered
+                // for the old type would linger after switching. If that type still holds
+                // data, confirm before discarding it
+                const bool isValidIndex = previous >= 0 && previous < typeWidgets.size();
+                const bool hasContent = isValidIndex &&
+                    hasWidgetContent(typeWidgets[previous]);
+                if (hasContent) {
+                    const int result = QMessageBox::question(
+                        this,
+                        "Clear Field",
+                        QString("Switching the type of \"%1\" will clear its current "
+                            "value. Continue?").arg(splitPascalCase(member.name)),
+                        QMessageBox::Yes | QMessageBox::No
+                    );
+                    if (result != QMessageBox::Yes) {
+                        // User declined: revert the combo without re-triggering
+                        // this handler
+                        typeCombo->blockSignals(true);
+                        typeCombo->setCurrentIndex(previous);
+                        typeCombo->blockSignals(false);
+                        return;
+                    }
+                    clearWidget(typeWidgets[previous]);
+
+                    if (std::shared_ptr<PropertyMap> props = _properties.lock();  props) {
+                        props->erase(member.name);
+                    }
+                    onChange();
+                }
                 for (int i = 0; i < typeWidgets.size(); i++) {
                     typeWidgets[i]->setVisible(i == index);
                 }
+                *previousIndex = index;
             }
         );
 
@@ -2039,6 +2124,33 @@ QWidget* SchemaFormWidget::createFlatWidget(const SchemaMember& member) {
         horizontalLayout->addWidget(combo, 1);
         horizontalLayout->addWidget(browseButton);
         return container;
+    }
+    if (member.type == "List of strings") {
+        StringListWidget* listWidget = new StringListWidget;
+        connect(
+            listWidget,
+            &StringListWidget::valueChanged,
+            listWidget,
+            [this, member, listWidget, onChange]() {
+                std::shared_ptr<PropertyMap> lockedProperties = _properties.lock();
+                if (!lockedProperties) {
+                    return;
+                }
+                const QStringList values = listWidget->values();
+                if (values.isEmpty()) {
+                    lockedProperties->erase(member.name);
+                }
+                else {
+                    PropertyList list;
+                    for (const QString& v : values) {
+                        list.push_back(v.toStdString());
+                    }
+                    (*lockedProperties)[member.name] = std::move(list);
+                }
+                onChange();
+            }
+        );
+        return listWidget;
     }
     const QStringList options = parseInList(member.description);
     if (!options.isEmpty()) {

--- a/apps/AssetBuilder/src/form/schemaformwidget.cpp
+++ b/apps/AssetBuilder/src/form/schemaformwidget.cpp
@@ -184,7 +184,7 @@ namespace {
     void clearWidget(QWidget* widget) {
         // Union containers: clear every child field widget and reset the combo to index 0
         if (widget->objectName() == UnionContainerName) {
-            const auto children = widget->findChildren<QWidget*>(
+            const QList<QWidget*> children = widget->findChildren<QWidget*>(
                 QString(),
                 Qt::FindDirectChildrenOnly
             );
@@ -230,7 +230,7 @@ namespace {
                 lineEditFile->blockSignals(false);
             }
         }
-        else if (auto* combo = widget->findChild<QComboBox*>(); combo) {
+        else if (auto* combo = widget->findChild<QComboBox*>();  combo) {
             combo->blockSignals(true);
             combo->setCurrentText("");
             combo->blockSignals(false);
@@ -238,12 +238,12 @@ namespace {
     }
 
     void populateWidget(QWidget* widget, const PropertyValue& propertyValue) {
-        if (auto* checkBox = qobject_cast<QCheckBox*>(widget); checkBox) {
+        if (auto* checkBox = qobject_cast<QCheckBox*>(widget);  checkBox) {
             checkBox->blockSignals(true);
             checkBox->setChecked(propertyValue.isBool() ? propertyValue.toBool() : false);
             checkBox->blockSignals(false);
         }
-        else if (auto* list = qobject_cast<StringListWidget*>(widget); list){
+        else if (auto* list = qobject_cast<StringListWidget*>(widget);  list){
             list->blockSignals(true);
             if (propertyValue.isList()) {
                 QStringList items;

--- a/apps/AssetBuilder/src/form/stringlistwidget.cpp
+++ b/apps/AssetBuilder/src/form/stringlistwidget.cpp
@@ -45,7 +45,7 @@ StringListWidget::StringListWidget(QWidget* parent)
     // The FlowLayout reports its true (wrapped) height only via heightForWidth(). A
     // parent layout queries that only when the widget's size policy opts in, so enable
     // height-for-width here; otherwise the parent grid allocates just the one-row
-    // sizeHint and clips chips that wrap to later rows (e.g. when loading a long list).
+    // sizeHint and clips chips that wrap to later rows (e.g. when loading a long list)
     QSizePolicy selfPolicy = sizePolicy();
     selfPolicy.setHeightForWidth(true);
     setSizePolicy(selfPolicy);
@@ -54,7 +54,7 @@ StringListWidget::StringListWidget(QWidget* parent)
     outer->setContentsMargins(0, 0, 0, 0);
     outer->setSpacing(4);
 
-    // Chip area with flow layout — hidden when empty to avoid dead spacing
+    // Chip area with flow layout - hidden when empty to avoid dead spacing
     _chipArea = new QWidget(this);
     _chipArea->setVisible(false);
     new FlowLayout(ChipSpacing, ChipSpacing, _chipArea);
@@ -135,7 +135,7 @@ void StringListWidget::setValues(const QStringList& values) {
         }
     }
     _chipArea->setVisible(_chipArea->layout()->count() > 0);
-    // The chip count changed, so the wrapped height did too — prompt the parent layout
+    // The chip count changed, so the wrapped height did too - prompt the parent layout
     // to re-query heightForWidth and give the area room for every row
     _chipArea->updateGeometry();
     updateGeometry();
@@ -175,16 +175,21 @@ void StringListWidget::addChip(const QString& text) {
     chipLayout->addWidget(removeBtn);
 
     // Button to remove this chip: deletes the chip widget and emits valueChanged
-    connect(removeBtn, &QPushButton::clicked, this, [this, chip]() {
-        chip->setParent(nullptr);
-        delete chip;
-        // Forces the flow layout to recalculate positions and update geometry
-        _chipArea->layout()->activate();
-        // Hide the chip area if this was the last chip
-        const bool shouldShow = _chipArea->layout()->count() > 0;
-        _chipArea->setVisible(shouldShow);
-        emit valueChanged();
-    });
+    connect(
+        removeBtn,
+        &QPushButton::clicked,
+        this,
+        [this, chip]() {
+            chip->setParent(nullptr);
+            delete chip;
+            // Forces the flow layout to recalculate positions and update geometry
+            _chipArea->layout()->activate();
+            // Hide the chip area if this was the last chip
+            const bool shouldShow = _chipArea->layout()->count() > 0;
+            _chipArea->setVisible(shouldShow);
+            emit valueChanged();
+        }
+    );
 
     _chipArea->layout()->addWidget(chip);
 }

--- a/apps/AssetBuilder/src/form/stringlistwidget.cpp
+++ b/apps/AssetBuilder/src/form/stringlistwidget.cpp
@@ -1,0 +1,190 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include "form/stringlistwidget.h"
+
+#include "form/flowlayout.h"
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+namespace {
+    constexpr int ChipSpacing = 4;
+
+    // UTF-8 multiplication sign used as the remove glyph
+    constexpr const char* RemoveGlyph = "\xc3\x97";
+} // namespace
+
+StringListWidget::StringListWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    // The FlowLayout reports its true (wrapped) height only via heightForWidth(). A
+    // parent layout queries that only when the widget's size policy opts in, so enable
+    // height-for-width here; otherwise the parent grid allocates just the one-row
+    // sizeHint and clips chips that wrap to later rows (e.g. when loading a long list).
+    QSizePolicy selfPolicy = sizePolicy();
+    selfPolicy.setHeightForWidth(true);
+    setSizePolicy(selfPolicy);
+
+    QVBoxLayout* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(4);
+
+    // Chip area with flow layout — hidden when empty to avoid dead spacing
+    _chipArea = new QWidget(this);
+    _chipArea->setVisible(false);
+    new FlowLayout(ChipSpacing, ChipSpacing, _chipArea);
+    QSizePolicy chipPolicy = _chipArea->sizePolicy();
+    chipPolicy.setHeightForWidth(true);
+    _chipArea->setSizePolicy(chipPolicy);
+    outer->addWidget(_chipArea);
+
+    // Input row: text field + add button
+    QWidget* inputRow = new QWidget(this);
+    QHBoxLayout* inputLayout = new QHBoxLayout(inputRow);
+    inputLayout->setContentsMargins(0, 0, 0, 0);
+    inputLayout->setSpacing(4);
+
+    _input = new QLineEdit(inputRow);
+    _input->setPlaceholderText("Add...");
+    inputLayout->addWidget(_input, 1);
+
+    _addButton = new QPushButton("Add", inputRow);
+    _addButton->setObjectName("secondary");
+    inputLayout->addWidget(_addButton);
+
+    outer->addWidget(inputRow);
+
+    auto addFromInput = [this]() {
+        const QString text = _input->text().trimmed();
+        if (text.isEmpty()) {
+            return;
+        }
+        // Skip duplicates
+        const QStringList current = values();
+        if (current.contains(text)) {
+            _input->clear();
+            return;
+        }
+        addChip(text);
+        _chipArea->setVisible(true);
+        _input->clear();
+        emit valueChanged();
+    };
+
+    connect(_input, &QLineEdit::returnPressed, this, addFromInput);
+    connect(_addButton, &QPushButton::clicked, this, addFromInput);
+}
+
+QStringList StringListWidget::values() const {
+    QStringList result;
+    QLayout* layout = _chipArea->layout();
+    if (!layout) {
+        return result;
+    }
+    for (int i = 0; i < layout->count(); i++) {
+        QWidget* chip = layout->itemAt(i)->widget();
+        if (!chip) {
+            continue;
+        }
+        QLabel* label = chip->findChild<QLabel*>();
+        if (label) {
+            result << label->text();
+        }
+    }
+    return result;
+}
+
+void StringListWidget::setValues(const QStringList& values) {
+    // Remove all existing chips
+    QLayout* layout = _chipArea->layout();
+    if (layout) {
+        while (QLayoutItem* item = layout->takeAt(0)) {
+            delete item->widget();
+            delete item;
+        }
+    }
+    for (const QString& value : values) {
+        const QString trimmed = value.trimmed();
+        if (!trimmed.isEmpty()) {
+            addChip(trimmed);
+        }
+    }
+    _chipArea->setVisible(_chipArea->layout()->count() > 0);
+    // The chip count changed, so the wrapped height did too — prompt the parent layout
+    // to re-query heightForWidth and give the area room for every row
+    _chipArea->updateGeometry();
+    updateGeometry();
+}
+
+bool StringListWidget::hasContent() const {
+    QLayout* layout = _chipArea->layout();
+    return layout && layout->count() > 0;
+}
+
+void StringListWidget::clear() {
+    QLayout* layout = _chipArea->layout();
+    if (layout) {
+        while (QLayoutItem* item = layout->takeAt(0)) {
+            delete item->widget();
+            delete item;
+        }
+    }
+    _chipArea->setVisible(false);
+    emit valueChanged();
+}
+
+void StringListWidget::addChip(const QString& text) {
+    QFrame* chip = new QFrame(_chipArea);
+    chip->setObjectName("string-list-chip");
+
+    QHBoxLayout* chipLayout = new QHBoxLayout(chip);
+    chipLayout->setContentsMargins(0, 0, 0, 0);
+    chipLayout->setSpacing(2);
+
+    QLabel* label = new QLabel(text, chip);
+    chipLayout->addWidget(label);
+
+    QPushButton* removeBtn = new QPushButton(RemoveGlyph, chip);
+    removeBtn->setObjectName("chip-remove-button");
+    removeBtn->setFixedSize(16, 16);
+    chipLayout->addWidget(removeBtn);
+
+    // Button to remove this chip: deletes the chip widget and emits valueChanged
+    connect(removeBtn, &QPushButton::clicked, this, [this, chip]() {
+        chip->setParent(nullptr);
+        delete chip;
+        // Forces the flow layout to recalculate positions and update geometry
+        _chipArea->layout()->activate();
+        // Hide the chip area if this was the last chip
+        const bool shouldShow = _chipArea->layout()->count() > 0;
+        _chipArea->setVisible(shouldShow);
+        emit valueChanged();
+    });
+
+    _chipArea->layout()->addWidget(chip);
+}


### PR DESCRIPTION
* Adds verifiers to codegen to get the List of String type instead of Table for the "Tag" field on a Scenegraphnode
* Adds new input field with chips to asset builder

To test:
* Create asset with asset builder and use the tag
* Try loading this in OpenSpace and Asset Builder

Closes #4061 