### PR TITLE
Fix powerscaling case sensitive includes

### DIFF
--- a/modules/solarbrowsing/shaders/spacecraftimagefrustum_vs.glsl
+++ b/modules/solarbrowsing/shaders/spacecraftimagefrustum_vs.glsl
@@ -24,7 +24,7 @@
 
 #version __CONTEXT__
 
-#include "powerScaling/powerScaling_vs.glsl"
+#include "powerscaling/powerscaling_vs.glsl"
 
 layout(location = 0) in vec4 in_position;
 

--- a/modules/solarbrowsing/shaders/spacecraftimageplane_vs.glsl
+++ b/modules/solarbrowsing/shaders/spacecraftimageplane_vs.glsl
@@ -24,7 +24,7 @@
 
 #version __CONTEXT__
 
-#include "powerScaling/powerScaling_vs.glsl"
+#include "powerscaling/powerscaling_vs.glsl"
 
 layout(location = 0) in vec2 in_position;
 layout(location = 1) in vec2 in_texCoords;

--- a/modules/solarbrowsing/shaders/spacecraftimageprojection_vs.glsl
+++ b/modules/solarbrowsing/shaders/spacecraftimageprojection_vs.glsl
@@ -24,7 +24,7 @@
 
 #version __CONTEXT__
 
-#include "powerScaling/powerScaling_vs.glsl"
+#include "powerscaling/powerscaling_vs.glsl"
 
 const int MaxSpacecraftObservatories = 7;
 

--- a/modules/volume/shaders/vectorfield_gs.glsl
+++ b/modules/volume/shaders/vectorfield_gs.glsl
@@ -24,7 +24,7 @@
 
 #version __CONTEXT__
 
-#include "powerScaling/powerScaling_vs.glsl"
+#include "powerscaling/powerscaling_vs.glsl"
 
 // The shader expands a single point vertex into an arrow originally pointing along +X
 // direction, it is then rotated to match the direction of the incomming vector.


### PR DESCRIPTION
Some module shaders still used `powerScaling` instead of `powerscaling` in their includes, which broke shaders on Linux and other case sensitive filesystems.