### PR TITLE
Small Assetvalidator Improvements

### DIFF
--- a/support/assetvalidation/assetvalidation.py
+++ b/support/assetvalidation/assetvalidation.py
@@ -451,7 +451,6 @@ def runAssetValidation(files: list[Path], executable: Path, rootDir: Path, args)
       logLevel = logging.ERROR
     )
     processedCount += 1
-    _printProgressBar(processedCount, totalCount)
     startIndex += completed + 1
     remaining = remaining[completed + 1:]
 
@@ -461,3 +460,5 @@ def runAssetValidation(files: list[Path], executable: Path, rootDir: Path, args)
         logLevel = logging.ERROR
       )
       break
+
+    _printProgressBar(processedCount, totalCount)

--- a/support/assetvalidation/assetvalidation.py
+++ b/support/assetvalidation/assetvalidation.py
@@ -56,6 +56,18 @@ def _sanitizePaths(text: str) -> str:
   """Replace all absolute Windows paths embedded in a string with display-safe relative paths"""
   return _WIN_PATH_RE.sub(lambda m: _relPath(m.group()), text)
 
+def _printProgressBar(current: int, total: int, width: int = 40):
+  """Print a simple in-place progress bar to stdout."""
+  if total <= 0:
+    return
+
+  ratio = max(0.0, min(1.0, current / total))
+  filled = int(width * ratio)
+  bar = "=" * filled + "." * (width - filled)
+  print(f"\rProgress: [{bar}] {current}/{total}", end = "", flush = True)
+  if current >= total:
+    print()
+
 class OpenSpaceCrashException(Exception):
   """
   Raised when OpenSpace crashes mid-run, carrying the number of assets that were
@@ -281,6 +293,7 @@ async def internalRun(openspace, assets: list[Path], osDir: Path, api: Api,
           await ensureEmptyScene(openspace, asset)
 
         assetCount += 1
+        _printProgressBar(startIndex + assetCount, totalCount)
         log("Finished testing asset\n", logLevel = logging.INFO)
         await asyncio.sleep(0.5) # Arbitrary sleep to let OpenSpace breathe
 
@@ -388,6 +401,9 @@ def runAssetValidation(files: list[Path], executable: Path, rootDir: Path, args)
   remaining = list(files)
   totalCount = len(files)
   startIndex = 0
+  processedCount = 0
+
+  _printProgressBar(processedCount, totalCount)
 
   while remaining:
     if startOpenSpace:
@@ -422,8 +438,11 @@ def runAssetValidation(files: list[Path], executable: Path, rootDir: Path, args)
       process = None
 
     if completed >= len(remaining):
+      processedCount = totalCount
       log("All assets validated", logLevel = logging.INFO)
       break
+
+    processedCount += completed
 
     # OpenSpace crashed - log the offending asset and continue with the next one
     crashedAsset = remaining[completed]
@@ -431,6 +450,8 @@ def runAssetValidation(files: list[Path], executable: Path, rootDir: Path, args)
       f"OpenSpace crashed during validation of '{_relPath(crashedAsset)}', skipping to next asset\n",
       logLevel = logging.ERROR
     )
+    processedCount += 1
+    _printProgressBar(processedCount, totalCount)
     startIndex += completed + 1
     remaining = remaining[completed + 1:]
 

--- a/support/assetvalidation/main.py
+++ b/support/assetvalidation/main.py
@@ -132,7 +132,11 @@ if not executable.exists():
 files = list(Path(rootDir / "data" / "assets").rglob("*.asset"))
 if args.filter:
   p = re.compile(args.filter)
-  files = [x for x in files if re.search(p, str(x))]
+  assetRoot = rootDir / "data" / "assets"
+  files = [
+    x for x in files
+    if re.search(p, str(x.relative_to(assetRoot)).replace("\\", "/"))
+  ]
 
 # Sort files to make sure the files we've gotten are consistent between runs, this way we
 # can start from a specific index


### PR DESCRIPTION
1. Makes it possible to use deeper paths in the `--filter`. Previously, only one folder, like `"examples/*"`, worked, but now it's also possible to load only the assets in subfolders like `"examples/screenspacerenderable/*"`

2. Also adds a very simple progress bar that shows how many assets will be loaded and the current progress.  Just went with a simple text-based approach that requires no other dependencies. LMK what you think. We could also do something fancier

<img width="1401" height="72" alt="image" src="https://github.com/user-attachments/assets/e23c5616-bbe0-404c-bc74-2a015c827115" />

@engbergandreas it would be great if you could check if the progress bar behaves acceptably when the validator fails to run (you probably know more about when this can happen) :)