### PR TITLE
Queue messages to be sent via main thread

### DIFF
--- a/include/openspace/topic/topics/errorlogtopic.h
+++ b/include/openspace/topic/topics/errorlogtopic.h
@@ -46,16 +46,23 @@ public:
     static openspace::Schema Schema();
 
 private:
+    static constexpr int UnsetOnChangeHandle = -1;
+
     /**
      * Creates a log object and register it to the `LogManager`, does nothing if an active
      * log already exists.
      */
     void createLog();
 
+    void flushQueuedMessages();
+
     bool _isSubscribedTo = false;
+    int _dataCallbackHandle = UnsetOnChangeHandle;
 
     /// Non-owning but we remove the log from LogManager on destruction
     ghoul::logging::Log* _log = nullptr;
+    std::vector<nlohmann::json> _queuedMessages;
+    std::mutex _queuedMessagesMutex;
 
     struct {
         bool isTimeStamping = true;

--- a/include/openspace/topic/topics/errorlogtopic.h
+++ b/include/openspace/topic/topics/errorlogtopic.h
@@ -28,6 +28,7 @@
 #include <openspace/topic/topics/topic.h>
 
 #include <ghoul/logging/loglevel.h>
+#include <optional>
 
 namespace ghoul::logging { class Log; }
 
@@ -46,8 +47,6 @@ public:
     static openspace::Schema Schema();
 
 private:
-    static constexpr int UnsetOnChangeHandle = -1;
-
     /**
      * Creates a log object and register it to the `LogManager`, does nothing if an active
      * log already exists.
@@ -57,7 +56,7 @@ private:
     void flushQueuedMessages();
 
     bool _isSubscribedTo = false;
-    int _dataCallbackHandle = UnsetOnChangeHandle;
+    std::optional<int> _dataCallbackHandle;
 
     /// Non-owning but we remove the log from LogManager on destruction
     ghoul::logging::Log* _log = nullptr;

--- a/src/topic/server.cpp
+++ b/src/topic/server.cpp
@@ -97,6 +97,7 @@ Server::Server()
     global::callback::preSync->emplace_back([this]() {
         using K = CallbackHandle;
         using V = CallbackFunction;
+        // Loop over all registered callbacks and call them
         for (const std::pair<K, V>& it : _preSyncCallbacks) {
             it.second();
         }

--- a/src/topic/topics/errorlogtopic.cpp
+++ b/src/topic/topics/errorlogtopic.cpp
@@ -25,7 +25,9 @@
 #include <openspace/topic/topics/errorlogtopic.h>
 
 #include <openspace/documentation/schema.h>
+#include <openspace/engine/globals.h>
 #include <openspace/topic/notificationlog.h>
+#include <openspace/topic/server.h>
 #include <ghoul/logging/logmanager.h>
 #include <ghoul/misc/stringconversion.h>
 #include <string_view>
@@ -37,6 +39,9 @@ ErrorLogTopic::~ErrorLogTopic() {
     if (_log) {
         ghoul::logging::LogManager::ref().removeLog(_log);
         _log = nullptr;
+    }
+    if (_dataCallbackHandle != UnsetOnChangeHandle) {
+        global::server->removePreSyncCallback(_dataCallbackHandle);
     }
 }
 
@@ -126,7 +131,9 @@ void ErrorLogTopic::createLog() {
             payload["level"] = ghoul::to_string(level);
         }
 
-        sendData(std::move(payload));
+        // Queue the message to be sent
+        const std::unique_lock lock(_queuedMessagesMutex);
+        _queuedMessages.push_back(std::move(payload));
     };
 
     auto log = std::make_unique<NotificationLog>(
@@ -135,6 +142,27 @@ void ErrorLogTopic::createLog() {
     );
     _log = log.get();
     ghoul::logging::LogManager::ref().addLog(std::move(log));
+
+    if (_dataCallbackHandle == UnsetOnChangeHandle) {
+        _dataCallbackHandle = global::server->addPreSyncCallback(
+            [this]() {
+                flushQueuedMessages();
+            }
+        );
+    }
+}
+
+void ErrorLogTopic::flushQueuedMessages() {
+    std::vector<nlohmann::json> messagesToSend;
+    {
+        const std::unique_lock lock(_queuedMessagesMutex);
+        std::swap(messagesToSend, _queuedMessages);
+    }
+
+    for (const nlohmann::json& message : messagesToSend) {
+        sendData(message);
+    }
+
 }
 
 bool ErrorLogTopic::isDone() const {

--- a/src/topic/topics/errorlogtopic.cpp
+++ b/src/topic/topics/errorlogtopic.cpp
@@ -40,8 +40,8 @@ ErrorLogTopic::~ErrorLogTopic() {
         ghoul::logging::LogManager::ref().removeLog(_log);
         _log = nullptr;
     }
-    if (_dataCallbackHandle != UnsetOnChangeHandle) {
-        global::server->removePreSyncCallback(_dataCallbackHandle);
+    if (_dataCallbackHandle.has_value()) {
+        global::server->removePreSyncCallback(*_dataCallbackHandle);
     }
 }
 
@@ -136,14 +136,11 @@ void ErrorLogTopic::createLog() {
         _queuedMessages.push_back(std::move(payload));
     };
 
-    auto log = std::make_unique<NotificationLog>(
-        onLogging,
-        _logSettings.logLevel
-    );
+    auto log = std::make_unique<NotificationLog>(onLogging, _logSettings.logLevel);
     _log = log.get();
     ghoul::logging::LogManager::ref().addLog(std::move(log));
 
-    if (_dataCallbackHandle == UnsetOnChangeHandle) {
+    if (!_dataCallbackHandle.has_value()) {
         _dataCallbackHandle = global::server->addPreSyncCallback(
             [this]() {
                 flushQueuedMessages();

--- a/src/topic/topics/errorlogtopic.cpp
+++ b/src/topic/topics/errorlogtopic.cpp
@@ -159,7 +159,6 @@ void ErrorLogTopic::flushQueuedMessages() {
     for (const nlohmann::json& message : messagesToSend) {
         sendData(message);
     }
-
 }
 
 bool ErrorLogTopic::isDone() const {

--- a/src/topic/topics/errorlogtopic.cpp
+++ b/src/topic/topics/errorlogtopic.cpp
@@ -108,26 +108,28 @@ void ErrorLogTopic::createLog() {
         return;
     }
 
-    auto onLogging = [this](std::string_view timeStamp, std::string_view dateStamp,
+    // _logSettings is an anonymous struct hence the use of auto
+    const auto logSettings = _logSettings;
+    auto onLogging = [this, logSettings](std::string_view timeStamp, std::string_view dateStamp,
                             std::string_view category, ghoul::logging::LogLevel level,
                             std::string_view message)
     {
         nlohmann::json payload;
         payload["message"] = message;
 
-        if (_logSettings.isTimeStamping) {
+        if (logSettings.isTimeStamping) {
             payload["timeStamp"] = timeStamp;
         }
 
-        if (_logSettings.isCategoryStamping) {
+        if (logSettings.isCategoryStamping) {
             payload["category"] = category;
         }
 
-        if (_logSettings.isDateStamping) {
+        if (logSettings.isDateStamping) {
             payload["dateStamp"] = dateStamp;
         }
 
-        if (_logSettings.isLogLevelStamping) {
+        if (logSettings.isLogLevelStamping) {
             payload["level"] = ghoul::to_string(level);
         }
 


### PR DESCRIPTION
Fixes an issue where we tried locking the same mutex deep inside ghoul networking files when disconnecting (or connecting) an app. Topic messages are now put in a queue and sent from the main thread on presync instead of synchronous on the same thread

Appeared with the recent ghoul network changes https://github.com/OpenSpace/Ghoul/pull/137