### PR TITLE
Add new topic `assetTreeTopic`

### DIFF
--- a/include/openspace/scene/assetmanager.h
+++ b/include/openspace/scene/assetmanager.h
@@ -25,7 +25,9 @@
 #ifndef __OPENSPACE_CORE___ASSETMANAGER___H__
 #define __OPENSPACE_CORE___ASSETMANAGER___H__
 
+#include <openspace/events/event.h>
 #include <filesystem>
+#include <functional>
 #include <list>
 #include <memory>
 #include <optional>
@@ -51,6 +53,23 @@ class ResourceSynchronization;
  */
 class AssetManager {
 public:
+    struct AssetTreeChange {
+        enum class Type {
+            Shipped,
+            User,
+            Other,
+            RootAssets,
+            State
+        };
+
+        Type type;
+
+        // Only populated when type == `Type::State`
+        std::string statePath;
+        EventAssetLoading::State state = EventAssetLoading::State::Unloaded;
+    };
+    using AssetTreeCallback = std::function<void(const AssetTreeChange&)>;
+
     AssetManager(ghoul::lua::LuaState* state, std::filesystem::path assetRootDirectory);
     ~AssetManager();
 
@@ -172,6 +191,65 @@ public:
      */
     void callOnDeinitialize(Asset* asset) const;
 
+    /**
+     * Update internal bookeeping state of the provided \p assetPath to the provided \p
+     * state.
+     *
+     * \param assetPath The asset path to update the state for.
+     * \param state The new state to update to.
+     */
+    void updateAssetState(const std::filesystem::path& assetPath,
+        EventAssetLoading::State state);
+
+    /**
+     * Register a callback to be invoked whenever the asset tree or state map changes.
+     *
+     * \param callback The call back to be invoked whenever there is an update.
+     * \return The id of the callback that can be used to unsubscribe the callback later.
+     */
+    size_t subscribeAssetTree(AssetTreeCallback callback);
+
+    /**
+     * Unregister a callback that was previously registered with `subscribeAssetTree`.
+     *
+     * \param callbackId The ID returned by `subscribeAssetTree` when starting the
+     *                   subscription.
+     */
+    void unsubscribeAssetTree(size_t callbackId);
+
+    /**
+     * Re-scans the Data and User asset directories from disk, updating the internal
+     * path lists.
+     */
+    void rescanAssetPaths();
+
+    /**
+     * \return The list of all asset paths in the Data folder, as of the last rescan.
+     */
+    std::vector<std::filesystem::path> shippedAssetPaths() const;
+
+    /**
+     * \return The list of all asset paths in the User folder, as of the last rescan.
+     */
+    std::vector<std::filesystem::path> userAssetPaths() const;
+
+    /**
+     * \return The list of all loaded asset paths that do not belong to the Data or User
+     * folders.
+     */
+    std::vector<std::filesystem::path> otherAssetPaths() const;
+
+    /**
+     * \return The list of all root asset paths, which are assets that have been loaded
+     * directly from the profile or by calling the #add method.
+     */
+    std::vector<std::filesystem::path> rootAssetPaths() const;
+
+    /**
+     * \return The state of all assets that are in any way loaded/loading/error'ed
+     */
+    std::unordered_map<std::string, EventAssetLoading::State> assetStates() const;
+
 private:
     /**
      * Creates and registers all of the callback functions that the asset is expected to
@@ -202,6 +280,26 @@ private:
     void runRemoveQueue();
     void runAddQueue();
 
+    enum class AssetPathLocation {
+        Shipped,
+        User,
+        Other
+    };
+
+    /**
+     * Classify an asset path as belonging to either the Data, User or Other base folder
+     *
+     * \return The asset base folder location type.
+     */
+    AssetPathLocation classifyAssetPath(const std::filesystem::path& path) const;
+
+    /**
+     * Notify all subscribers of the asset tree \p change
+     *
+     * \param change The update to notify all subscribers
+     */
+    void notifyAssetTreeSubscribers(const AssetTreeChange& change) const;
+
     //
     // Assets
     //
@@ -224,6 +322,22 @@ private:
 
     /// This list contains all of the assets that will be deleted in the next update call
     std::vector<std::unique_ptr<Asset>> _toBeDeleted;
+
+    // This list contains all of the shipped asset paths that are available to be loaded
+    std::vector<std::filesystem::path> _shippedAssetPaths;
+
+    // This list contains all of the user asset paths that are available to be loaded
+    std::vector<std::filesystem::path> _userAssetPaths;
+
+    // This list contains all asset paths that have been loaded from other sources than
+    // Data and User
+    std::vector<std::filesystem::path> _otherAssetPaths;
+
+    std::unordered_map<size_t, AssetTreeCallback> _assetTreeSubscribers;
+    size_t _nextAssetTreeSubscriptionId = 0;
+
+    // The state of assets that have in any way been loaded/loading or have error'ed out
+    std::unordered_map<std::string, EventAssetLoading::State> _assetStates;
 
     //
     // ResourceSynchronizations

--- a/include/openspace/scene/assetmanager.h
+++ b/include/openspace/scene/assetmanager.h
@@ -192,7 +192,7 @@ public:
     void callOnDeinitialize(Asset* asset) const;
 
     /**
-     * Update internal bookeeping state of the provided \p assetPath to the provided \p
+     * Update internal bookkeeping state of the provided \p assetPath to the provided \p
      * state.
      *
      * \param assetPath The asset path to update the state for.

--- a/include/openspace/topic/topics/assettreetopic.h
+++ b/include/openspace/topic/topics/assettreetopic.h
@@ -1,0 +1,59 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#ifndef __OPENSPACE_CORE___ASSETTREE_TOPIC___H__
+#define __OPENSPACE_CORE___ASSETTREE_TOPIC___H__
+
+#include <openspace/topic/topics/topic.h>
+
+#include <openspace/scene/assetmanager.h>
+
+namespace openspace {
+
+struct Schema;
+
+class AssetTreeTopic : public Topic {
+public:
+    AssetTreeTopic() = default;
+    ~AssetTreeTopic() override;
+
+    void handleJson(const nlohmann::json& json) override;
+    bool isDone() const override;
+
+    static openspace::Schema Schema();
+
+private:
+    void sendPathList(std::string_view category,
+        const std::vector<std::filesystem::path>& paths);
+    void sendFullSnapshot();
+    void handleChange(const AssetManager::AssetTreeChange& change);
+
+
+    bool _isDone = false;
+    std::optional<size_t> _subscriptionId;
+};
+
+} // namespace openspace
+
+#endif // __OPENSPACE_CORE___ASSETTREE_TOPIC___H__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,7 @@ set(OPENSPACE_SOURCE
   topic/serverinterface.cpp
   topic/server.cpp
   topic/topics/actionkeybindtopic.cpp
+  topic/topics/assettreetopic.cpp
   topic/topics/authorizationtopic.cpp
   topic/topics/camerapathtopic.cpp
   topic/topics/cameratopic.cpp
@@ -409,6 +410,7 @@ set(OPENSPACE_HEADER
   ${PROJECT_SOURCE_DIR}/include/openspace/topic/serverinterface.h
   ${PROJECT_SOURCE_DIR}/include/openspace/topic/server.h
   ${PROJECT_SOURCE_DIR}/include/openspace/topic/topics/actionkeybindtopic.h
+  ${PROJECT_SOURCE_DIR}/include/openspace/topic/topics/assettreetopic.h
   ${PROJECT_SOURCE_DIR}/include/openspace/topic/topics/authorizationtopic.h
   ${PROJECT_SOURCE_DIR}/include/openspace/topic/topics/camerapathtopic.h
   ${PROJECT_SOURCE_DIR}/include/openspace/topic/topics/cameratopic.h

--- a/src/documentation/core_registration.cpp
+++ b/src/documentation/core_registration.cpp
@@ -101,6 +101,7 @@
 #include <openspace/topic/server.h>
 #include <openspace/topic/serverinterface.h>
 #include <openspace/topic/topics/actionkeybindtopic.h>
+#include <openspace/topic/topics/assettreetopic.h>
 #include <openspace/topic/topics/authorizationtopic.h>
 #include <openspace/topic/topics/camerapathtopic.h>
 #include <openspace/topic/topics/cameratopic.h>
@@ -153,6 +154,7 @@ void registerCoreClasses(DocumentationEngine& engine) {
 
 void registerCoreSchemas(DocumentationEngine& engine) {
     engine.addSchema(ActionKeybindTopic::Schema());
+    engine.addSchema(AssetTreeTopic::Schema());
     engine.addSchema(AuthorizationTopic::Schema());
     engine.addSchema(CameraPathTopic::Schema());
     engine.addSchema(CameraTopic::Schema());

--- a/src/scene/asset.cpp
+++ b/src/scene/asset.cpp
@@ -303,6 +303,7 @@ void Asset::initialize() {
         _assetPath.string(),
         EventAssetLoading::State::Loading
     );
+    _manager.updateAssetState(_assetPath, EventAssetLoading::State::Loading);
     // 1. Initialize requirements
     for (Asset* child : _requiredAssets) {
         child->initialize();
@@ -316,12 +317,22 @@ void Asset::initialize() {
         LERROR(std::format("Failed to initialize asset '{}'", path()));
         logError(e);
         setState(State::InitializationFailed);
+        global::eventEngine->publishEvent<EventAssetLoading>(
+            _assetPath.string(),
+            EventAssetLoading::State::Error
+        );
+        _manager.updateAssetState(_assetPath, EventAssetLoading::State::Error);
         return;
     }
     catch (const ghoul::RuntimeError& e) {
         LERROR(std::format("Failed to initialize asset '{}'", path()));
         LERROR(std::format("{}: {}", e.component, e.message));
         setState(State::InitializationFailed);
+        global::eventEngine->publishEvent<EventAssetLoading>(
+            _assetPath.string(),
+            EventAssetLoading::State::Error
+        );
+        _manager.updateAssetState(_assetPath, EventAssetLoading::State::Error);
         return;
     }
 
@@ -331,6 +342,7 @@ void Asset::initialize() {
         _assetPath.string(),
         EventAssetLoading::State::Loaded
     );
+    _manager.updateAssetState(_assetPath, EventAssetLoading::State::Loaded);
 }
 
 void Asset::deinitialize() {

--- a/src/scene/asset.cpp
+++ b/src/scene/asset.cpp
@@ -213,6 +213,11 @@ void Asset::startSynchronizations() {
     }
 
     setState(State::Synchronizing);
+    global::eventEngine->publishEvent<EventAssetLoading>(
+        _assetPath.string(),
+        EventAssetLoading::State::Loading
+    );
+    _manager.updateAssetState(_assetPath, EventAssetLoading::State::Loading);
 
     // Start synchronization of all children first
     for (Asset* child : _requiredAssets) {

--- a/src/scene/asset.cpp
+++ b/src/scene/asset.cpp
@@ -299,11 +299,6 @@ void Asset::initialize() {
     }
     LDEBUG(std::format("Initializing asset '{}'", _assetPath));
 
-    global::eventEngine->publishEvent<EventAssetLoading>(
-        _assetPath.string(),
-        EventAssetLoading::State::Loading
-    );
-    _manager.updateAssetState(_assetPath, EventAssetLoading::State::Loading);
     // 1. Initialize requirements
     for (Asset* child : _requiredAssets) {
         child->initialize();

--- a/src/scene/assetmanager.cpp
+++ b/src/scene/assetmanager.cpp
@@ -86,6 +86,21 @@ namespace {
         return PathType::RelativeToAssetRoot;
     }
 
+    /**
+     * Check if \p path belongs to directory of \p root
+     *
+     * \param path The path to check
+     * \param root The root directory to check \p path against
+     * \return True if a \p path is belonging to a subdirectory \p root, false otherwise
+     */
+    bool underRoot(const std::filesystem::path& path, const std::filesystem::path& root) {
+        if (path.root_name() != root.root_name()) {
+            return false;
+        }
+
+        return !std::filesystem::relative(path, root).string().starts_with("..");
+    }
+
     struct [[codegen::Dictionary(AssetMeta)]] Parameters {
         // The user-facing name of the asset. It should describe to the user what they can
         // expect when loading the asset into a profile.
@@ -134,6 +149,7 @@ AssetManager::AssetManager(ghoul::lua::LuaState* state,
     // Create _assets table
     lua_newtable(*_luaState);
     _assetsTableRef = luaL_ref(*_luaState, LUA_REGISTRYINDEX);
+    rescanAssetPaths();
 }
 
 AssetManager::~AssetManager() {
@@ -155,6 +171,7 @@ void AssetManager::deinitialize() {
         }
         _rootAssets.pop_back();
     }
+    notifyAssetTreeSubscribers({ AssetTreeChange::Type::RootAssets });
     _toBeDeleted.clear();
 }
 
@@ -190,6 +207,7 @@ void AssetManager::runRemoveQueue() {
         }
 
         _rootAssets.erase(jt);
+        notifyAssetTreeSubscribers({ AssetTreeChange::Type::RootAssets });
         // Even though we are removing a root asset, we might not be the only person that
         // is interested in the asset, so we can only deinitialize it if we were, in fact,
         // the only person, meaning that the asset never had any parents
@@ -233,6 +251,7 @@ void AssetManager::runAddQueue() {
             continue;
         }
         _rootAssets.push_back(a);
+        notifyAssetTreeSubscribers({ AssetTreeChange::Type::RootAssets });
         a->startSynchronizations();
 
         _toBeInitialized.push_back(a);
@@ -409,10 +428,16 @@ bool AssetManager::loadAsset(Asset* asset, Asset* parent) {
             asset->path().string(),
             EventAssetLoading::State::Error
         );
+        updateAssetState(asset->path(), EventAssetLoading::State::Error);
         return false;
     }
     catch (const ghoul::RuntimeError& e) {
         LERRORC(e.component, e.message);
+        global::eventEngine->publishEvent<EventAssetLoading>(
+            asset->path().string(),
+            EventAssetLoading::State::Error
+        );
+        updateAssetState(asset->path(), EventAssetLoading::State::Error);
         return false;
     }
 
