### PR TITLE
Fix dashboarditemangle crash 

### DIFF
--- a/modules/base/dashboard/dashboarditemangle.cpp
+++ b/modules/base/dashboard/dashboarditemangle.cpp
@@ -221,8 +221,6 @@ DashboardItemAngle::DashboardItemAngle(const ghoul::Dictionary& dictionary)
         }
     }
     addProperty(_destination.nodeIdentifier);
-
-    _localBuffer.resize(128);
 }
 
 void DashboardItemAngle::update() {
@@ -235,27 +233,22 @@ void DashboardItemAngle::update() {
     const glm::dvec3 a = referenceInfo.first - sourceInfo.first;
     const glm::dvec3 b = destinationInfo.first - sourceInfo.first;
 
-    std::fill(_localBuffer.begin(), _localBuffer.end(), char(0));
     if (glm::length(a) == 0.0 || glm::length(b) == 0) {
-        char* end = std::format_to(
-            _localBuffer.data(),
+        _buffer = std::format(
             "Could not compute angle at {} between {} and {}. At least two of the three "
             "items are placed in the same location",
             sourceInfo.second, destinationInfo.second, referenceInfo.second
         );
-        _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
     }
     else {
         const double angle = glm::degrees(
             glm::acos(glm::dot(a, b) / (glm::length(a) * glm::length(b)))
         );
 
-        char* end = std::format_to(
-            _localBuffer.data(),
+        _buffer = std::format(
             "Angle at {} between {} and {}: {} degrees",
             sourceInfo.second, destinationInfo.second, referenceInfo.second, angle
         );
-        _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
     }
 }
 

--- a/modules/base/dashboard/dashboarditemangle.h
+++ b/modules/base/dashboard/dashboarditemangle.h
@@ -56,8 +56,6 @@ private:
     Component _source;
     Component _reference;
     Component _destination;
-
-    std::vector<char> _localBuffer;
 };
 
 } // namespace openspace

--- a/modules/base/dashboard/dashboarditemdistance.cpp
+++ b/modules/base/dashboard/dashboarditemdistance.cpp
@@ -247,8 +247,6 @@ DashboardItemDistance::DashboardItemDistance(const ghoul::Dictionary& dictionary
 
     _formatString = p.formatString.value_or(_formatString);
     addProperty(_formatString);
-
-    _localBuffer.resize(256);
 }
 
 std::pair<glm::dvec3, std::string> DashboardItemDistance::positionAndLabel(
@@ -334,11 +332,9 @@ void DashboardItemDistance::update() {
         dist = std::pair(convertedD, nameForDistanceUnit(unit, convertedD != 1.0));
     }
 
-    std::fill(_localBuffer.begin(), _localBuffer.end(), char(0));
     try {
         // @CPP26(abock): This can be replaced with std::runtime_format
-        char* end = std::vformat_to(
-            _localBuffer.data(),
+        _buffer = std::vformat(
             _formatString.value(),
             std::make_format_args(
                 sourceInfo.second,
@@ -347,8 +343,6 @@ void DashboardItemDistance::update() {
                 dist.second
             )
         );
-
-        _buffer = std::string(_localBuffer.data(), end - _localBuffer.data());
     }
     catch (const std::format_error&) {
         LERROR("Illegal format string");

--- a/modules/base/dashboard/dashboarditemdistance.h
+++ b/modules/base/dashboard/dashboarditemdistance.h
@@ -61,8 +61,6 @@ private:
 
     Component _source;
     Component _destination;
-
-    std::vector<char> _localBuffer;
 };
 
 } // namespace openspace


### PR DESCRIPTION
Fixes a crash that happened when loading some of our DashboardItemAngle example assets in the empty profile (tested, and it happened in both master and 0.22.0). 

The issue is that we created a "local buffer" of only 128 characters, but the generated string when two nodes were in the same location could be longer than that. Consequently, the old `std::format_to` call led to undefined behavior (the crash)

The suggested solution removes the local buffer entirely rather than increasing its size. I could not quite see why it was needed, and increasing it could still mean crashing if the names of the objects were long enough. Let me know if I missed something that opts for keeping it (ping @alexanderbock)  

I made the same corresponding change in the other dashboarditem class that used a similar approach