### PR TITLE
Fixes to `ScreenSpaceTimeVaryingImageOnline`

### DIFF
--- a/data/assets/examples/screenspacerenderable/screenspacetimevaryingimageonline/timevaryingimageonline.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacetimevaryingimageonline/timevaryingimageonline.asset
@@ -1,7 +1,11 @@
 -- Basic
 -- Create a time-varying screenspace image plane that shows the content of images from
--- web URLs based on in-game simulation time. The data in this example has images shown at
--- 2024-05-10 between 15:00:00 and 15:20:00.
+-- web URLs based on in-game simulation time. The image to display is selected according
+-- to timestamp information provided in a data file. If the simulation time is outside
+-- the range of timestamps in the data file, no image is displayed.
+
+-- The data in this example has images shown at 2024-05-10 between 15:00:00 and
+-- 15:20:00.
 
 local Item = {
   Type = "ScreenSpaceTimeVaryingImageOnline",

--- a/data/assets/examples/screenspacerenderable/screenspacetimevaryingimageonline/timevaryingimageonline.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacetimevaryingimageonline/timevaryingimageonline.asset
@@ -2,7 +2,7 @@
 -- Create a time-varying screenspace image plane that shows the content of images from
 -- web URLs based on in-game simulation time. The image to display is selected according
 -- to timestamp information provided in a data file. If the simulation time is outside
--- the range of timestamps in the data file, no image is displayed.
+-- the time range covered by the data file, no image is displayed.
 
 -- The data in this example has images shown at 2024-05-10 between 15:00:00 and
 -- 15:20:00.

--- a/data/assets/examples/screenspacerenderable/screenspacetimevaryingimageonline/timevaryingimageonline_show-before-after.asset
+++ b/data/assets/examples/screenspacerenderable/screenspacetimevaryingimageonline/timevaryingimageonline_show-before-after.asset
@@ -1,0 +1,25 @@
+-- Show Before and After
+-- Create a time-varying screenspace image plane that displays images from web URLs
+-- based on the in-game simulation time. In this example, the first image is also shown
+-- before the first timestamp, and the last image is shown after the last timestamp.
+-- Images are selected according to timestamp information provided in a data file.
+--
+-- The data in this example contains images shown on 2024-05-10 between 15:00:00
+-- and 15:20:00.
+
+local Item = {
+  Type = "ScreenSpaceTimeVaryingImageOnline",
+  Identifier = "ScreenSpaceTimeVaryingImageOnline_Example_ShowBeforeAfter",
+  FilePath = asset.resource("data/example.json"),
+  ShowBefore = true,
+  ShowAfter = true
+}
+
+
+asset.onInitialize(function()
+  openspace.addScreenSpaceRenderable(Item)
+end)
+
+asset.onDeinitialize(function()
+  openspace.removeScreenSpaceRenderable(Item)
+end)

--- a/modules/base/rendering/screenspacetimevaryingimageonline.cpp
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.cpp
@@ -146,6 +146,13 @@ void ScreenSpaceTimeVaryingImageOnline::computeSequenceEndTime() {
     _sequenceEndTime = last + avg;
 }
 
+void ScreenSpaceTimeVaryingImageOnline::render(const RenderData& renderData) {
+    if (!_texture) {
+        return;
+    }
+    ScreenSpaceRenderable::render(renderData);
+}
+
 void ScreenSpaceTimeVaryingImageOnline::update() {
     if (_timestamps.empty()) {
         return;

--- a/modules/base/rendering/screenspacetimevaryingimageonline.cpp
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.cpp
@@ -66,7 +66,7 @@ namespace {
         "ShowAfter",
         "Show image after last time",
         "If enabled, the image with the latest timestamp is shown when the simulation "
-        "time is after the lasttimestamp specified in the data file.",
+        "time is after the last timestamp specified in the data file.",
         Property::Visibility::User
     };
 

--- a/modules/base/rendering/screenspacetimevaryingimageonline.cpp
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.cpp
@@ -54,6 +54,29 @@ namespace {
         Property::Visibility::User
     };
 
+    constexpr Property::PropertyInfo ShowBeforeInfo = {
+        "ShowBefore",
+        "Show image before first time",
+        "If enabled, the image with the earliest timestamp is shown when the simulation "
+        "time is before the first timestamp specified in the data file.",
+        Property::Visibility::User
+    };
+
+    constexpr Property::PropertyInfo ShowAfterInfo = {
+        "ShowAfter",
+        "Show image after last time",
+        "If enabled, the image with the latest timestamp is shown when the simulation "
+        "time is after the lasttimestamp specified in the data file.",
+        Property::Visibility::User
+    };
+
+    constexpr Property::PropertyInfo JumpToFirstTimeInfo = {
+        "JumpToFirstTime",
+        "Jump to first time",
+        "Performs a time jump to the first timestamp in the loaded file.",
+        Property::Visibility::NoviceUser
+    };
+
     // Displays an image based on the current in-game simulation time. The image shown is
     // selected from a JSON file containing timestamp-URL pairs. The image with the
     // closest timestamp before or equal to the current time is displayed.
@@ -68,6 +91,12 @@ namespace {
     struct [[codegen::Dictionary(ScreenSpaceTimeVaryingImageOnline)]] Parameters {
         // [[codegen::verbatim(FileInfo.description)]]
         std::filesystem::path filePath;
+
+        // [[codegen::verbatim(ShowBeforeInfo.description)]]
+        std::optional<bool> showBefore;
+
+        // [[codegen::verbatim(ShowAfterInfo.description)]]
+        std::optional<bool> showAfter;
     };
 } // namespace
 #include "screenspacetimevaryingimageonline_codegen.cpp"
@@ -85,12 +114,31 @@ ScreenSpaceTimeVaryingImageOnline::ScreenSpaceTimeVaryingImageOnline(
                                                       const ghoul::Dictionary& dictionary)
     : ScreenSpaceRenderable(dictionary)
     , _jsonFilePath(FileInfo, "")
+    , _showBefore(ShowBeforeInfo, false)
+    , _showAfter(ShowAfterInfo, false)
+    , _jumpToFirstTime(JumpToFirstTimeInfo)
 {
     const Parameters p = codegen::bake<Parameters>(dictionary);
 
     _jsonFilePath = p.filePath.string();
     _jsonFilePath.onChange([this]() { loadJsonData(_jsonFilePath.value()); });
     addProperty(_jsonFilePath);
+
+    _showBefore = p.showBefore.value_or(_showBefore);
+    addProperty(_showBefore);
+
+    _showAfter = p.showAfter.value_or(_showAfter);
+    addProperty(_showAfter);
+
+    _jumpToFirstTime.onChange([this]() {
+        if (_timestamps.empty()) {
+            LWARNING("Cannot jump to first time because no times were loaded");
+        }
+        else {
+            global::timeManager->setTimeNextFrame(Time(_timestamps[0]));
+        }
+    });
+    addProperty(_jumpToFirstTime);
 }
 
 void ScreenSpaceTimeVaryingImageOnline::initialize() {
@@ -160,25 +208,23 @@ void ScreenSpaceTimeVaryingImageOnline::update() {
 
     const double current = global::timeManager->time().j2000Seconds();
 
-    if (current < _timestamps.front() || current >= _sequenceEndTime) {
+    const bool timeIsBeforeFirst = current < _timestamps.front();
+    const bool timeIsLastOrLater = current >= _sequenceEndTime;
+
+    if ((!_showBefore && timeIsBeforeFirst) || (!_showAfter && timeIsLastOrLater)) {
         _activeIndex = -1;
         _texture = nullptr;
         _currentUrl.clear();
         return;
     }
 
-    if (current >= _timestamps.front() && current < _sequenceEndTime) {
-        if (int idx = activeIndex(current);  idx != _activeIndex) {
-            _activeIndex = idx;
-            std::string url = _urls[_timestamps[_activeIndex]];
-            if (_currentUrl != url) {
-                _currentUrl = url;
-                loadImage(url);
-            }
+    if (int idx = activeIndex(current);  idx != _activeIndex) {
+        _activeIndex = idx;
+        std::string url = _urls[_timestamps[_activeIndex]];
+        if (_currentUrl != url) {
+            _currentUrl = url;
+            loadImage(url);
         }
-    }
-    else {
-        _activeIndex = -1;
     }
 
     if (_imageFuture.valid() && DownloadManager::futureReady(_imageFuture)) {

--- a/modules/base/rendering/screenspacetimevaryingimageonline.h
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.h
@@ -29,6 +29,8 @@
 
 #include <openspace/engine/downloadmanager.h>
 #include <openspace/properties/misc/stringproperty.h>
+#include <openspace/properties/misc/triggerproperty.h>
+#include <openspace/properties/scalar/boolproperty.h>
 #include <filesystem>
 #include <future>
 
@@ -56,6 +58,9 @@ private:
     int activeIndex(double currentTime) const;
 
     StringProperty _jsonFilePath;
+    BoolProperty _showBefore;
+    BoolProperty _showAfter;
+    TriggerProperty _jumpToFirstTime;
 
     std::future<DownloadManager::MemoryFile> _imageFuture;
     std::map<double, std::string> _urls;

--- a/modules/base/rendering/screenspacetimevaryingimageonline.h
+++ b/modules/base/rendering/screenspacetimevaryingimageonline.h
@@ -42,6 +42,8 @@ public:
 
     void initialize() override;
     void deinitializeGL() override;
+
+    void render(const RenderData& renderData) override;
     void update() override;
 
     static openspace::Documentation Documentation();


### PR DESCRIPTION
* Fix a rendering bug where the plane was rendered with whatever texture was bound when outside valid data time. 
* Add new properties `ShowBefore` and `ShowAfter` to decide whether the image should stay visible before/after the first/last time + add an example
* Add a trigger property to jump to the first time in the data file (there is no way of knowing what this is from the UI otherwise)

I feel like this renderable could use some testing in general, so please try it out and see if there are other imporvement we want to make