### PR TITLE
Set light source UI name from new `Name` parameter, or from identifier

### DIFF
--- a/src/scene/lightsource.cpp
+++ b/src/scene/lightsource.cpp
@@ -57,6 +57,10 @@ namespace {
         // The identifier of the light source.
         std::string identifier [[codegen::identifier()]];
 
+        // An optional name for the light source, to show in the GUI. If not specified,
+        // the identifier is used.
+        std::optional<std::string> name;
+
         // [[codegen::verbatim(EnabledInfo.description)]]
         std::optional<bool> enabled;
     };
@@ -80,20 +84,24 @@ std::unique_ptr<LightSource> LightSource::createFromDictionary(
 
     ghoul::TemplateFactory<LightSource>* factory =
         FactoryManager::ref().factory<LightSource>();
-    LightSource* source = factory->create(p.type, dictionary);
-    source->setIdentifier(p.identifier);
 
-    source->_type = p.type;
+    LightSource* source = factory->create(p.type, dictionary);
+
     return std::unique_ptr<LightSource>(source);
 }
 
 LightSource::LightSource(const ghoul::Dictionary& dictionary)
-    : PropertyOwner({ "LightSource", "Light Source" })
+    : PropertyOwner({ "LightSource" })
     , _enabled(EnabledInfo, true)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
-    addProperty(_enabled);
+
     _enabled = p.enabled.value_or(_enabled);
+    addProperty(_enabled);
+
+    _type = p.type;
+    _identifier = p.identifier;
+    _guiName = p.name.value_or(_identifier);
 }
 
 bool LightSource::initialize() {


### PR DESCRIPTION
Fixes an issue where all added light sources appeared with the same name in the UI. The identifier is now shown instead, and it is possible to add a `Name` for the property owner as well. 

This is a small PR, opened for visibility: the `Name` field isn't currently used anywhere, but is now available for future use 🙂 

Also cleans up the construction code by initializing all parameters in the constructor instead of `createFromDictionary`. 

Here's an example with an extra light source for ISS:
<img width="468" height="497" alt="image" src="https://github.com/user-attachments/assets/cfea1707-9c22-4c64-9e7c-f5a6acdc0ad1" />

After this change 
<img width="353" height="256" alt="after" src="https://github.com/user-attachments/assets/a509187b-005b-4c71-8ccf-6efd936f78c8" />

Before
<img width="337" height="244" alt="image" src="https://github.com/user-attachments/assets/52e12f0e-bd87-413c-b7c0-cb35e37182c8" />