@@ -492,6 +517,7 @@ void AssetManager::unloadAsset(Asset* asset) {
             asset->path().string(),
             EventAssetLoading::State::Unloaded
         );
+        updateAssetState(asset->path(), EventAssetLoading::State::Unloaded);
     }
 }
 
@@ -1017,10 +1043,6 @@ void AssetManager::callOnInitialize(Asset* asset) const {
     for (const int init : it->second) {
         lua_rawgeti(*_luaState, LUA_REGISTRYINDEX, init);
         if (lua_pcall(*_luaState, 0, 0, 0) != LUA_OK) {
-            global::eventEngine->publishEvent<EventAssetLoading>(
-                asset->path().string(),
-                EventAssetLoading::State::Error
-            );
             throw ghoul::lua::LuaRuntimeException(std::format(
                 "When initializing '{}': {}",
                 asset->path(),
@@ -1123,6 +1145,129 @@ std::filesystem::path AssetManager::generateAssetPath(
     // comprehensively logged by Lua either way
     return absPath(fullAssetPath);
 }
+
+void AssetManager::updateAssetState(const std::filesystem::path& path,
+                                                           EventAssetLoading::State state)
+{
+    const std::string key = path.generic_string();
+    _assetStates[key] = state;
+
+    AssetTreeChange change = {
+        .type = AssetTreeChange::Type::State,
+        .statePath = key,
+        .state = state
+    };
+    notifyAssetTreeSubscribers(change);
+
+    if (classifyAssetPath(path) != AssetPathLocation::Other) {
+        return;
+    }
+
+    // We may need to update the `otherAssetPaths` list
+    const auto it = std::find(_otherAssetPaths.begin(), _otherAssetPaths.end(), path);
+    const bool alreadyTracked = it != _otherAssetPaths.end();
+
+    // If we we're tracking a now unloaded asset, we need to remove it and notify
+    if (state == EventAssetLoading::State::Unloaded && alreadyTracked) {
+        _otherAssetPaths.erase(it);
+        notifyAssetTreeSubscribers({ AssetTreeChange::Type::Other });
+    }
+
+    // If the asset is loading, has finished loading or errored out and we were not
+    // already tracking it - add it to the list and notify
+    if(state != EventAssetLoading::State::Unloaded && !alreadyTracked) {
+        _otherAssetPaths.push_back(path);
+        notifyAssetTreeSubscribers({ AssetTreeChange::Type::Other });
+    }
+}
+
+size_t AssetManager::subscribeAssetTree(AssetTreeCallback callback) {
+    const size_t id = _nextAssetTreeSubscriptionId++;
+    _assetTreeSubscribers[id] = std::move(callback);
+    return id;
+}
+
+void AssetManager::unsubscribeAssetTree(size_t id) {
+    _assetTreeSubscribers.erase(id);
+}
+
+void AssetManager::notifyAssetTreeSubscribers(const AssetTreeChange& change) const {
+    for (auto& [_, callback] : _assetTreeSubscribers) {
+        callback(change);
+    }
+}
+
+void AssetManager::rescanAssetPaths() {
+    auto scanAssets = [](const std::filesystem::path& root) {
+        return ghoul::filesystem::walkDirectory(
+            root,
+            ghoul::filesystem::Recursive::Yes,
+            ghoul::filesystem::Sorted::Yes,
+            [](const std::filesystem::path& p) {
+                return (
+                    std::filesystem::is_regular_file(p) &&
+                    (p.extension() == ".asset" || p.extension() == ".jasset")
+                );
+            }
+        );
+    };
+
+    std::vector<std::filesystem::path> newShipped = scanAssets(_assetRootDirectory);
+    std::vector<std::filesystem::path> newUser = scanAssets(absPath("${USER_ASSETS}"));
+
+    const bool shippedChanged = newShipped != _shippedAssetPaths;
+    const bool userChanged = newUser != _userAssetPaths;
+
+    _shippedAssetPaths = std::move(newShipped);
+    _userAssetPaths = std::move(newUser);
+
+    if (shippedChanged) {
+        notifyAssetTreeSubscribers({ AssetTreeChange::Type::Shipped });
+    }
+    if (userChanged) {
+        notifyAssetTreeSubscribers({ AssetTreeChange::Type::User });
+    }
+}
+
+AssetManager::AssetPathLocation
+AssetManager::classifyAssetPath(const std::filesystem::path& path) const
+{
+    if (underRoot(path, _assetRootDirectory)) {
+        return AssetPathLocation::Shipped;
+    }
+    if (underRoot(path, absPath("${USER_ASSETS}"))) {
+        return AssetPathLocation::User;
+    }
+    return AssetPathLocation::Other;
+}
+
+std::vector<std::filesystem::path> AssetManager::shippedAssetPaths() const {
+    return _shippedAssetPaths;
+}
+
+std::vector<std::filesystem::path> AssetManager::userAssetPaths() const {
+    return _userAssetPaths;
+}
+
+std::vector<std::filesystem::path> AssetManager::otherAssetPaths() const {
+    return _otherAssetPaths;
+}
+
+std::vector<std::filesystem::path> AssetManager::rootAssetPaths() const {
+    std::vector<std::filesystem::path> result;
+    result.reserve(_rootAssets.size());
+    for (const Asset* a : _rootAssets) {
+        result.push_back(a->path());
+    }
+    return result;
+}
+
+std::unordered_map<std::string, EventAssetLoading::State>
+AssetManager::assetStates() const
+{
+    return _assetStates;
+}
+
 
 LuaLibrary AssetManager::luaLibrary() {
     return {

--- a/src/scene/assetmanager.cpp
+++ b/src/scene/assetmanager.cpp
@@ -253,11 +253,6 @@ void AssetManager::runAddQueue() {
         _rootAssets.push_back(a);
         notifyAssetTreeSubscribers({ AssetTreeChange::Type::RootAssets });
         a->startSynchronizations();
-        global::eventEngine->publishEvent<EventAssetLoading>(
-            a->path().string(),
-            EventAssetLoading::State::Loading
-        );
-        updateAssetState(a->path(), EventAssetLoading::State::Loading);
 
         _toBeInitialized.push_back(a);
         global::profile->addAsset(asset);

--- a/src/scene/assetmanager.cpp
+++ b/src/scene/assetmanager.cpp
@@ -253,6 +253,11 @@ void AssetManager::runAddQueue() {
         _rootAssets.push_back(a);
         notifyAssetTreeSubscribers({ AssetTreeChange::Type::RootAssets });
         a->startSynchronizations();
+        global::eventEngine->publishEvent<EventAssetLoading>(
+            a->path().string(),
+            EventAssetLoading::State::Loading
+        );
+        updateAssetState(a->path(), EventAssetLoading::State::Loading);
 
         _toBeInitialized.push_back(a);
         global::profile->addAsset(asset);
@@ -277,6 +282,11 @@ void AssetManager::update() {
 
         if (a->isFailed()) {
             _toBeInitialized.erase(it);
+            global::eventEngine->publishEvent<EventAssetLoading>(
+                a->path().string(),
+                EventAssetLoading::State::Error
+            );
+            updateAssetState(a->path(), EventAssetLoading::State::Error);
             break;
         }
 

--- a/src/scene/assetmanager_lua.inl
+++ b/src/scene/assetmanager_lua.inl
@@ -101,13 +101,7 @@ namespace {
  * either through a profile or by calling the `openspace.asset.add` method.
  */
 [[codegen::luawrap]] std::vector<std::filesystem::path> rootAssets() {
-    std::vector<const Asset*> as = global::openSpaceEngine->assetManager().rootAssets();
-    std::vector<std::filesystem::path> res;
-    res.reserve(as.size());
-    for (const Asset* a : as) {
-        res.push_back(a->path());
-    }
-    return res;
+    return global::openSpaceEngine->assetManager().rootAssetPaths();
 }
 
 /**

--- a/src/scripting/scriptengine.cpp
+++ b/src/scripting/scriptengine.cpp
@@ -796,6 +796,7 @@ void ScriptEngine::addBaseLibrary() {
             codegen::lua::WalkDirectoryFiles,
             codegen::lua::WalkDirectoryFolders,
             codegen::lua::DirectoryForPath,
+            codegen::lua::OpenFileExplorer,
             codegen::lua::UnzipFile,
             codegen::lua::RegisterRepeatedScript,
             codegen::lua::RemoveRepeatedScript,

--- a/src/scripting/scriptengine_lua.inl
+++ b/src/scripting/scriptengine_lua.inl
@@ -25,6 +25,15 @@
 #include <ghoul/ext/assimp/contrib/zip/src/zip.h>
 #include <ghoul/misc/stringhelper.h>
 #include <vector>
+#ifdef WIN32
+#include <windows.h>
+#include <shellapi.h>
+#else
+#include <cstdlib>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif // WIN32
 
 using namespace openspace;
 
@@ -61,6 +70,111 @@ int printError(lua_State* L) {
 
 int printFatal(lua_State* L) {
     return printInternal(ghoul::logging::LogLevel::Fatal, L);
+}
+
+/**
+ * Open a directory path using Windows explorer and in Linux the default explorer
+ * application.
+ *
+ * \param path The directory path to open in the explorer.
+ * \return Windows: True if the explorer window was successfully launched, false
+ *         otherwise.
+ *
+ *         Linux: True if the request to launch the file manager was successfully handed
+ *         off, false otherwise. This does not guarantee that xdg-open successfully opened
+ *         the requested path.
+ */
+bool openDirectory(const std::filesystem::path& path) {
+#ifdef WIN32
+    HINSTANCE result = ShellExecuteW(
+        nullptr,
+        L"open",
+        L"explorer.exe",
+        path.wstring().c_str(),
+        nullptr,
+        SW_SHOWNORMAL
+    );
+
+    // If successful ShellExecuteW returns a value greater than 32
+    return reinterpret_cast<std::intptr_t>(result) > 32;
+#else
+    const pid_t pid = fork();
+
+    if (pid < 0) {
+        return false;
+    }
+
+    if (pid == 0) {
+        // Intermediate child
+        const pid_t grandchild = fork();
+
+        if (grandchild < 0) {
+            _exit(EXIT_FAILURE);
+        }
+
+        // We launch the xdg-open from a grandchild to avoid having to deal with zombie
+        // processes that we'd have to cleanup. Instead we let the grandchild be reaped by
+        // the system
+        if (grandchild == 0) {
+            execlp(
+                "xdg-open",
+                "xdg-open",
+                path.string().c_str(),
+                static_cast<char*>(nullptr)
+            );
+
+            // `execlp` only returns if it failed and we're currently in the child process
+            // so we should kill it
+            _exit(EXIT_FAILURE);
+        }
+
+        // Intermediate child is no longer needed
+        _exit(EXIT_SUCCESS);
+    }
+
+    // Reap the intermediate child, should return almost immediately
+    int status = 0;
+    if (waitpid(pid, &status, 0) == -1) {
+        return false;
+    }
+
+    // Sucessfully started the child process, which is now independent of OpenSpace
+    return WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS;
+#endif // WIN32
+}
+
+/**
+ * Open a file path using Windows explorer and in Linux the default explorer application.
+ *
+ * \param path The file path to open in the explorer.
+ * \return Windows: True if the explorer window was successfully launched, false
+ *         otherwise.
+ *
+ *         Linux: True if the request to launch the file manager was successfully handed
+ *         off, false otherwise. This does not guarantee that xdg-open successfully opened
+ *         the requested path.
+ */
+bool openFileLocation(const std::filesystem::path& path) {
+#ifdef WIN32
+    // Explorer supports selecting a file using /select
+    const std::wstring arguments = std::format(L"/select,\"{}\"", path.wstring());
+
+    HINSTANCE result = ShellExecuteW(
+        nullptr,
+        L"open",
+        L"explorer.exe",
+        arguments.c_str(),
+        nullptr,
+        SW_SHOWNORMAL
+    );
+
+    // If successful ShellExecuteW returns a value greater than 32
+    return reinterpret_cast<std::intptr_t>(result) > 32;
+
+#else
+    // xdg-open doesn't have a "select this file" option
+    return openDirectory(path.parent_path());
+#endif // WIN32
 }
 
 /**
@@ -245,6 +359,26 @@ int printFatal(lua_State* L) {
 [[codegen::luawrap]] std::filesystem::path directoryForPath(std::filesystem::path file) {
     std::filesystem::path path = std::filesystem::path(std::move(file)).parent_path();
     return path;
+}
+
+/**
+ * Open a file or folder path in the native OS explorer window. For Windows the path is
+ * opened in windows explorer and for Linux the default explorer app.
+ */
+[[codegen::luawrap]] void openFileExplorer(std::filesystem::path path) {
+    path.make_preferred();
+
+    if (!std::filesystem::exists(path)) {
+        throw ghoul::RuntimeError(std::format("Could not find path '{}'", path));
+    }
+
+    const bool success = std::filesystem::is_directory(path)
+        ? openDirectory(path)
+        : openFileLocation(path);
+
+    if (!success) {
+        throw ghoul::RuntimeError(std::format("Could not open path '{}'", path));
+    }
 }
 
 /**

--- a/src/scripting/scriptengine_lua.inl
+++ b/src/scripting/scriptengine_lua.inl
@@ -138,7 +138,7 @@ bool openDirectory(const std::filesystem::path& path) {
         return false;
     }
 
-    // Sucessfully started the child process, which is now independent of OpenSpace
+    // Successfully started the child process, which is now independent of OpenSpace
     return WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS;
 #endif // WIN32
 }

--- a/src/topic/server.cpp
+++ b/src/topic/server.cpp
@@ -31,8 +31,9 @@
 #include <openspace/documentation/documentation.h>
 #include <openspace/topic/connection.h>
 #include <openspace/topic/serverinterface.h>
-#include <openspace/topic/topics/authorizationtopic.h>
 #include <openspace/topic/topics/actionkeybindtopic.h>
+#include <openspace/topic/topics/assettreetopic.h>
+#include <openspace/topic/topics/authorizationtopic.h>
 #include <openspace/topic/topics/camerapathtopic.h>
 #include <openspace/topic/topics/cameratopic.h>
 #include <openspace/topic/topics/documentationtopic.h>
@@ -130,6 +131,7 @@ void Server::initialize(const ghoul::Dictionary& configuration) {
 
     // Add the topics to the topic factory
     fTopic->registerClass<ActionKeybindTopic>("actionsKeybinds");
+    fTopic->registerClass<AssetTreeTopic>("assetTree");
     fTopic->registerClass<AuthorizationTopic>("authorize");
     fTopic->registerClass<CameraTopic>("camera");
     fTopic->registerClass<CameraPathTopic>("cameraPath");

--- a/src/topic/topics/assettreetopic.cpp
+++ b/src/topic/topics/assettreetopic.cpp
@@ -1,0 +1,216 @@
+/*****************************************************************************************
+ *                                                                                       *
+ * OpenSpace                                                                             *
+ *                                                                                       *
+ * Copyright (c) 2014-2026                                                               *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+ * software and associated documentation files (the "Software"), to deal in the Software *
+ * without restriction, including without limitation the rights to use, copy, modify,    *
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+ * permit persons to whom the Software is furnished to do so, subject to the following   *
+ * conditions:                                                                           *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all copies *
+ * or substantial portions of the Software.                                              *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+ ****************************************************************************************/
+
+#include <openspace/topic/topics/assettreetopic.h>
+
+#include <openspace/documentation/schema.h>
+#include <openspace/engine/globals.h>
+#include <openspace/engine/openspaceengine.h>
+#include <openspace/scene/assetmanager.h>
+
+namespace {
+    std::string stateToString(openspace::EventAssetLoading::State state) {
+        // @TODO (anden88 2026-08-19): The creation of an event and passing it to params
+        // is just to get the state value in text. Should we use a local toString function
+        // instead?
+        openspace::EventAssetLoading e("", state);
+        ghoul::Dictionary params = toParameter(e);
+        return params.value<std::string>("State");
+    }
+} // namespace
+
+namespace openspace {
+
+AssetTreeTopic::~AssetTreeTopic() {
+    if (_subscriptionId.has_value()) {
+        global::openSpaceEngine->assetManager().unsubscribeAssetTree(*_subscriptionId);
+    }
+}
+
+void AssetTreeTopic::handleJson(const nlohmann::json& json) {
+    const std::string event = json.at("event").get<std::string>();
+
+    if (event == "start_subscription") {
+        _subscriptionId = global::openSpaceEngine->assetManager().subscribeAssetTree(
+            [this](const AssetManager::AssetTreeChange& change) {
+                handleChange(change);
+            }
+        );
+        sendFullSnapshot();
+    }
+    else if (event == "stop_subscription" && _subscriptionId.has_value()) {
+        global::openSpaceEngine->assetManager().unsubscribeAssetTree(*_subscriptionId);
+        _subscriptionId.reset();
+    }
+    else if (event == "scan_assets" && _subscriptionId.has_value()) {
+        global::openSpaceEngine->assetManager().rescanAssetPaths();
+    }
+}
+
+bool AssetTreeTopic::isDone() const {
+    return !_subscriptionId.has_value();
+}
+
+Schema AssetTreeTopic::Schema() {
+    nlohmann::json schema = nlohmann::json::parse(R"(
+        {
+          "$defs": {
+            "PathList": {
+              "type": "object",
+              "properties": {
+                "type": { "const": "pathList" },
+                "category": {
+                  "type": "string",
+                  "enum": ["shipped", "user", "other", "rootAssets"]
+                },
+                "paths": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["type", "category", "paths"]
+            },
+            "StateSnapshot": {
+              "type": "object",
+              "properties": {
+                "type": { "const": "stateSnapshot" },
+                "states": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "eventtopic.json#/$defs/AssetLoadingEventData/properties/State"
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["type", "states"]
+            },
+            "State": {
+              "properties": {
+                "type": { "const": "state" },
+                "path": { "type": "string" },
+                "state": {
+                  "$ref": "eventtopic.json#/$defs/AssetLoadingEventData/properties/State"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["type", "path", "state"]
+            }
+          },
+          "title": "AssetTreeTopic",
+          "type": "object",
+          "properties": {
+            "topicId": { "const": "assetTree" },
+            "topicPayload": {
+              "type": "object",
+              "properties": {
+                "event": {
+                  "type": "string",
+                  "enum": ["start_subscription", "stop_subscription", "scan_assets"]
+                }
+              },
+              "additionalProperties": false,
+              "required": ["event"]
+            },
+            "data": {
+              "type": "object",
+              "anyOf": [
+                { "$ref": "#/$defs/PathList" },
+                { "$ref": "#/$defs/StateSnapshot" },
+                { "$ref": "#/$defs/State" }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["topicId", "topicPayload", "data"]
+        }
+
+    )");
+
+    return { "assettreetopic", schema };
+}
+
+void AssetTreeTopic::sendPathList(std::string_view category,
+                                          const std::vector<std::filesystem::path>& paths)
+{
+    nlohmann::json result = nlohmann::json::array();
+    for (const std::filesystem::path& p : paths) {
+        result.push_back(p.generic_string());
+    }
+
+    nlohmann::json payload;
+    payload["type"] = "pathList";
+    payload["category"] = category;
+    payload["paths"] = result;
+    sendData(payload);
+}
+
+void AssetTreeTopic::sendFullSnapshot() {
+    AssetManager& m = global::openSpaceEngine->assetManager();
+
+    sendPathList("shipped", m.shippedAssetPaths());
+    sendPathList("user", m.userAssetPaths());
+    sendPathList("other", m.otherAssetPaths());
+    sendPathList("rootAssets", m.rootAssetPaths());
+
+    nlohmann::json states;
+    for (const auto& [path, state] : m.assetStates()) {
+        states[path] = stateToString(state);
+    }
+
+    nlohmann::json payload;
+    payload["type"] = "stateSnapshot";
+    payload["states"] = states;
+    sendData(payload);
+}
+
+void AssetTreeTopic::handleChange(const AssetManager::AssetTreeChange& change) {
+    using Type = AssetManager::AssetTreeChange::Type;
+    AssetManager& m = global::openSpaceEngine->assetManager();
+
+    switch (change.type) {
+        case Type::Shipped:
+            sendPathList("shipped", m.shippedAssetPaths());
+            break;
+        case Type::User:
+            sendPathList("user", m.userAssetPaths());
+            break;
+        case Type::Other:
+            sendPathList("other", m.otherAssetPaths());
+            break;
+        case Type::RootAssets:
+            sendPathList("rootAssets", m.rootAssetPaths());
+            break;
+        case Type::State: {
+            nlohmann::json payload;
+            payload["type"] = "state";
+            payload["path"] = change.statePath;
+            payload["state"] = stateToString(change.state);
+            sendData(payload);
+            break;
+        }
+    }
+}
+
+} // namespace openspace

--- a/src/topic/topics/assettreetopic.cpp
+++ b/src/topic/topics/assettreetopic.cpp
@@ -174,7 +174,7 @@ void AssetTreeTopic::sendFullSnapshot() {
     sendPathList("other", m.otherAssetPaths());
     sendPathList("rootAssets", m.rootAssetPaths());
 
-    nlohmann::json states;
+    nlohmann::json states = nlohmann::json::object();
     for (const auto& [path, state] : m.assetStates()) {
         states[path] = stateToString(state);
     }

--- a/src/topic/topics/assettreetopic.cpp
+++ b/src/topic/topics/assettreetopic.cpp
@@ -106,7 +106,7 @@ Schema AssetTreeTopic::Schema() {
               "additionalProperties": false,
               "required": ["type", "states"]
             },
-            "State": {
+            "AssetState": {
               "properties": {
                 "type": { "const": "state" },
                 "path": { "type": "string" },
@@ -138,7 +138,7 @@ Schema AssetTreeTopic::Schema() {
               "anyOf": [
                 { "$ref": "#/$defs/PathList" },
                 { "$ref": "#/$defs/StateSnapshot" },
-                { "$ref": "#/$defs/State" }
+                { "$ref": "#/$defs/AssetState" }
               ]
             }
           },


### PR DESCRIPTION
add assetManager to keep track of possible assets and their states

The `assetTreeTopic` gives information on all available asset paths in the Data and User folders, as well as an `Other` where assets that do not belong to either Data or User. Further, it also keeps data on the loading state for all "active" assets. The assetManager is the owner of this data

To be used with https://github.com/OpenSpace/OpenSpace-WebGui/pull/235

closes #3963, #3873, and #4233