### PR TITLE
Toggle Shutdown function takes parameter

### DIFF
--- a/include/openspace/engine/configuration.h
+++ b/include/openspace/engine/configuration.h
@@ -109,8 +109,6 @@ struct Configuration {
 
     Key consoleKey = Key::GraveAccent;
 
-    float shutdownCountdown = 0.f;
-
     bool shouldUseScreenshotDateTime = false;
 
     bool sandboxedLua = true;

--- a/include/openspace/engine/openspaceengine.h
+++ b/include/openspace/engine/openspaceengine.h
@@ -121,7 +121,7 @@ public:
     void decode(std::vector<std::byte> data);
 
     Property::Visibility visibility() const;
-    void toggleShutdownMode();
+    void toggleShutdownMode(std::optional<float> timer);
 
     Mode currentMode() const;
     bool setMode(Mode newMode);
@@ -164,6 +164,7 @@ private:
     BoolProperty _showPropertyConfirmationDialog;
     FloatProperty _fadeOnEnableDuration;
     BoolProperty _disableAllMouseInputs;
+    FloatProperty _defaultShutdownCountdown;
 
     std::unique_ptr<Scene> _scene;
     std::unique_ptr<AssetManager> _assetManager;

--- a/include/openspace/engine/openspaceengine.h
+++ b/include/openspace/engine/openspaceengine.h
@@ -121,7 +121,7 @@ public:
     void decode(std::vector<std::byte> data);
 
     Property::Visibility visibility() const;
-    void toggleShutdownMode(std::optional<float> timer);
+    void toggleShutdownMode(std::optional<float> timer = std::nullopt);
 
     Mode currentMode() const;
     bool setMode(Mode newMode);

--- a/openspace.cfg
+++ b/openspace.cfg
@@ -177,7 +177,6 @@ ConsoleKey = "GRAVEACCENT"
 
 SandboxedLua = true
 
-ShutdownCountdown = 3
 ScreenshotUseDateTime = true
 BypassLauncher = false
 

--- a/src/engine/configuration.cpp
+++ b/src/engine/configuration.cpp
@@ -170,10 +170,6 @@ namespace {
         // Right now only contains the path where the documentation is written to.
         std::optional<Documentation> documentation;
 
-        // The countdown that the application will wait between pressing ESC and actually
-        // shutting down. If ESC is pressed again in this time, the shutdown is aborted.
-        std::optional<float> shutdownCountdown [[codegen::greater(0.0)]];
-
         // If this is set to 'true', the name of the profile will be appended to the cache
         // directory, thus not reusing the same directory. This is useful in cases where
         // the same instance of OpenSpace is run with multiple profiles, but the caches
@@ -437,7 +433,6 @@ ghoul::Dictionary Configuration::createDictionary() {
     res.setValue("IsLoggingOpenGLCalls", isLoggingOpenGLCalls);
     res.setValue("IsPrintingEvents", isPrintingEvents);
     res.setValue("ConsoleKey", ghoul::to_string(consoleKey));
-    res.setValue("ShutdownCountdown", static_cast<double>(shutdownCountdown));
     res.setValue("shouldUseScreenshotDateTime", shouldUseScreenshotDateTime);
     res.setValue("sandboxedLua", sandboxedLua);
     res.setValue("OnScreenTextScaling", onScreenTextScaling);
@@ -591,7 +586,6 @@ void parseLuaState(Configuration& configuration) {
         c.consoleKey = km.key;
     }
 
-    c.shutdownCountdown = p.shutdownCountdown.value_or(c.shutdownCountdown);
     c.shouldUseScreenshotDateTime =
         p.screenshotUseDateTime.value_or(c.shouldUseScreenshotDateTime);
     c.sandboxedLua = p.sandboxedLua.value_or(c.sandboxedLua);

--- a/src/engine/openspaceengine.cpp
+++ b/src/engine/openspaceengine.cpp
@@ -173,6 +173,15 @@ namespace {
         Property::NeedsConfirmation::Yes
     };
 
+    constexpr Property::PropertyInfo DefaultShutdownCountdownInfo = {
+        "DefaultShutdownCountdown",
+        "Default Shutdown Countdown",
+        "The default shutdown countdown timer (in seconds). Unless some other time is "
+        "specified in the 'toggleShutdown' function, this is the number of seconds the "
+        "application will wait before shutting down",
+        Property::Visibility::AdvancedUser
+    };
+
     constexpr Property::PropertyInfo ShowPropertyConfirmationDialogInfo = {
         "ShowPropertyConfirmation",
         "Show property confirmation",
@@ -228,6 +237,7 @@ OpenSpaceEngine::OpenSpaceEngine()
     , _showPropertyConfirmationDialog(ShowPropertyConfirmationDialogInfo, true)
     , _fadeOnEnableDuration(FadeDurationInfo, 1.f, 0.f, 5.f)
     , _disableAllMouseInputs(DisableMouseInputInfo, false)
+    , _defaultShutdownCountdown(DefaultShutdownCountdownInfo, 3.f, 0.f, 60.f)
 {
     FactoryManager::initialize();
     SpiceManager::initialize();
@@ -248,6 +258,8 @@ OpenSpaceEngine::OpenSpaceEngine()
 
     addProperty(_fadeOnEnableDuration);
     addProperty(_disableAllMouseInputs);
+
+    addProperty(_defaultShutdownCountdown);
 
 
     ghoul::TemplateFactory<Task>* fTask = FactoryManager::ref().factory<Task>();
@@ -531,8 +543,6 @@ void OpenSpaceEngine::initialize() {
     }
 
     global::scriptEngine->initialize();
-
-    _shutdown.waitTime = global::configuration->shutdownCountdown;
 
     global::navigationHandler->initialize();
 
@@ -1725,7 +1735,7 @@ Property::Visibility OpenSpaceEngine::visibility() const {
     return static_cast<Property::Visibility>(_visibility.value());
 }
 
-void OpenSpaceEngine::toggleShutdownMode() {
+void OpenSpaceEngine::toggleShutdownMode(std::optional<float> timer) {
     if (_shutdown.inShutdown) {
         // If we are already in shutdown mode, we want to disable it
         _shutdown.inShutdown = false;
@@ -1735,7 +1745,8 @@ void OpenSpaceEngine::toggleShutdownMode() {
     }
     else {
         // Else, we have to enable it
-        _shutdown.timer = _shutdown.waitTime;
+        _shutdown.timer = timer.value_or(_defaultShutdownCountdown);
+        _shutdown.waitTime = timer.value_or(_defaultShutdownCountdown);
         _shutdown.inShutdown = true;
         global::eventEngine->publishEvent<EventApplicationShutdown>(
             EventApplicationShutdown::State::Started

--- a/src/engine/openspaceengine_lua.inl
+++ b/src/engine/openspaceengine_lua.inl
@@ -49,8 +49,8 @@ namespace {
  * Toggles the shutdown mode that will close the application after the countdown timer is
  * reached.
  */
-[[codegen::luawrap]] void toggleShutdown() {
-    global::openSpaceEngine->toggleShutdownMode();
+[[codegen::luawrap]] void toggleShutdown(std::optional<float> timer = std::nullopt) {
+    global::openSpaceEngine->toggleShutdownMode(timer);
 }
 
 /**

--- a/support/runner/testsuite/openspace.py
+++ b/support/runner/testsuite/openspace.py
@@ -60,9 +60,6 @@ def write_configuration_overwrite(base_path: Path, data_path: Path) -> None:
     # Setting this to true will cause OpenGL errors to appear in the log
     f.write("CheckOpenGLState = true\n")
 
-    # We can reduce the amount of time that we have to wait for OpenSpace to shut down
-    f.write("ShutdownCountdown = 0.25\n")
-
 
 
 async def setup_test_run(openspace: Any) -> None:
@@ -112,7 +109,7 @@ async def internal_run(openspace: Any, os_api: Api, test: Test, shutdown: bool =
   commit = version["Commit"]
 
   if shutdown:
-    await openspace.toggleShutdown()
+    await openspace.toggleShutdown(0.25)
 
   return screenshot_folder, commit
 


### PR DESCRIPTION
Replace the openspace.cfg setting for the toggle shutdown timer with a property.  The `toggleShutdown` Lua script now takes an optional parameter.

Closes #4256 