### PR TITLE
Fix globe browsing skirt artefact

### DIFF
--- a/modules/globebrowsing/shaders/globalrenderer_vs.glsl
+++ b/modules/globebrowsing/shaders/globalrenderer_vs.glsl
@@ -120,9 +120,10 @@ void main() {
   );
 
   // Get the height value and apply skirts
-  out_data.isSkirt = tileVertexSkirtLength() > 0.0 ? 1.0 : 0.0;
+  float skirtLength = tileVertexSkirtLength();
+  out_data.isSkirt = skirtLength > 0.0 ? 1.0 : 0.0;
   float height =
-    tileHeight(in_texCoords, out_data.levelWeights) - tileVertexSkirtLength();
+    tileHeight(in_texCoords, out_data.levelWeights) - skirtLength;
 
 #if USE_ACCURATE_NORMALS
   // Calculate tangents

--- a/modules/globebrowsing/shaders/globalrenderer_vs.glsl
+++ b/modules/globebrowsing/shaders/globalrenderer_vs.glsl
@@ -37,6 +37,7 @@ layout(location = 1) in vec2 in_texCoords;
 out Data {
   vec4 position;
   vec2 texCoords;
+  float isSkirt;
   vec3 ellipsoidNormalCameraSpace;
   vec3 levelWeights;
   vec3 positionCameraSpace;
@@ -119,6 +120,7 @@ void main() {
   );
 
   // Get the height value and apply skirts
+  out_data.isSkirt = tileVertexSkirtLength() > 0.0 ? 1.0 : 0.0;
   float height =
     tileHeight(in_texCoords, out_data.levelWeights) - tileVertexSkirtLength();
 

--- a/modules/globebrowsing/shaders/localrenderer_vs.glsl
+++ b/modules/globebrowsing/shaders/localrenderer_vs.glsl
@@ -37,6 +37,7 @@ layout(location = 1) in vec2 in_texCoords;
 out Data {
   vec4 position;
   vec2 texCoords;
+  float isSkirt;
   vec3 ellipsoidNormalCameraSpace;
   vec3 levelWeights;
   vec3 positionCameraSpace;
@@ -107,6 +108,7 @@ void main() {
   );
 
   // Get the height value and apply skirts
+  out_data.isSkirt = tileVertexSkirtLength() > 0.0 ? 1.0 : 0.0;
   float height =
     tileHeightScaled(in_texCoords, out_data.levelWeights) - tileVertexSkirtLength() *
     100.0;

--- a/modules/globebrowsing/shaders/localrenderer_vs.glsl
+++ b/modules/globebrowsing/shaders/localrenderer_vs.glsl
@@ -108,9 +108,10 @@ void main() {
   );
 
   // Get the height value and apply skirts
-  out_data.isSkirt = tileVertexSkirtLength() > 0.0 ? 1.0 : 0.0;
+  float skirtLength = tileVertexSkirtLength();
+  out_data.isSkirt = skirtLength > 0.0 ? 1.0 : 0.0;
   float height =
-    tileHeightScaled(in_texCoords, out_data.levelWeights) - tileVertexSkirtLength() *
+    tileHeightScaled(in_texCoords, out_data.levelWeights) - skirtLength *
     100.0;
 
   // Translate the point along normal

--- a/modules/globebrowsing/shaders/renderer_fs.glsl
+++ b/modules/globebrowsing/shaders/renderer_fs.glsl
@@ -203,10 +203,10 @@ Fragment getFragment() {
   Fragment frag;
   frag.color = vec4(0.3, 0.3, 0.3, 1.0);
 
-  // Skirts are vertical walls that hide gaps between neighbouring tiles. They sit
-  // below the surface and are occluded while the globe is opaque, but once the globe
-  // is faded they become visible as stretched edges. Drop the skirt fragments when
-  // the globe is transparent.
+  // Skirts are vertical walls that hide gaps between neighboring tiles. They sit below
+  // the surface and are occluded while the globe is opaque, but once the globe is faded
+  // they become visible as stretched edges. Drop the skirt fragments when the globe is
+  // transparent
   if (opacity < 1.0 && in_data.isSkirt > 0.0) {
     discard;
   }

--- a/modules/globebrowsing/shaders/renderer_fs.glsl
+++ b/modules/globebrowsing/shaders/renderer_fs.glsl
@@ -34,6 +34,7 @@
 in Data {
   vec4 position;
   vec2 texCoords;
+  float isSkirt;
   vec3 ellipsoidNormalCameraSpace;
   vec3 levelWeights;
   vec3 positionCameraSpace;
@@ -201,6 +202,14 @@ uniform float opacity;
 Fragment getFragment() {
   Fragment frag;
   frag.color = vec4(0.3, 0.3, 0.3, 1.0);
+
+  // Skirts are vertical walls that hide gaps between neighbouring tiles. They sit
+  // below the surface and are occluded while the globe is opaque, but once the globe
+  // is faded they become visible as stretched edges. Drop the skirt fragments when
+  // the globe is transparent.
+  if (opacity < 1.0 && in_data.isSkirt > 0.0) {
+    discard;
+  }
 
   vec3 normal = normalize(in_data.ellipsoidNormalCameraSpace);
 


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/e39ea2c8-d882-4991-82cd-bd9968bcabd6

After:

https://github.com/user-attachments/assets/6993ddae-7c8b-4768-ba88-26c896198951

The fix is that each vertex is given a float (0 or 1) if it is a skirt (pushed in edge) or not. If the opacity is less than 0 (includes fading) then a vertex with skirt value 1 will be discarded.